### PR TITLE
fix: derive Codex status labels from backend data

### DIFF
--- a/claude_code_core/backend.py
+++ b/claude_code_core/backend.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
 class SessionBackend(Protocol):
     """Protocol that all CLI backends must satisfy."""
 
+    backend: str
     command: str
     model: str
     working_dir: str | None

--- a/claude_code_core/codex_runner.py
+++ b/claude_code_core/codex_runner.py
@@ -251,6 +251,8 @@ def _build_resume_recovery_prompt(prompt: str, session_id: str, env: dict[str, s
 class CodexRunner:
     """Manages OpenAI Codex CLI subprocess."""
 
+    backend = "codex"
+
     def __init__(
         self,
         command: str = "codex",

--- a/claude_code_core/runner.py
+++ b/claude_code_core/runner.py
@@ -72,6 +72,8 @@ def _resolve_windows_cmd(cmd_path: Path) -> list[str] | None:
 class ClaudeRunner:
     """Manages Claude Code CLI subprocess execution."""
 
+    backend = "claude"
+
     def __init__(
         self,
         command: str = "claude",

--- a/claude_discord/cogs/claude_chat.py
+++ b/claude_discord/cogs/claude_chat.py
@@ -1378,4 +1378,5 @@ class ClaudeChatCog(commands.Cog):
                     ThreadState.WAITING_INPUT,
                     description,
                     thread=thread,
+                    backend=runner.backend,
                 )

--- a/claude_discord/discord_ui/engine_status.py
+++ b/claude_discord/discord_ui/engine_status.py
@@ -118,6 +118,26 @@ def _fmt_pct(snap: dict | None) -> str | None:
         return None
 
 
+def _window_label(snap: dict | None, fallback: str) -> str:
+    """Return the quota window label from its reported duration."""
+    if not isinstance(snap, dict):
+        return fallback
+    duration = snap.get("windowDurationMins")
+    try:
+        minutes = round(float(duration))
+    except (TypeError, ValueError):
+        return fallback
+    if minutes == 300:
+        return "5h"
+    if minutes == 10080:
+        return "週次"
+    if minutes > 0 and minutes % 1440 == 0:
+        return f"{minutes // 1440}日"
+    if minutes > 0 and minutes % 60 == 0:
+        return f"{minutes // 60}h"
+    return f"{minutes}分"
+
+
 def format_codex_status_line(data: dict | None) -> str | None:
     """Format a ``account/rateLimits/read`` result into one Discord line.
 
@@ -131,12 +151,14 @@ def format_codex_status_line(data: dict | None) -> str | None:
         return None
 
     segments: list[str] = []
-    primary = _fmt_pct(snap.get("primary"))
+    primary_snap = snap.get("primary")
+    primary = _fmt_pct(primary_snap)
     if primary is not None:
-        segments.append(f"5h {primary}")
-    secondary = _fmt_pct(snap.get("secondary"))
+        segments.append(f"{_window_label(primary_snap, '5h')} {primary}")
+    secondary_snap = snap.get("secondary")
+    secondary = _fmt_pct(secondary_snap)
     if secondary is not None:
-        segments.append(f"週次 {secondary}")
+        segments.append(f"{_window_label(secondary_snap, '週次')} {secondary}")
 
     credit_info = snap.get("credits")
     if isinstance(credit_info, dict):

--- a/claude_discord/discord_ui/thread_dashboard.py
+++ b/claude_discord/discord_ui/thread_dashboard.py
@@ -63,6 +63,7 @@ class _ThreadInfo:
     thread_id: int
     description: str
     state: ThreadState
+    backend: str = "claude"
     started_at: float = field(default_factory=time.monotonic)
     state_changed_at: float = field(default_factory=time.monotonic)
 
@@ -111,6 +112,7 @@ class ThreadStatusDashboard:
         state: ThreadState,
         description: str,
         thread: discord.Thread | discord.TextChannel | None = None,
+        backend: str | None = None,
     ) -> None:
         """Update a thread's state and refresh the dashboard embed.
 
@@ -128,6 +130,9 @@ class ThreadStatusDashboard:
             Short human-readable summary (e.g. the first 100 chars of the prompt).
         thread:
             The ``discord.Thread`` object, required for owner mentions.
+        backend:
+            Backend running this turn. Used to name the engine in the owner
+            mention; omitted values preserve the thread's previous backend.
         """
         async with self._lock:
             prev_state = self._threads[thread_id].state if thread_id in self._threads else None
@@ -137,6 +142,7 @@ class ThreadStatusDashboard:
                     thread_id=thread_id,
                     description=description,
                     state=state,
+                    backend=backend or "claude",
                 )
             else:
                 info = self._threads[thread_id]
@@ -144,6 +150,8 @@ class ThreadStatusDashboard:
                 info.state_changed_at = time.monotonic()
                 if description:
                     info.description = description
+                if backend:
+                    info.backend = backend
 
             # Mention owner on first WAITING_INPUT transition
             should_mention = (
@@ -152,6 +160,7 @@ class ThreadStatusDashboard:
                 and self._owner_id is not None
                 and thread is not None
             )
+            engine = "Codex" if self._threads[thread_id].backend == "codex" else "Claude"
 
             await self._refresh_dashboard()
 
@@ -159,7 +168,7 @@ class ThreadStatusDashboard:
         if should_mention and thread is not None:
             try:
                 await thread.send(
-                    f"🟡 <@{self._owner_id}> Claude has finished — your reply is needed here."
+                    f"🟡 <@{self._owner_id}> {engine} has finished — your reply is needed here."
                 )
             except (discord.HTTPException, RuntimeError):
                 logger.debug("Failed to send owner mention in thread %d", thread_id, exc_info=True)

--- a/tests/test_backend_protocol.py
+++ b/tests/test_backend_protocol.py
@@ -32,6 +32,7 @@ class TestSessionBackendProtocol:
 
     def test_protocol_has_required_properties(self) -> None:
         runner = ClaudeRunner(command="claude", model="sonnet")
+        assert runner.backend == "claude"
         assert hasattr(runner, "model")
         assert hasattr(runner, "working_dir")
         assert hasattr(runner, "permission_mode")
@@ -54,6 +55,7 @@ class TestCreateBackend:
 
         backend = create_backend(backend="codex", model="o4-mini")
         assert isinstance(backend, CodexRunner)
+        assert backend.backend == "codex"
 
     def test_unknown_backend_raises(self) -> None:
         with pytest.raises(ValueError, match="Unknown backend"):

--- a/tests/test_engine_status.py
+++ b/tests/test_engine_status.py
@@ -44,6 +44,37 @@ class TestFormat:
         assert line is not None
         assert "5h 13%" in line
 
+    def test_primary_weekly_window_uses_reported_duration(self) -> None:
+        data = {
+            "rateLimits": {
+                "primary": {
+                    "usedPercent": 3,
+                    "windowDurationMins": 10080,
+                }
+            }
+        }
+
+        line = format_codex_status_line(data)
+
+        assert line is not None
+        assert "週次 3%" in line
+        assert "5h 3%" not in line
+
+    def test_unknown_window_uses_duration_instead_of_slot_name(self) -> None:
+        data = {
+            "rateLimits": {
+                "primary": {
+                    "usedPercent": 7,
+                    "windowDurationMins": 1440,
+                }
+            }
+        }
+
+        line = format_codex_status_line(data)
+
+        assert line is not None
+        assert "1日 7%" in line
+
     def test_rate_limit_reached_warning(self) -> None:
         data = {
             "rateLimits": {

--- a/tests/test_thread_dashboard.py
+++ b/tests/test_thread_dashboard.py
@@ -142,6 +142,32 @@ class TestOwnerMention:
         thread.send.assert_called_once()
         sent_text = thread.send.call_args.args[0]
         assert "<@42>" in sent_text
+        assert "Claude has finished" in sent_text
+
+    @pytest.mark.asyncio
+    async def test_codex_mention_names_codex(self) -> None:
+        dashboard, _ = _make_dashboard(owner_id=42)
+        await dashboard.initialize()
+        thread = _make_thread(10)
+
+        await dashboard.set_state(
+            10,
+            ThreadState.PROCESSING,
+            "working",
+            thread=thread,
+            backend="codex",
+        )
+        await dashboard.set_state(
+            10,
+            ThreadState.WAITING_INPUT,
+            "working",
+            thread=thread,
+            backend="codex",
+        )
+
+        sent_text = thread.send.call_args.args[0]
+        assert "Codex has finished" in sent_text
+        assert "Claude has finished" not in sent_text
 
     @pytest.mark.asyncio
     async def test_mention_not_sent_if_already_waiting(self) -> None:


### PR DESCRIPTION
## What does this PR do?

- Derives Codex quota-window labels from `windowDurationMins` instead of assuming the primary slot is always five hours.
- Supports the known 5-hour and weekly windows plus generic day/hour/minute durations.
- Exposes the runner backend through the backend protocol.
- Uses that backend identity in the thread dashboard so completion notices say `Codex has finished` for Codex runs and `Claude has finished` for Claude runs.

## Why?

The rate-limit response can report a weekly window in the primary slot. Hardcoding that slot as `5h` produced misleading output such as `Codex: 5h 3%` when the value was weekly.

Completion notifications were also hardcoded to Claude even when the active runner was Codex.

## How to test

```bash
uv run --frozen ruff check claude_discord/ claude_code_core/ tests/
uv run --frozen ruff format --check claude_discord/ claude_code_core/ tests/
env -u CCDB_API_URL -u CCDB_API_SECRET uv run --frozen pytest -q
```

Result: `1899 passed`.

## Checklist

- [x] Tests pass: `uv run pytest tests/ -v`
- [x] Lint passes: `uv run ruff check claude_discord/`
- [x] New functionality has tests
- [ ] README updated (not required; behavior correction only)
