### PR TITLE
security: inline the containment guard into _unique_path

### DIFF
--- a/claude_discord/ext/api_server.py
+++ b/claude_discord/ext/api_server.py
@@ -1494,18 +1494,36 @@ class ApiServer:
         containment check happens before any filesystem access, and every
         candidate variant is re-checked because ``with_name`` takes a value
         derived from the same untrusted filename.
+
+        The check is written out here rather than delegated to
+        ``_contained_path``. The two are identical, but a guard that lives in a
+        helper does not propagate across the call boundary for static analysis:
+        with the delegated version CodeQL still reported both ``exists()`` calls
+        below as live path injections. Keeping the ``realpath`` + prefix test in
+        the same function as the filesystem call it protects makes the guarantee
+        local — to a reader and to the analyser alike.
         """
-        safe = self._contained_path(path)
-        if safe is None:
+        try:
+            root = os.path.realpath(str(self._ingest_root()))
+        except OSError:
             return None
-        if not safe.exists():
-            return safe
-        stem, suffix = safe.stem, safe.suffix
-        for n in range(2, 1000):
-            candidate = self._contained_path(safe.with_name(f"{stem}_{n}{suffix}"))
-            if candidate is not None and not candidate.exists():
-                return candidate
-        return self._contained_path(safe.with_name(f"{stem}_{uuid.uuid4().hex[:8]}{suffix}"))
+
+        stem, suffix = path.stem, path.suffix
+        candidates = [path] + [path.with_name(f"{stem}_{n}{suffix}") for n in range(2, 1001)]
+        for candidate in candidates:
+            try:
+                resolved = os.path.realpath(str(candidate))
+            except OSError:
+                return None
+            # root + os.sep, not bare root: "/…/ingest-evil" has "/…/ingest" as
+            # a string prefix without being inside it.
+            if resolved != root and not resolved.startswith(root + os.sep):
+                return None
+            if not os.path.exists(resolved):
+                return Path(resolved)
+        # 1000 files of the same name in one request is not a real export; refuse
+        # it rather than inventing a random name nothing else can predict.
+        return None
 
     def _save_ingest_attachments(
         self, attachments: list[dict], thread_id: str

--- a/tests/test_api_server.py
+++ b/tests/test_api_server.py
@@ -1148,6 +1148,30 @@ class TestIngest:
         inside = api._unique_path(tmp_path / "ingest" / "req" / "ok.txt")
         assert inside is not None and str(inside).startswith(str((tmp_path / "ingest").resolve()))
 
+    def test_unique_path_walks_past_existing_collisions(
+        self, repo: NotificationRepository, bot_with_text_channel: MagicMock, tmp_path
+    ) -> None:
+        # The disambiguation loop is what stops a same-named attachment from
+        # overwriting an earlier one, so it has to keep stepping past every name
+        # already taken — not just the first.
+        api = ApiServer(repo=repo, bot=bot_with_text_channel, working_dir=str(tmp_path))
+        dest = tmp_path / "ingest" / "req"
+        dest.mkdir(parents=True)
+        (dest / "image.png").write_bytes(b"a")
+        (dest / "image_2.png").write_bytes(b"b")
+        got = api._unique_path(dest / "image.png")
+        assert got is not None and got.name == "image_3.png"
+
+    def test_unique_path_refuses_rather_than_inventing_a_name_when_exhausted(
+        self, repo: NotificationRepository, bot_with_text_channel: MagicMock, tmp_path, monkeypatch
+    ) -> None:
+        # Every candidate taken → refuse (the caller turns this into a 400)
+        # rather than fall back to a random name nothing else can predict.
+        api = ApiServer(repo=repo, bot=bot_with_text_channel, working_dir=str(tmp_path))
+        (tmp_path / "ingest").mkdir()
+        monkeypatch.setattr(os.path, "exists", lambda _p: True)
+        assert api._unique_path(tmp_path / "ingest" / "image.png") is None
+
     def test_contained_path_rejects_a_sibling_with_the_root_as_a_name_prefix(
         self, repo: NotificationRepository, bot_with_text_channel: MagicMock, tmp_path
     ) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -259,7 +259,7 @@ wheels = [
 
 [[package]]
 name = "claude-code-discord-bridge"
-version = "3.3.0"
+version = "3.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Closes out the CodeQL residue from #527 → #529 → #531.

## Why another pass

#531 got the *spelling* right (`os.path.realpath` + `startswith`) but kept the check in a helper. CodeQL's sanitiser **does not propagate across a call boundary**, so both `exists()` calls inside `_unique_path` were still reported as live path injections.

Net state before this PR: `main` sat at **3** open high `py/path-injection` alerts against a pre-existing baseline of **1**. The earlier PR checks looked clean only because that gate measures *newly introduced* alerts, not the total.

## Change

Same `realpath` + prefix test, written out in the function that makes the filesystem call:

```python
root = os.path.realpath(str(self._ingest_root()))
candidates = [path] + [path.with_name(f"{stem}_{n}{suffix}") for n in range(2, 1001)]
for candidate in candidates:
    resolved = os.path.realpath(str(candidate))
    if resolved != root and not resolved.startswith(root + os.sep):
        return None
    if not os.path.exists(resolved):
        return Path(resolved)
```

The guarantee is now local — to a reader and to the analyser alike. `_contained_path` stays for the paths handed to `hash_files()`, where CodeQL is already satisfied.

## Behaviour change

Exhausting all 1000 candidates now **refuses** (the caller turns it into a `400`) instead of falling back to a uuid-suffixed name. 1000 identically-named attachments in one request is not a real export, and a random name nothing else can predict is worse than a clear refusal.

## Test plan

- [x] New: walks past existing collisions — `image.png` + `image_2.png` present → returns `image_3.png` (this loop is what stops a same-named attachment from overwriting an earlier one, so it has to step past *every* taken name, not just the first)
- [x] New: refuses rather than inventing a name when every candidate is taken
- [x] Existing containment, sibling-prefix (`/…/ingest-evil`), path-traversal and zip-slip tests still pass
- [x] Full suite: 1807 passed (excluding `tests/test_run_helper.py`, which hangs on Python 3.12 on `main` independently of this branch)
- [x] `ruff check` / `ruff format --check` / `pyright` clean
- [ ] Confirm `main`'s open high `py/path-injection` count returns to the pre-#527 baseline of 1 after the post-merge scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)