### PR TITLE
fix: preserve actionable Teams attachment failures

### DIFF
--- a/claude_discord/ext/teams_store.py
+++ b/claude_discord/ext/teams_store.py
@@ -408,5 +408,17 @@ class TeamsVaultStore:
                 continue
             if name in self._attachments_present(thread_dir, mid):
                 continue
-            merged[(mid, name)] = {**item, "mid": mid, "name": name}
+            candidate = {**item, "mid": mid, "name": name}
+            key = (mid, name)
+            current = merged.get(key)
+            candidate_priority = (
+                bool(candidate.get("url")),
+                bool(candidate.get("reason")),
+            )
+            current_priority = (
+                bool(current and current.get("url")),
+                bool(current and current.get("reason")),
+            )
+            if current is None or candidate_priority >= current_priority:
+                merged[key] = candidate
         return sorted(merged.values(), key=lambda i: (i["mid"], i["name"]))

--- a/tests/test_api_teams_sync.py
+++ b/tests/test_api_teams_sync.py
@@ -418,6 +418,47 @@ async def test_partial_push_preserves_pending_for_an_untouched_message(
     ]
 
 
+async def test_pending_merge_prefers_a_real_link_over_a_provisional_failure(
+    client: TestClient,
+) -> None:
+    """A late provisional DOM fallback must not hide the actionable SharePoint URL."""
+    resp = await client.post(
+        "/api/teams/sync/push",
+        headers=AUTH,
+        json=thread_body(
+            messages=[
+                msg(
+                    ROOT,
+                    "x",
+                    "h1",
+                    attachments=[
+                        {
+                            "name": "admin.evtx",
+                            "status": "linked",
+                            "url": "https://contoso.sharepoint.com/sites/team/admin.evtx",
+                            "reason": "HTTP 404",
+                        },
+                        {
+                            "name": "admin.evtx",
+                            "status": "failed",
+                            "reason": "本文で言及されていますが添付カードを検出できません",
+                        },
+                    ],
+                )
+            ]
+        ),
+    )
+
+    assert (await resp.json())["pending"] == [
+        {
+            "mid": ROOT,
+            "name": "admin.evtx",
+            "reason": "HTTP 404",
+            "url": "https://contoso.sharepoint.com/sites/team/admin.evtx",
+        }
+    ]
+
+
 async def test_plan_requests_a_message_with_obsolete_pending_metadata(
     client: TestClient,
 ) -> None:


### PR DESCRIPTION
## Summary

Preserve a URL-bearing Teams attachment failure when a later provisional DOM fallback describes the same message and filename.

## Why

Long virtualized Teams threads can report the message body before the attachment card is hydrated. The server previously let that late no-URL fallback overwrite a more actionable SharePoint failure.

## Validation

- focused Teams sync API tests: 24 passed
- ruff check and format check
- pyright: 0 errors
- full CI suite is the clean-environment arbiter

Refs #546