### PR TITLE
security: spell the ingest containment check so CodeQL recognises it

### DIFF
--- a/claude_discord/ext/api_server.py
+++ b/claude_discord/ext/api_server.py
@@ -1463,14 +1463,24 @@ class ApiServer:
         tree passes through here first. Returns ``None`` for anything that
         resolves outside the root (or cannot be resolved at all), which callers
         treat as a refusal rather than a path to use.
+
+        The check is written as ``os.path.realpath`` + a ``startswith`` prefix
+        test rather than ``Path.resolve()`` + ``relative_to()``. The two are
+        equivalent, but only the former is recognised as a path sanitiser by
+        static analysis — with the pathlib spelling, CodeQL still reported every
+        call below as a live path injection and the hardening was invisible to
+        the very tool meant to check it. Comparing against ``root + os.sep``
+        (not bare ``root``) is what stops a sibling directory whose name merely
+        starts with the root's from passing.
         """
         try:
-            root = self._ingest_root().resolve()
-            resolved = path.resolve()
-            resolved.relative_to(root)
-        except (OSError, ValueError):
+            root = os.path.realpath(str(self._ingest_root()))
+            resolved = os.path.realpath(str(path))
+        except OSError:
             return None
-        return resolved
+        if resolved != root and not resolved.startswith(root + os.sep):
+            return None
+        return Path(resolved)
 
     def _unique_path(self, path: Path) -> Path | None:
         """Return ``path``, or the first free ``name_2.ext``-style variant.

--- a/tests/test_api_server.py
+++ b/tests/test_api_server.py
@@ -1148,6 +1148,18 @@ class TestIngest:
         inside = api._unique_path(tmp_path / "ingest" / "req" / "ok.txt")
         assert inside is not None and str(inside).startswith(str((tmp_path / "ingest").resolve()))
 
+    def test_contained_path_rejects_a_sibling_with_the_root_as_a_name_prefix(
+        self, repo: NotificationRepository, bot_with_text_channel: MagicMock, tmp_path
+    ) -> None:
+        # "/…/ingest-evil" starts with "/…/ingest" as a *string* but is not
+        # inside it. The guard compares against root + os.sep for this reason.
+        api = ApiServer(repo=repo, bot=bot_with_text_channel, working_dir=str(tmp_path))
+        (tmp_path / "ingest").mkdir()
+        sibling = tmp_path / "ingest-evil"
+        sibling.mkdir()
+        assert api._contained_path(sibling / "loot.txt") is None
+        assert api._contained_path(tmp_path / "ingest" / "ok.txt") is not None
+
     @pytest.mark.asyncio
     async def test_manifest_shortfall_warns_the_session_and_the_caller(
         self, ingest_client: TestClient, mock_cog: MagicMock, tmp_path


### PR DESCRIPTION
Follow-up to #529.

The containment guard added there is correct, but **invisible to the tool meant to verify it**. CodeQL does not treat `Path.resolve()` + `relative_to()` as a path-injection sanitiser, so it kept reporting every filesystem call downstream of the guard as a live path injection.

Net effect: `main` went from **1** open high `py/path-injection` alert to **4** — *after* adding hardening. #529's PR check passed only because that gate measures *newly introduced* alerts, not the total.

## Fix

Same check, canonical spelling:

```python
root = os.path.realpath(str(self._ingest_root()))
resolved = os.path.realpath(str(path))
if resolved != root and not resolved.startswith(root + os.sep):
    return None
```

`os.path.realpath` + a `startswith` prefix test is the form CodeQL's sanitiser model recognises. Behaviour is unchanged.

Comparing against `root + os.sep` rather than bare `root` is not incidental: `/…/ingest-evil` starts with `/…/ingest` as a *string* but is not inside it. A new test covers exactly that case.

## Test plan

- [x] New test: a sibling directory whose name has the root as a string prefix is rejected; a real child is accepted
- [x] Existing containment, path-traversal and zip-slip tests still pass
- [x] `tests/test_api_server.py` + `tests/test_ingest_manifest.py`: 115 passed
- [x] Full suite: 1805 passed (excluding `tests/test_run_helper.py`, which hangs on Python 3.12 on `main` independently of this branch)
- [x] `ruff check` / `ruff format --check` / `pyright` clean
- [ ] Confirm `main`'s open high `py/path-injection` count drops to the pre-#527 baseline after the post-merge scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)