### PR TITLE
security: enforce ingest-root containment at the filesystem call

### DIFF
--- a/claude_discord/ext/api_server.py
+++ b/claude_discord/ext/api_server.py
@@ -1453,23 +1453,49 @@ class ApiServer:
         """Directory under which ingested attachments are saved."""
         return Path(self.working_dir or os.getcwd()) / "ingest"
 
-    @staticmethod
-    def _unique_path(path: Path) -> Path:
+    def _contained_path(self, path: Path) -> Path | None:
+        """Resolve ``path`` and return it only if it stays inside the ingest root.
+
+        Filenames and zip member names are attacker-controlled. They are already
+        reduced to a safe basename upstream, but that sanitiser lives far from
+        the filesystem calls it protects, so this re-establishes containment
+        *at* the sink: every path ccdb opens, stats or writes under the ingest
+        tree passes through here first. Returns ``None`` for anything that
+        resolves outside the root (or cannot be resolved at all), which callers
+        treat as a refusal rather than a path to use.
+        """
+        try:
+            root = self._ingest_root().resolve()
+            resolved = path.resolve()
+            resolved.relative_to(root)
+        except (OSError, ValueError):
+            return None
+        return resolved
+
+    def _unique_path(self, path: Path) -> Path | None:
         """Return ``path``, or the first free ``name_2.ext``-style variant.
 
         Two attachments in one request routinely share a filename (Teams names
         every pasted screenshot ``image.png``). Writing both to the same path
         would leave one file where two were sent — a silent loss that looks
         identical to success in the saved count.
+
+        Returns ``None`` when the requested path escapes the ingest root; the
+        containment check happens before any filesystem access, and every
+        candidate variant is re-checked because ``with_name`` takes a value
+        derived from the same untrusted filename.
         """
-        if not path.exists():
-            return path
-        stem, suffix = path.stem, path.suffix
+        safe = self._contained_path(path)
+        if safe is None:
+            return None
+        if not safe.exists():
+            return safe
+        stem, suffix = safe.stem, safe.suffix
         for n in range(2, 1000):
-            candidate = path.with_name(f"{stem}_{n}{suffix}")
-            if not candidate.exists():
+            candidate = self._contained_path(safe.with_name(f"{stem}_{n}{suffix}"))
+            if candidate is not None and not candidate.exists():
                 return candidate
-        return path.with_name(f"{stem}_{uuid.uuid4().hex[:8]}{suffix}")
+        return self._contained_path(safe.with_name(f"{stem}_{uuid.uuid4().hex[:8]}{suffix}"))
 
     def _save_ingest_attachments(
         self, attachments: list[dict], thread_id: str
@@ -1513,6 +1539,11 @@ class ApiServer:
             filename = _safe_attachment_name(att.get("filename"), i)
             dest_dir.mkdir(parents=True, exist_ok=True)
             path = self._unique_path(dest_dir / filename)
+            if path is None:
+                logger.warning("Refusing ingest attachment outside the ingest root: %s", i)
+                return [], web.json_response(
+                    {"error": f"Attachment {i} has an unusable filename"}, status=400
+                )
             try:
                 path.write_bytes(blob)
             except OSError as exc:
@@ -1607,14 +1638,21 @@ class ApiServer:
                             _sanitize_log(member),
                         )
                         continue
-                    dest.parent.mkdir(parents=True, exist_ok=True)
                     # Two members can carry the same name (some writers allow
                     # duplicates); overwriting would drop one file while still
-                    # reporting both as extracted.
-                    dest = self._unique_path(dest)
-                    with zf.open(info) as src, open(dest, "wb") as out:
+                    # reporting both as extracted. This also re-checks
+                    # containment right before the write.
+                    unique = self._unique_path(dest)
+                    if unique is None:
+                        logger.warning(
+                            "Skipping zip member escaping the ingest root: %s",
+                            _sanitize_log(member),
+                        )
+                        continue
+                    unique.parent.mkdir(parents=True, exist_ok=True)
+                    with zf.open(info) as src, open(unique, "wb") as out:
                         out.write(src.read())
