### PR TITLE
fix: zip と誤認したバイナリ添付を削除してしまう不具合（.evtx が消える）

### DIFF
--- a/claude_discord/ext/api_server.py
+++ b/claude_discord/ext/api_server.py
@@ -1611,6 +1611,17 @@ class ApiServer:
         Extraction is bounded (``_MAX_INGEST_UNZIP_*``) and refuses members that
         would escape the target directory (zip-slip). On any failure the zip is
         left untouched in the list so nothing is silently lost.
+
+        The original is deleted **only** when extraction actually produced
+        files. ``zipfile.is_zipfile()`` looks for the end-of-central-directory
+        signature near the end of a file; it does not require the file to start
+        like an archive. Any binary can end up containing a well-formed empty
+        EOCD by chance — Windows event logs (.evtx), dumps and captures are
+        exactly the large opaque blobs where that happens — and such a file was
+        "expanded" into nothing and then unlinked, destroying the attachment
+        while the count still read as a success. Replacing a file with nothing
+        is never an improvement, so if there is nothing to replace it with, it
+        stays.
         """
         result: list[Path] = []
         for path in saved_paths:
@@ -1618,8 +1629,15 @@ class ApiServer:
                 result.append(path)
                 continue
             extracted = self._safe_extract_zip(path)
-            if extracted is None:
-                # Extraction refused/failed — keep the zip so it isn't lost.
+            if not extracted:
+                # Refused, failed, or an "archive" with no members at all —
+                # almost certainly not a bundle. Keep the original.
+                if extracted is not None:
+                    logger.info(
+                        "Ingest attachment %s looks like a zip but holds no files — "
+                        "keeping it as-is",
+                        _sanitize_log(path),
+                    )
                 result.append(path)
                 continue
             result.extend(extracted)

--- a/tests/test_api_server.py
+++ b/tests/test_api_server.py
@@ -1559,3 +1559,155 @@ class TestIngestResult:
             assert any("<@999>" in s and "回答ができました" in s for s in contents)
         finally:
             await client.close()
+
+
+class TestBinaryAttachmentMisdetectedAsZip:
+    """A binary attachment must survive being mistaken for a zip archive.
+
+    ``zipfile.is_zipfile()`` looks for the end-of-central-directory signature
+    (``PK\\x05\\x06``) near the end of the file — it does not require the file to
+    *start* like a zip. Any binary can contain those four bytes by chance, and
+    Windows event logs (.evtx), memory dumps and packet captures are exactly the
+    kind of large opaque blobs where that happens.
+
+    When it did, the expander treated the file as an archive, "extracted" its
+    zero members, and then deleted the original — destroying the attachment and
+    reporting ``attachments_saved: 0``. Reproduced against the live endpoint
+    with a real 1.1 MB Admin.evtx before this was fixed.
+    """
+
+    INGEST_TOKEN = "ingest-secret-xyz"
+    AUTH = {"Authorization": f"Bearer {INGEST_TOKEN}"}
+
+    @pytest.fixture
+    def mock_cog(self) -> MagicMock:
+        thread = MagicMock()
+        thread.id = 111222333
+        thread.name = "Ingested thread"
+        cog = MagicMock()
+        cog.spawn_session = AsyncMock(return_value=thread)
+        return cog
+
+    @pytest.fixture
+    def bot_with_text_channel(self, mock_cog: MagicMock) -> MagicMock:
+        import discord
+
+        b = MagicMock()
+        channel = MagicMock(spec=discord.TextChannel)
+        channel.send = AsyncMock()
+        b.get_channel.return_value = channel
+        b.cogs = {"ClaudeChatCog": mock_cog}
+        return b
+
+    @pytest.fixture
+    async def client(
+        self, repo: NotificationRepository, bot_with_text_channel: MagicMock, tmp_path
+    ) -> TestClient:
+        api = ApiServer(
+            repo=repo,
+            bot=bot_with_text_channel,
+            default_channel_id=12345,
+            ingest_token=self.INGEST_TOKEN,
+            working_dir=str(tmp_path),
+        )
+        c = TestClient(TestServer(api.app))
+        await c.start_server()
+        yield c
+        await c.close()
+
+    @staticmethod
+    def _evtx_containing_eocd() -> bytes:
+        """A .evtx-shaped blob ending in a well-formed, empty EOCD record.
+
+        Built deterministically rather than by scribbling the signature into
+        random bytes: ``is_zipfile`` also validates the trailing comment-length
+        field, so a random blob only trips it some of the time and the test
+        would be flaky. This is the worst realistic case — a binary that any
+        zip reader agrees is an archive containing nothing.
+        """
+        import struct
+
+        eocd = b"PK\x05\x06" + struct.pack("<HHHHIIH", 0, 0, 0, 0, 0, 0, 0)
+        return b"ElfFile\x00" + bytes(200_000) + eocd
+
+    @pytest.mark.asyncio
+    async def test_binary_that_looks_like_a_zip_is_not_deleted(
+        self, client: TestClient, tmp_path
+    ) -> None:
+        import base64
+        import hashlib
+
+        raw = self._evtx_containing_eocd()
+        resp = await client.post(
+            "/api/ingest",
+            json={
+                "content": "see log",
+                "attachments": [{"filename": "Admin.evtx", "data": base64.b64encode(raw).decode()}],
+            },
+            headers=self.AUTH,
+        )
+        assert resp.status == 201
+        assert (await resp.json())["attachments_saved"] == 1
+
+        found = list(tmp_path.glob("ingest/*/Admin.evtx"))
+        assert len(found) == 1, "the attachment must still exist on disk"
+        assert hashlib.sha256(found[0].read_bytes()).hexdigest() == (
+            hashlib.sha256(raw).hexdigest()
+        ), "and must be byte-for-byte intact"
+
+    @pytest.mark.asyncio
+    async def test_a_genuinely_empty_zip_is_kept_rather_than_deleted(
+        self, client: TestClient, tmp_path
+    ) -> None:
+        # Nothing to replace it with, so removing it would leave the session
+        # with strictly less than it was sent.
+        import base64
+        import io
+        import zipfile as zf
+
+        buf = io.BytesIO()
+        with zf.ZipFile(buf, "w"):
+            pass
+        resp = await client.post(
+            "/api/ingest",
+            json={
+                "content": "empty bundle",
+                "attachments": [
+                    {"filename": "b.zip", "data": base64.b64encode(buf.getvalue()).decode()}
+                ],
+            },
+            headers=self.AUTH,
+        )
+        assert resp.status == 201
+        assert list(tmp_path.glob("ingest/*/b.zip"))
+
+    @pytest.mark.asyncio
+    async def test_a_real_bundle_is_still_expanded_and_the_zip_removed(
+        self, client: TestClient, tmp_path
+    ) -> None:
+        # The behaviour that must not regress.
+        import base64
+        import io
+        import zipfile as zf
+
+        buf = io.BytesIO()
+        with zf.ZipFile(buf, "w") as z:
+            z.writestr("Admin.evtx", b"ElfFile\x00payload")
+        resp = await client.post(
+            "/api/ingest",
+            json={
+                "content": "bundle",
+                "attachments": [
+                    {
+                        "filename": "teams-attachments.zip",
+                        "data": base64.b64encode(buf.getvalue()).decode(),
+                    }
+                ],
+            },
+            headers=self.AUTH,
+        )
+        assert resp.status == 201
+        member = list(tmp_path.glob("ingest/*/**/Admin.evtx"))
+        assert len(member) == 1
+        assert member[0].read_bytes() == b"ElfFile\x00payload"
+        assert not list(tmp_path.glob("ingest/*/teams-attachments.zip"))

--- a/uv.lock
+++ b/uv.lock
@@ -259,7 +259,7 @@ wheels = [
 
 [[package]]
 name = "claude-code-discord-bridge"
-version = "3.3.1"
+version = "3.3.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
ご指摘のとおり「サーバー側は自分でテストできる」ので、**実ファイルで往復させました**。結果、**サーバー側に実バグが1件見つかりました。**

## まず、正常系は問題なかった

実機にあった本物の `Admin.evtx`（1,118,208 bytes）を稼働中の `/api/ingest` に流しました:

| 検証項目 | 結果 |
|---|---|
| サイズ | 1,118,208 → 1,118,208 ✅ |
| sha256 | `841200…4814a` → 完全一致 ✅ |
| EVTX マジック | `b'ElfFile\x00'` 保持 ✅ |
| 判定 | ✅ 完全 |

zip 同梱・展開・sha256 照合・レポート生成まで、`.evtx` を正しく扱えています。

## しかし2本目のテストでファイルが消えた

```
attachments_saved = 0
attachments.missing = [Admin.evtx]
```

`zipfile.is_zipfile()` は **end-of-central-directory シグネチャがファイル末尾付近にあるか**しか見ません。**ファイルが zip として始まっている必要はない**のです。

つまり**任意のバイナリが偶然 EOCD を含みうる**。そして Windows イベントログ・メモリダンプ・パケットキャプチャは、まさにそれが起きる「大きくて不透明なバイナリ」です。

該当すると:

1. バンドルだと判定される
2. メンバー0件で「展開成功」になる
3. **`path.unlink()` で元ファイルが削除される**
4. 保存件数は成功のまま

**添付が破壊されます。**

## 修正

**展開が実際にファイルを生んだときだけ**元ファイルを削除します。

> **ファイルを「無」で置き換えることは、決して改善ではない。置き換えるものが無いなら、そのまま残す。**

中身が本当に空の zip も同じ理由で保持します。

## 3.3.0 のマニフェスト検証について

このバグを捕捉したのは 3.3.0 で入れた検証でした（`complete: false` / `missing: Admin.evtx`）。それが無ければ「保存0件」が成功に見えていたはずで、可視化の仕組みが効いた形です。**ただし、欠落を捕捉することと、欠落を起こさないことは別です。**

## テスト

- `test_binary_that_looks_like_a_zip_is_not_deleted` — 実体が残り、**バイト単位で一致**すること
- `test_a_genuinely_empty_zip_is_kept_rather_than_deleted`
- `test_a_real_bundle_is_still_expanded_and_the_zip_removed` — 正常系に回帰が無いこと

検体は `struct.pack` で **EOCD レコードを決定的に構築**しています。最初はランダムバイトにシグネチャを書き込む方式にしたのですが、`is_zipfile` は末尾のコメント長フィールドも検証するため**確率的にしか再現せず、フレーキーなテストになる**ことが分かったので作り直しました。

- 全体: **1810 passed**（`tests/test_run_helper.py` を除く。これは本ブランチと無関係に main で Python 3.12 だと hang する既知の問題）
- `ruff check` / `ruff format --check` / `pyright` クリーン

## サイズ上限も併せて確認（今回の欠落とは無関係）

| 上限 | 値 | 超過時 |
|---|---|---|
| 1リクエスト添付合計 | 50 MB | `413`（無言ではない） |
| zip 展開後の合計 | 200 MB | 展開せず zip のまま保持 |
| 拡張側 1ファイル | 24 MB | `skipped` として申告 |

実在の `.evtx` は 1.1 MB と 4.1 MB なので、いずれの上限にも当たりません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
