### PR TITLE
fix: gate prompt blocks on whether the feature behind them is reachable

### DIFF
--- a/claude_discord/cogs/_run_helper.py
+++ b/claude_discord/cogs/_run_helper.py
@@ -127,11 +127,21 @@ async def _build_system_context(config: RunConfig) -> str | None:
     parts: list[str] = []
 
     # Layer 3: AI Lounge context (recent messages + invitation).
-    if config.lounge_repo is not None:
+    # Gated on the backend's api_port: the invite tells the model to POST to
+    # $CCDB_API_URL, and _build_env() only injects that variable when api_port
+    # is set (SessionBackend.api_port; same condition in both the Claude and
+    # Codex runners).  With the API server disabled every session opens by
+    # running a curl against an empty URL, which exits 3 — the lounge is
+    # unreachable, so the whole block is noise.  Deriving this from api_port
+    # rather than a new setting keeps the zero-config contract: enabling the
+    # API server is all a consumer has to do.
+    lounge_injected = False
+    if config.lounge_repo is not None and config.runner.api_port is not None:
         try:
             recent = await config.lounge_repo.get_recent(limit=10)
             lounge_context = build_lounge_prompt(recent, current_thread_id=config.thread.id)
             parts.append(lounge_context)
+            lounge_injected = True
             logger.debug("Lounge context built (%d recent message(s))", len(recent))
         except Exception:
             logger.warning("Failed to fetch lounge context — skipping", exc_info=True)
@@ -140,7 +150,11 @@ async def _build_system_context(config: RunConfig) -> str | None:
     if config.registry is not None:
         config.registry.register(config.thread.id, config.prompt[:100], config.runner.working_dir)
         others = config.registry.list_others(config.thread.id)
