### PR TITLE
feat: add frontend-neutral stream presentation policy

### DIFF
--- a/claude_code_core/__init__.py
+++ b/claude_code_core/__init__.py
@@ -38,6 +38,19 @@ from .models import init_db
 # Parser
 from .parser import parse_line
 
+# Frontend-neutral presentation
+from .presentation import (
+    ErrorProjection,
+    FinalResult,
+    InteractiveProjection,
+    PresentationMode,
+    PresentationPolicy,
+    Projection,
+    StreamProjector,
+    TextUpdate,
+    project_stream,
+)
+
 # Rewind
 from .rewind import TurnEntry, find_session_jsonl, parse_user_turns, truncate_jsonl_at_line
 
@@ -79,6 +92,16 @@ __all__ = [
     "ToolUseEvent",
     # Parser
     "parse_line",
+    # Presentation
+    "ErrorProjection",
+    "FinalResult",
+    "InteractiveProjection",
+    "PresentationMode",
+    "PresentationPolicy",
+    "Projection",
+    "StreamProjector",
+    "TextUpdate",
+    "project_stream",
     # API provider
     "detect_api_provider",
     # Backend

--- a/claude_code_core/presentation.py
+++ b/claude_code_core/presentation.py
@@ -1,0 +1,135 @@
+"""Frontend-neutral projection of backend stream events.
+
+The projector decides *what* a frontend may present.  Discord, Slack, and other
+adapters remain responsible for *how* a projection is rendered (send, edit,
+buttons, and chunking).
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterable, AsyncIterator
+from dataclasses import dataclass
+from enum import Enum
+from typing import TypeAlias
+
+from .types import MessageType, StreamEvent
+
+
+class PresentationMode(str, Enum):
+    """Assistant-text delivery policy.
+
+    ``STREAM`` preserves the existing behavior: assistant text is visible as it
+    arrives. ``FINAL`` suppresses intermediate commentary and emits text only
+    when the backend reaches a successful terminal result.
+    """
+
+    STREAM = "stream"
+    FINAL = "final"
+
+
+@dataclass(frozen=True)
+class PresentationPolicy:
+    """Frontend-neutral choices for projecting one backend turn."""
+
+    mode: PresentationMode = PresentationMode.STREAM
+
+
+@dataclass(frozen=True)
+class TextUpdate:
+    """Assistant text that a streaming frontend may upsert in place."""
+
+    text: str
+
+
+@dataclass(frozen=True)
+class InteractiveProjection:
+    """An interactive request that must be presented without waiting for RESULT."""
+
+    event: StreamEvent
+
+
+@dataclass(frozen=True)
+class FinalResult:
+    """The single successful terminal answer for a turn."""
+
+    text: str
+
+
+@dataclass(frozen=True)
+class ErrorProjection:
+    """A backend error that must be presented immediately."""
+
+    error: str
+    event: StreamEvent
+
+
+Projection: TypeAlias = TextUpdate | InteractiveProjection | FinalResult | ErrorProjection
+
+
+class StreamProjector:
+    """Stateful reducer from backend ``StreamEvent`` values to UI projections."""
+
+    def __init__(
+        self,
+        policy: PresentationPolicy | PresentationMode | None = None,
+    ) -> None:
+        if policy is None:
+            policy = PresentationPolicy()
+        self.policy = (
+            policy if isinstance(policy, PresentationPolicy) else PresentationPolicy(mode=policy)
+        )
+        self.mode = self.policy.mode
+        self._latest_text = ""
+        self._terminal = False
+
+    def project(self, event: StreamEvent) -> tuple[Projection, ...]:
+        """Project one stream event, omitting empty and post-terminal output."""
+        if self._terminal:
+            return ()
+
+        if event.error:
+            self._terminal = True
+            return (ErrorProjection(event.error, event),)
+
+        projected: list[Projection] = []
+        if _is_interactive(event):
+            projected.append(InteractiveProjection(event))
+
+        if event.message_type == MessageType.ASSISTANT and _has_text(event.text):
+            assert event.text is not None
+            self._latest_text = event.text
+            if self.mode == PresentationMode.STREAM:
+                projected.append(TextUpdate(event.text))
+
+        if event.message_type == MessageType.RESULT or event.is_complete:
+            self._terminal = True
+            final_text = event.text if _has_text(event.text) else self._latest_text
+            if _has_text(final_text):
+                assert final_text is not None
+                projected.append(FinalResult(final_text))
+
+        return tuple(projected)
+
+
+async def project_stream(
+    events: AsyncIterable[StreamEvent],
+    policy: PresentationPolicy | None = None,
+) -> AsyncIterator[Projection]:
+    """Project a backend event stream for consumption by any frontend adapter."""
+    projector = StreamProjector(policy)
+    async for event in events:
+        for projection in projector.project(event):
+            yield projection
+
+
+def _has_text(text: str | None) -> bool:
+    return text is not None and bool(text.strip())
+
+
+def _is_interactive(event: StreamEvent) -> bool:
+    return bool(
+        event.permission_request is not None
+        or event.elicitation is not None
+        or event.ask_questions
+        or event.is_plan_approval
+    )

--- a/tests/test_presentation.py
+++ b/tests/test_presentation.py
@@ -1,0 +1,130 @@
+"""Tests for frontend-neutral stream presentation policy."""
+
+from __future__ import annotations
+
+from claude_code_core.presentation import (
+    ErrorProjection,
+    FinalResult,
+    InteractiveProjection,
+    PresentationMode,
+    PresentationPolicy,
+    StreamProjector,
+    TextUpdate,
+    project_stream,
+)
+from claude_code_core.types import (
+    AskQuestion,
+    ElicitationRequest,
+    MessageType,
+    PermissionRequest,
+    StreamEvent,
+    ToolCategory,
+    ToolUseEvent,
+)
+
+
+def _assistant(text: str, *, tool: bool = False) -> StreamEvent:
+    return StreamEvent(
+        message_type=MessageType.ASSISTANT,
+        text=text,
+        tool_use=(
+            ToolUseEvent("tool-1", "Read", {"file_path": "README.md"}, ToolCategory.READ)
+            if tool
+            else None
+        ),
+    )
+
+
+def test_stream_mode_is_the_backward_compatible_default() -> None:
+    projector = StreamProjector()
+
+    assert projector.mode is PresentationMode.STREAM
+    assert projector.project(_assistant("working")) == (TextUpdate("working"),)
+
+
+def test_projector_accepts_an_explicit_policy() -> None:
+    projector = StreamProjector(PresentationPolicy(mode=PresentationMode.FINAL))
+
+    assert projector.mode is PresentationMode.FINAL
+
+
+def test_final_mode_emits_only_one_terminal_result_across_commentary_and_tools() -> None:
+    projector = StreamProjector(PresentationMode.FINAL)
+
+    emitted = []
+    emitted.extend(projector.project(_assistant("I will inspect the files.")))
+    emitted.extend(projector.project(_assistant("Reading now.", tool=True)))
+    emitted.extend(projector.project(_assistant("The tests reveal the cause.")))
+    emitted.extend(
+        projector.project(
+            StreamEvent(
+                message_type=MessageType.RESULT,
+                text="Fixed and verified.",
+                is_complete=True,
+            )
+        )
+    )
+
+    assert emitted == [FinalResult("Fixed and verified.")]
+
+
+def test_final_mode_never_emits_empty_text() -> None:
+    projector = StreamProjector(PresentationMode.FINAL)
+
+    assert projector.project(_assistant("")) == ()
+    assert projector.project(StreamEvent(message_type=MessageType.RESULT, is_complete=True)) == ()
+
+
+def test_final_mode_emits_interactive_requests_immediately() -> None:
+    events = [
+        StreamEvent(
+            message_type=MessageType.ASSISTANT,
+            ask_questions=[AskQuestion("Continue?")],
+        ),
+        StreamEvent(
+            message_type=MessageType.SYSTEM,
+            permission_request=PermissionRequest("p1", "Bash"),
+        ),
+        StreamEvent(
+            message_type=MessageType.SYSTEM,
+            elicitation=ElicitationRequest("e1", "server", "form-mode"),
+        ),
+        StreamEvent(message_type=MessageType.ASSISTANT, is_plan_approval=True),
+    ]
+
+    for event in events:
+        projector = StreamProjector(PresentationMode.FINAL)
+        assert projector.project(event) == (InteractiveProjection(event),)
+
+
+def test_final_mode_emits_errors_immediately_without_a_final_result() -> None:
+    projector = StreamProjector(PresentationMode.FINAL)
+    projector.project(_assistant("Trying a fallback."))
+    event = StreamEvent(
+        message_type=MessageType.RESULT,
+        error="backend unavailable",
+        is_complete=True,
+    )
+
+    assert projector.project(event) == (ErrorProjection("backend unavailable", event),)
+    assert (
+        projector.project(
+            StreamEvent(message_type=MessageType.RESULT, text="must not leak", is_complete=True)
+        )
+        == ()
+    )
+
+
+async def test_project_stream_projects_an_async_backend_stream() -> None:
+    async def events():
+        yield _assistant("Working")
+        yield StreamEvent(message_type=MessageType.RESULT, text="Done", is_complete=True)
+
+    projections = [
+        projection
+        async for projection in project_stream(
+            events(), PresentationPolicy(mode=PresentationMode.FINAL)
+        )
+    ]
+
+    assert projections == [FinalResult("Done")]


### PR DESCRIPTION
## 概要

frontend非依存の `PresentationPolicy` / `StreamProjector` を `claude_code_core` に追加します。Discord・Slack等のadapterは描画方法に専念し、coreがstream textの公開方針を決定できます。

- 既定は従来互換の `stream` mode
- `final` modeは中間commentary/tool境界のtextを抑止し、terminal `FinalResult` を1件だけemit
- 空textはemitしない
- AskUserQuestion / permission / elicitation / plan approvalは即時emit
- errorは即時emitし、後続terminal outputを抑止
- async event stream向け `project_stream()` を公開

## 検証

- `uv run ruff check claude_code_core/ tests/test_presentation.py`
- `uv run ruff format --check claude_code_core/ tests/test_presentation.py`
- `uv run pyright claude_code_core/`
- `uv run pytest tests/ -q --tb=short` → 1903 passed

既存のDiscord EventProcessorには未接続のため、現行stream表示のruntime behaviorは変わりません。