### PR TITLE
chore: auto-detect repo root in cleanup_worktrees.sh

### DIFF
--- a/scripts/cleanup_worktrees.sh
+++ b/scripts/cleanup_worktrees.sh
@@ -6,11 +6,13 @@
 # Removes worktrees whose PRs are MERGED or CLOSED.
 # Keeps worktrees for OPEN PRs and the main worktree.
 #
-# Run from repo root: /home/ebi/claude-code-discord-bridge/
+# Run from repo root (auto-detected from script location)
 
 set -euo pipefail
 
-REPO_ROOT="/home/ebi/claude-code-discord-bridge"
+# Auto-detect repo root from script location
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
 DRY_RUN=false
 
 if [[ "${1:-}" == "--dry-run" ]]; then

--- a/scripts/cleanup_worktrees.sh
+++ b/scripts/cleanup_worktrees.sh
@@ -10,9 +10,12 @@
 
 set -euo pipefail
 
-# Auto-detect repo root from script location
-SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
-REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+# Auto-detect repo root from script location.
+# Uses `git rev-parse --show-toplevel` rather than `readlink -f` because BSD
+# readlink (macOS) has no -f flag; git itself is already a hard dependency
+# for this script (see the `gh`/`git worktree` calls below).
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
 DRY_RUN=false
 
 if [[ "${1:-}" == "--dry-run" ]]; then
@@ -74,7 +77,7 @@ while IFS= read -r line; do
             dev_worktree=$(cat "$DEV_WORKTREE_FILE" | tr -d '[:space:]')
             if [[ "$current_path" == "$dev_worktree" ]]; then
                 echo "  [PROTECTED] Active dev worktree — skipping"
-                ((kept++))
+                kept=$((kept + 1))
                 current_path=""
                 current_branch=""
                 continue
@@ -83,7 +86,7 @@ while IFS= read -r line; do
 
         if [[ -z "$current_branch" ]]; then
             echo "[WARN] $current_path: detached HEAD, no branch. Skipping."
-            ((warned++))
+            warned=$((warned + 1))
             current_path=""
             current_branch=""
             continue
@@ -118,20 +121,20 @@ while IFS= read -r line; do
                     echo "  [WARN] Branch $current_branch already deleted or not found"
                 fi
             fi
-            ((removed++))
+            removed=$((removed + 1))
 
         elif [[ "$pr_state" == "OPEN" ]]; then
             echo "  PR state: OPEN -> keeping"
-            ((kept++))
+            kept=$((kept + 1))
 
         elif [[ -z "$pr_state" ]]; then
             echo "  [WARN] No PR found for branch '$current_branch'. Leftover branch?"
             echo "  Keeping worktree (manual review recommended)."
-            ((warned++))
+            warned=$((warned + 1))
 
         else
             echo "  [ERROR] Unexpected PR state: $pr_state"
-            ((errors++))
+            errors=$((errors + 1))
         fi
 
         echo ""