-                    extracted.append(dest)
+                    extracted.append(unique)
         except (zipfile.BadZipFile, OSError) as exc:
             logger.error("Failed to extract ingest zip %s: %s", _sanitize_log(zip_path), exc)
             return None
@@ -1796,8 +1834,11 @@ class ApiServer:
         # Verify the delivery against the manifest before anything is spawned:
         # a shortfall changes what the session is told, and (in strict mode)
         # whether a session is worth starting at all.
+        # Only hash files proven to live under the ingest root — the names came
+        # from the client, so containment is re-checked at the read as well.
+        contained = [p for p in (self._contained_path(p) for p in saved_paths) if p is not None]
         reconciliation = ingest_manifest.reconcile(
-            manifest_entries, ingest_manifest.hash_files(saved_paths)
+            manifest_entries, ingest_manifest.hash_files(contained)
         )
         self._write_attachment_report(reconciliation, request_id)
         if not reconciliation.is_complete:

--- a/tests/test_api_server.py
+++ b/tests/test_api_server.py
@@ -1135,6 +1135,19 @@ class TestIngest:
         files = sorted(p.read_bytes() for p in tmp_path.glob("ingest/*/**/image*.png"))
         assert files == [b"first", b"second"]
 
+    def test_unique_path_refuses_a_path_outside_the_ingest_root(
+        self, repo: NotificationRepository, bot_with_text_channel: MagicMock, tmp_path
+    ) -> None:
+        # Containment is re-established at the filesystem call itself, not only
+        # by the basename sanitiser far upstream.
+        from pathlib import Path
+
+        api = ApiServer(repo=repo, bot=bot_with_text_channel, working_dir=str(tmp_path))
+        assert api._unique_path(Path("/etc/passwd")) is None
+        assert api._unique_path(tmp_path / "ingest" / ".." / ".." / "escape.txt") is None
+        inside = api._unique_path(tmp_path / "ingest" / "req" / "ok.txt")
+        assert inside is not None and str(inside).startswith(str((tmp_path / "ingest").resolve()))
+
     @pytest.mark.asyncio
     async def test_manifest_shortfall_warns_the_session_and_the_caller(
         self, ingest_client: TestClient, mock_cog: MagicMock, tmp_path


### PR DESCRIPTION
Follow-up to #527, which auto-merged before this could be added to it.

CodeQL flagged **3 high** `py/path-injection` alerts on the code #527 introduced:

| File | Sink |
|---|---|
| `ext/api_server.py` | `_unique_path()` stats sibling paths derived from a client-supplied filename |
| `ext/api_server.py` | …and each `with_name()` variant of it |
| `ext/ingest_manifest.py` | `hash_files()` opens every delivered path |

Both were only ever reached through already-sanitised names (`_safe_attachment_name` reduces a filename to a safe basename; the zip extractor has its own zip-slip guard), so this is not a live exploit. But CodeQL is right about the shape of it: **the guarantee is not local.** The sanitiser sits far from the calls it protects, and a future caller could reach these sinks without passing through it.

## Fix

`_contained_path()` resolves a path and returns it only when it stays under `{working_dir}/ingest`. Every write, stat and read on the ingest tree now goes through it:

- `_unique_path` checks containment **before** touching the filesystem, and re-checks each `with_name()` variant (that name is derived from the same untrusted input), returning `None` for an escape
- `_save_ingest_attachments` turns that `None` into a `400`
- the zip extractor re-checks immediately before the write and skips the member
- only contained paths are handed to `hash_files()`

Defence in depth, not a suppression — the zip-slip guard and the basename sanitiser both stay exactly where they were.

## Test plan

- [x] New test: `_unique_path` refuses `/etc/passwd` and a `../..` escape, and accepts a path inside the root
- [x] Existing path-traversal and zip-slip tests still pass
- [x] `tests/test_api_server.py` + `tests/test_ingest_manifest.py`: 114 passed
- [x] Full suite: 1804 passed (excluding `tests/test_run_helper.py`, which hangs on Python 3.12 on `main` independently of this branch)
- [x] `ruff check` / `pyright` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)