-        notice = config.registry.build_concurrency_notice(config.thread.id)
+        # Reflects what was actually appended above, not just what was
+        # configured: a failed get_recent() leaves the caveat describing nothing.
+        notice = config.registry.build_concurrency_notice(
+            config.thread.id, lounge_enabled=lounge_injected
+        )
         parts.append(notice)
         logger.info(
             "Concurrency notice built for thread %d (%d other active session(s), dir=%s)",

--- a/claude_discord/concurrency.py
+++ b/claude_discord/concurrency.py
@@ -26,12 +26,42 @@ class ActiveSession:
     working_dir: str | None = None
 
 
+# Only meaningful when a lounge transcript is actually injected alongside the
+# notice.  _build_system_context skips the lounge block when the REST API the
+# invite depends on is not running, and then these lines explain how to read
+# messages the session will never see.
+_LOUNGE_SELF_POSTS_NOTE = (
+    " Messages marked [this thread] in the AI Lounge are YOUR earlier posts from"
+    " this same thread — not from other sessions. After context compaction you may"
+    " see your own lounge messages; do NOT treat them as another session's work."
+)
+
+# Sent when this session is the only one registered.  It keeps the advice that
+# holds for a single session (shared-state checks, the working-directory reset)
+# and drops the two statements that are simply false on their own: that other
+# sessions are active, and that a worktree is required before any edit.
+_SOLO_CONCURRENCY_NOTICE = """\
+[CONCURRENCY NOTICE] You are a Claude Code session running via Discord. \
+Your thread ID is {thread_id}.{lounge_note}
+
+No other Claude Code session is active right now, so the main working \
+directory is yours — no isolation step is needed. Another session may still \
+start while you work, so check the current state of anything shared (git \
+index, databases, network ports, lock files, singleton processes) before \
+assuming nothing else touches it.
+
+**Working directory does NOT persist between messages**: Each of your Discord \
+replies runs in a FRESH process that starts in the base working directory. A \
+`cd` only lasts for the current message — it is gone by your next reply, and \
+the shell resets. So a relative-path script you set up in one message will \
+silently run in the WRONG directory later. ALWAYS use absolute paths (for \
+scripts, `os.chdir` to an absolute path at startup); for long jobs or large \
+output, write results to an absolute-path log file and read it back.\
+"""
+
 _BASE_CONCURRENCY_NOTICE = """\
 [CONCURRENCY NOTICE — MANDATORY] You are one of MULTIPLE Claude Code sessions \
-running simultaneously via Discord. Your thread ID is {thread_id}. \
-Messages marked [this thread] in the AI Lounge are YOUR earlier posts from \
-this same thread — not from other sessions. After context compaction you may \
-see your own lounge messages; do NOT treat them as another session's work. \
+running simultaneously via Discord. Your thread ID is {thread_id}.{lounge_note} \
 Other sessions ARE active right now. \
 You MUST follow these rules to avoid destroying each other's work:
 
@@ -119,23 +149,38 @@ class SessionRegistry:
         with self._lock:
             return [s for s in self._sessions.values() if s.thread_id != thread_id]
 
-    def build_concurrency_notice(self, thread_id: int) -> str:
+    def build_concurrency_notice(self, thread_id: int, *, lounge_enabled: bool = True) -> str:
         """Build the full concurrency notice for a session.
 
         Combines the base Layer 1 warning with Layer 2 context about
         other active sessions.
+
+        When this session is the only one registered, the mandatory wording is
+        replaced by a shorter notice that says the same thing truthfully: the
+        full version asserts "Other sessions ARE active right now" and REQUIRES
+        ``git worktree add ../wt-<thread_id>`` before any edit.  Both are wrong
+        with nothing else running, and the demanded worktree is a checkout in
+        the repository's parent directory that nothing removes unless
+        WORKTREE_BASE_DIR is configured.
+
+        ``lounge_enabled`` drops the AI Lounge caveat when no lounge transcript
+        is being injected, since it would describe messages the session cannot
+        see.  Defaults to True so existing callers keep the current wording.
         """
-        notice = _BASE_CONCURRENCY_NOTICE.format(thread_id=thread_id)
+        lounge_note = _LOUNGE_SELF_POSTS_NOTE if lounge_enabled else ""
         others = self.list_others(thread_id)
-        if others:
-            notice += _OTHER_SESSIONS_HEADER
-            for s in others:
-                line = f"- {s.description}"
-                if s.working_dir:
-                    line += f" (working in {s.working_dir})"
-                notice += line + "\n"
-            notice += (
-                "\nIf your work targets the same repository as any session above, "
-                "you MUST use a git worktree. Do NOT proceed without isolation.\n"
-            )
+        if not others:
+            return _SOLO_CONCURRENCY_NOTICE.format(thread_id=thread_id, lounge_note=lounge_note)
+
+        notice = _BASE_CONCURRENCY_NOTICE.format(thread_id=thread_id, lounge_note=lounge_note)
+        notice += _OTHER_SESSIONS_HEADER
+        for s in others:
+            line = f"- {s.description}"
+            if s.working_dir:
+                line += f" (working in {s.working_dir})"
+            notice += line + "\n"
+        notice += (
+            "\nIf your work targets the same repository as any session above, "
+            "you MUST use a git worktree. Do NOT proceed without isolation.\n"
+        )
         return notice

--- a/tests/test_run_helper.py
+++ b/tests/test_run_helper.py
@@ -21,6 +21,7 @@ from claude_discord.claude.types import (
 from claude_discord.cogs import _run_helper as _rh_module
 from claude_discord.cogs._run_helper import (
     TOOL_RESULT_MAX_CHARS,
+    _build_system_context,
     _make_error_embed,
     _truncate_result,
     configure_session_limit,
@@ -1895,3 +1896,111 @@ class TestResultSink:
         config = RunConfig(thread=thread, runner=runner, prompt="hi")
         # Must not raise when result_sink is None.
         await run_claude_with_config(config)
+
+
+class TestLoungeInjectionGate:
+    """The lounge block is only useful when the REST API it depends on is up."""
+
+    @pytest.fixture
+    def thread(self) -> MagicMock:
+        t = MagicMock(spec=discord.Thread)
+        t.id = 77777
+        return t
+
+    def _lounge_repo(self) -> MagicMock:
+        repo = MagicMock()
+        repo.get_recent = AsyncMock(return_value=[])
+        return repo
+
+    def _runner(self, api_port: int | None) -> MagicMock:
+        runner = MagicMock()
+        runner.working_dir = None
+        runner.api_port = api_port
+        return runner
+
+    @pytest.mark.asyncio
+    async def test_lounge_skipped_when_api_server_disabled(self, thread: MagicMock) -> None:
+        """api_port is None → CCDB_API_URL is never injected into the subprocess.
+
+        Sending the invite anyway tells the agent to run
+        ``curl -s -X POST "$CCDB_API_URL/api/lounge"`` against an empty
+        variable, which fails with exit code 3 on every single session.
+        """
+        lounge_repo = self._lounge_repo()
+        config = RunConfig(
+            thread=thread, runner=self._runner(None), prompt="hi", lounge_repo=lounge_repo
+        )
+
+        context = await _build_system_context(config)
+
+        assert context is None or "AI LOUNGE" not in context
+        lounge_repo.get_recent.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_lounge_injected_when_api_server_enabled(self, thread: MagicMock) -> None:
+        """api_port set → the POST command in the invite actually resolves."""
+        lounge_repo = self._lounge_repo()
+        config = RunConfig(
+            thread=thread, runner=self._runner(8099), prompt="hi", lounge_repo=lounge_repo
+        )
+
+        context = await _build_system_context(config)
+
+        assert context is not None
+        assert "AI LOUNGE" in context
+        lounge_repo.get_recent.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_notice_drops_lounge_caveat_when_gated_off(self, thread: MagicMock) -> None:
+        """Gating the block must also drop the notice's lounge caveat.
+
+        Otherwise the notice still explains how to read "[this thread]" markers
+        in a transcript that was never injected.
+        """
+        config = RunConfig(
+            thread=thread,
+            runner=self._runner(None),
+            prompt="hi",
+            registry=SessionRegistry(),
+            lounge_repo=self._lounge_repo(),
+        )
+
+        context = await _build_system_context(config)
+
+        assert context is not None
+        assert "CONCURRENCY NOTICE" in context
+        assert "AI Lounge" not in context
+
+    @pytest.mark.asyncio
+    async def test_notice_keeps_lounge_caveat_when_injected(self, thread: MagicMock) -> None:
+        """Lounge block present → the caveat explaining its markers stays."""
+        config = RunConfig(
+            thread=thread,
+            runner=self._runner(8099),
+            prompt="hi",
+            registry=SessionRegistry(),
+            lounge_repo=self._lounge_repo(),
+        )
+
+        context = await _build_system_context(config)
+
+        assert context is not None
+        assert "AI Lounge" in context
+
+    @pytest.mark.asyncio
+    async def test_lounge_fetch_failure_also_drops_the_caveat(self, thread: MagicMock) -> None:
+        """get_recent() raised → nothing was injected, so the caveat is dead text."""
+        lounge_repo = MagicMock()
+        lounge_repo.get_recent = AsyncMock(side_effect=RuntimeError("db gone"))
+        config = RunConfig(
+            thread=thread,
+            runner=self._runner(8099),
+            prompt="hi",
+            registry=SessionRegistry(),
+            lounge_repo=lounge_repo,
+        )
+
+        context = await _build_system_context(config)
+
+        assert context is not None
+        assert "AI Lounge" not in context

--- a/tests/test_session_registry.py
+++ b/tests/test_session_registry.py
@@ -120,12 +120,74 @@ class TestConcurrencyNotice:
         assert "task B" in notice
         assert "task C" in notice
 
-    def test_notice_mentions_git_worktree(self) -> None:
-        """The notice should advise git worktree usage."""
+    def test_notice_mentions_git_worktree_when_others_active(self) -> None:
+        """The notice should advise git worktree usage — when it actually applies.
+
+        The mandate exists to stop concurrent sessions from clobbering each
+        other's working directory. With no other session running there is
+        nothing to isolate from, so demanding a worktree is pure overhead: it
+        leaves a wt-<thread_id> checkout in the repository's parent directory
+        that nothing cleans up unless WORKTREE_BASE_DIR is set.
+        """
+        registry = SessionRegistry()
+        registry.register(1001, "my task")
+        registry.register(1002, "another task")
+        notice = registry.build_concurrency_notice(1001)
+        assert "worktree" in notice.lower()
+
+    def test_solo_notice_has_no_worktree_mandate(self) -> None:
+        """Alone in the registry → no REQUIRED worktree instruction."""
         registry = SessionRegistry()
         registry.register(1001, "my task")
         notice = registry.build_concurrency_notice(1001)
+        assert "worktree" not in notice.lower()
+
+    def test_solo_notice_does_not_claim_others_are_active(self) -> None:
+        """Alone in the registry → the notice must not assert other sessions exist.
+
+        The unconditional wording ("Other sessions ARE active right now") is
+        simply false whenever a single session is running, which is the common
+        case for a personal deployment.
+        """
+        registry = SessionRegistry()
+        registry.register(1001, "my task")
+        notice = registry.build_concurrency_notice(1001)
+        assert "ARE active right now" not in notice
+        assert "No other Claude Code session is active" in notice
+
+    def test_solo_notice_is_shorter_than_multi_session_notice(self) -> None:
+        """The solo path should cost fewer prompt tokens than the full warning."""
+        registry = SessionRegistry()
+        registry.register(1001, "my task")
+        solo = registry.build_concurrency_notice(1001)
+        registry.register(1002, "another task")
+        multi = registry.build_concurrency_notice(1001)
+        assert len(solo) < len(multi)
+
+    def test_lounge_caveat_present_by_default(self) -> None:
+        """Callers that don't pass lounge_enabled keep the existing wording."""
+        registry = SessionRegistry()
+        registry.register(1001, "my task")
+        assert "AI Lounge" in registry.build_concurrency_notice(1001)
+
+    def test_solo_notice_drops_lounge_caveat_when_disabled(self) -> None:
+        """No lounge transcript injected → its disclaimer describes nothing."""
+        registry = SessionRegistry()
+        registry.register(1001, "my task")
+        notice = registry.build_concurrency_notice(1001, lounge_enabled=False)
+        assert "AI Lounge" not in notice
+        assert "1001" in notice
+
+    def test_multi_notice_drops_lounge_caveat_but_keeps_the_mandate(self) -> None:
+        """Dropping the lounge caveat must not weaken the real warning."""
+        registry = SessionRegistry()
+        registry.register(1001, "my task")
+        registry.register(1002, "another task")
+        notice = registry.build_concurrency_notice(1001, lounge_enabled=False)
+        assert "AI Lounge" not in notice
+        assert "Other sessions ARE active right now" in notice
         assert "worktree" in notice.lower()
+        assert "another task" in notice
 
     def test_notice_mentions_shared_resources(self) -> None:
         """The notice should warn about non-git conflicts too."""


### PR DESCRIPTION
## What does this PR do?

Makes two always-injected system-context blocks conditional on whether the thing they describe actually exists.

1. **Concurrency notice** — `build_concurrency_notice()` returns a shorter, truthful notice when no other session is registered. When others *are* active, the full mandate is byte-for-byte unchanged.
2. **AI Lounge block** — gated on `runner.api_port`, so it appears exactly when the endpoint the invite depends on is reachable.

## Why?

**(1) The concurrency notice asserts things that are false with one session running.**

`_BASE_CONCURRENCY_NOTICE` is injected unconditionally, and it states:

- `Other sessions ARE active right now.` — while the log line right next to it says `0 other active session(s)`.
- `1. **Git — USE A WORKTREE (REQUIRED)**: Run git worktree add ../wt-{thread_id} ... BEFORE making any changes. NEVER modify the main working directory directly.`

With a single session there is nothing to isolate from, so the mandate is pure overhead — and it leaves a `wt-<thread_id>` checkout in the repository's **parent** directory that nothing removes unless `WORKTREE_BASE_DIR` is configured. On a personal deployment the solo case is the common one.

The solo notice deliberately **keeps** the advice that still applies alone: check the current state of anything shared before assuming nothing else touches it, and the "working directory does NOT persist between messages" warning (that one is about the subprocess model, not about concurrency, so dropping it would be a regression). It drops only the two false statements.

**(2) The lounge invite points at a URL that is empty unless the API server runs.**

The invite tells the agent to `curl -s -X POST "$CCDB_API_URL/api/lounge"`, but `_build_env()` only injects `CCDB_API_URL` when `api_port` is set — the same condition in both `claude_code_core/runner.py` and `claude_code_core/codex_runner.py`, and `api_port` is part of the `SessionBackend` protocol. `setup_bridge()` builds `lounge_repo` unconditionally, so with the API server disabled **every** session opens by running a curl against an empty URL, which exits 3.

Deriving the gate from `api_port` rather than adding a setting keeps the zero-config contract: enabling the API server is all a consumer has to do.

The notice's `[this thread]` caveat belongs to (2) — it explains how to read a transcript that is not injected when the lounge is gated off. So `build_concurrency_notice()` takes a keyword-only `lounge_enabled`, defaulting to `True` so any other caller keeps the current wording. `_build_system_context` passes what it actually appended rather than what was configured, so a failed `get_recent()` drops the caveat too.

For a solo session with the API server disabled, the injected context drops from **3024 to 427 characters**.

### Assumptions worth checking on your side

- **You may never have seen (2).** If your deployment sets `api_port`, `CCDB_API_URL` resolves and the invite works — the dead curl only shows up with the API server disabled.
- **(1) affects you whenever only one session is running**, regardless of `api_port`.
- I assumed the worktree mandate's entire value comes from concurrency. If you also rely on it to keep the main working tree clean for a different reason, the solo branch is the wrong shape and I'm happy to rework it.

## How to test

```bash
uv sync --dev
uv run pytest tests/test_session_registry.py tests/test_run_helper.py -v
```

Behaviour by hand:

```python
from claude_discord.concurrency import SessionRegistry

r = SessionRegistry()
r.register(1001, "my task")
print(r.build_concurrency_notice(1001))            # solo: no worktree mandate, no false claim
print(r.build_concurrency_notice(1001, lounge_enabled=False))  # also no [this thread] caveat

r.register(1002, "another task")
print(r.build_concurrency_notice(1001))            # unchanged full mandate
```

End to end: with the API server disabled, start a session and confirm it no longer opens with a failing `curl $CCDB_API_URL/api/lounge` (exit 3) and no longer creates `../wt-<thread_id>`.

## Checklist

- [x] Tests pass: `1872 passed, 6 skipped`
- [x] Lint passes: `ruff check` and `ruff format --check` both clean
- [x] New functionality has tests — 11 added, covering the solo notice, the lounge gate in both directions, and the fetch-failure path
- [x] README updated (if applicable) — n/a, no user-facing configuration changes

### One existing test changed

`test_notice_mentions_git_worktree` registered a single session and asserted the worktree mandate — exactly the behaviour this PR changes. It now registers a second session and is renamed to `test_notice_mentions_git_worktree_when_others_active`; the solo path gets its own coverage instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