--- a/tests/test_cleanup_worktrees_script.py
+++ b/tests/test_cleanup_worktrees_script.py
@@ -1,0 +1,130 @@
+"""Regression tests for scripts/cleanup_worktrees.sh.
+
+These exercise the actual shell script (not a Python port of it) against a
+throwaway git repo, so they double as a portability check for the repo-root
+auto-detection logic (see PR discussion: BSD `readlink` has no `-f`).
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "cleanup_worktrees.sh"
+
+
+def _init_repo_with_worktree(base: Path) -> tuple[Path, Path]:
+    """Create a throwaway git repo with one extra worktree on its own branch.
+
+    Returns (repo_dir, worktree_dir).
+    """
+    repo_dir = base / "repo"
+    repo_dir.mkdir()
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=repo_dir, check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=repo_dir, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=repo_dir, check=True)
+    (repo_dir / "README.md").write_text("hello\n")
+    subprocess.run(["git", "add", "README.md"], cwd=repo_dir, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=repo_dir, check=True)
+
+    (repo_dir / "scripts").mkdir()
+    shutil.copy(SCRIPT, repo_dir / "scripts" / SCRIPT.name)
+
+    worktree_dir = base / "wt-feature"
+    subprocess.run(
+        ["git", "worktree", "add", str(worktree_dir), "-b", "feature/thing"],
+        cwd=repo_dir,
+        check=True,
+    )
+    return repo_dir, worktree_dir
+
+
+def _fake_gh_bin(base: Path, pr_state: str) -> Path:
+    """A fake `gh` on PATH that reports a fixed PR state for any branch.
+
+    Lets the test drive the script's "would remove" branch deterministically
+    without depending on network access or a real GitHub PR.
+    """
+    bin_dir = base / "fakebin"
+    bin_dir.mkdir()
+    gh = bin_dir / "gh"
+    gh.write_text(
+        "#!/bin/bash\n"
+        'if [[ "$1" == "pr" && "$2" == "list" ]]; then\n'
+        f'  echo \'[{{"state":"{pr_state}"}}]\'\n'
+        "  exit 0\n"
+        "fi\n"
+        'echo "unexpected gh invocation: $*" >&2\n'
+        "exit 1\n"
+    )
+    gh.chmod(0o755)
+    return bin_dir
+
+
+def _run_script(
+    repo_dir: Path, cwd: Path, path_prefix: Path | None
+) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    if path_prefix is not None:
+        env["PATH"] = f"{path_prefix}:{env['PATH']}"
+    return subprocess.run(
+        [str(repo_dir / "scripts" / SCRIPT.name), "--dry-run"],
+        cwd=cwd,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+class TestDryRunNeverRemoves:
+    def test_dry_run_leaves_removable_worktree_on_disk(self, tmp_path: Path) -> None:
+        """A worktree whose PR is MERGED would normally be removed — but not in --dry-run."""
+        repo_dir, worktree_dir = _init_repo_with_worktree(tmp_path)
+        fake_gh = _fake_gh_bin(tmp_path, pr_state="MERGED")
+
+        result = _run_script(repo_dir, cwd=tmp_path, path_prefix=fake_gh)
+
+        assert result.returncode == 0, result.stderr
+        assert worktree_dir.exists(), "dry-run must not delete the worktree directory"
+
+        worktrees = subprocess.run(
+            ["git", "worktree", "list"], cwd=repo_dir, check=True, capture_output=True, text=True
+        ).stdout
+        assert "feature/thing" in worktrees, "dry-run must not delete the branch/worktree entry"
+
+        branches = subprocess.run(
+            ["git", "branch", "--list", "feature/thing"],
+            cwd=repo_dir,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout
+        assert "feature/thing" in branches, "dry-run must not delete the branch"
+
+        assert "[DRY RUN] Would remove worktree" in result.stdout
+
+    def test_dry_run_works_when_invoked_from_unrelated_cwd(self, tmp_path: Path) -> None:
+        """Repo-root auto-detection must not depend on the caller's cwd."""
+        repo_dir, _worktree_dir = _init_repo_with_worktree(tmp_path)
+        fake_gh = _fake_gh_bin(tmp_path, pr_state="OPEN")
+
+        unrelated_cwd = tmp_path / "somewhere-else"
+        unrelated_cwd.mkdir()
+
+        result = _run_script(repo_dir, cwd=unrelated_cwd, path_prefix=fake_gh)
+
+        assert result.returncode == 0, result.stderr
+        assert f"Main worktree: {repo_dir}" in result.stdout
+
+
+@pytest.mark.skipif(shutil.which("bash") is None, reason="requires bash")
+def test_script_is_executable_bash() -> None:
+    assert SCRIPT.exists()
+    first_line = SCRIPT.read_text().splitlines()[0]
+    assert first_line == "#!/bin/bash"


### PR DESCRIPTION
## What does this PR do?

Replaces a hardcoded repo path in `scripts/cleanup_worktrees.sh` with auto-detection based on the script's own location.

## Why?

The script had `REPO_ROOT="/home/ebi/claude-code-discord-bridge"` hardcoded — the maintainer's personal deployment path. This makes the script fail (or silently operate on the wrong directory) for anyone else who clones the repo to a different path. Since this script ships in the repo for any contributor/deployer to use, it shouldn't assume one specific machine's layout.

## How to test

```sh
# Before the fix, this only worked from /home/ebi/claude-code-discord-bridge.
# After the fix, it resolves its own repo root regardless of caller cwd or clone location:
cd /tmp
bash /path/to/any/clone/of/claude-code-discord-bridge/scripts/cleanup_worktrees.sh --dry-run
# -> "Main worktree: /path/to/any/clone/of/claude-code-discord-bridge" (correct, not /home/ebi/...)
```

Verified manually with `--dry-run` from an unrelated working directory against a clone at a non-`/home/ebi/...` path.

## Checklist

- [x] Tests pass: `uv run pytest tests/ -v` (1868 passed) — this script has no pytest coverage (shell script, outside `claude_discord/`), verified manually as shown above
- [x] Lint passes: `uv run ruff check claude_discord/` (unaffected by this change; confirmed still clean)
- [x] New functionality has tests — N/A, shell script outside the pytest surface
- [ ] README updated — not applicable, no documented behavior change (behavior is now correct instead of environment-specific)