### PR TITLE
feat(core): define the frontend-agnostic conversation surface protocol

### DIFF
--- a/claude_code_core/__init__.py
+++ b/claude_code_core/__init__.py
@@ -7,6 +7,8 @@ that needs to invoke the Claude Code CLI and process its stream-json output:
 - **StreamEvent / parse_line**: Stream-json parser and typed event model
 - **SessionRepository**: SQLite-backed session persistence
 - **rewind utilities**: JSONL session history manipulation
+- **frontend protocol**: the vocabulary a chat frontend (Discord, Teams, ...)
+  implements so the session machinery never names a platform
 
 Usage::
 
@@ -32,6 +34,29 @@ from .backend import SessionBackend, create_backend
 from .codex_runner import CodexRunner, parse_codex_line
 
 # Database
+# Frontend protocol
+from .frontend import (
+    ActivityHandle,
+    ActivitySpec,
+    Choice,
+    ChoicePrompt,
+    ConversationSurface,
+    FormField,
+    FormPrompt,
+    InboundAttachment,
+    InboundMessage,
+    InterruptHandle,
+    Mention,
+    Notice,
+    NoticeLevel,
+    OutboundFile,
+    SessionFrontend,
+    StatusKind,
+    SurfaceCapabilities,
+    TextStream,
+    ThreadKey,
+    derive_thread_key,
+)
 from .lounge_repo import LoungeMessage, LoungeRepository
 from .models import init_db
 
@@ -95,6 +120,27 @@ __all__ = [
     "SessionRepository",
     "UsageStatsRepository",
     "init_db",
+    # Frontend protocol
+    "ActivityHandle",
+    "ActivitySpec",
+    "Choice",
+    "ChoicePrompt",
+    "ConversationSurface",
+    "FormField",
+    "FormPrompt",
+    "InboundAttachment",
+    "InboundMessage",
+    "InterruptHandle",
+    "Mention",
+    "Notice",
+    "NoticeLevel",
+    "OutboundFile",
+    "SessionFrontend",
+    "StatusKind",
+    "SurfaceCapabilities",
+    "TextStream",
+    "ThreadKey",
+    "derive_thread_key",
     # Rewind
     "TurnEntry",
     "find_session_jsonl",

--- a/claude_code_core/frontend.py
+++ b/claude_code_core/frontend.py
@@ -1,0 +1,570 @@
+"""Frontend-agnostic vocabulary for driving a chat surface.
+
+A "frontend" is whatever carries the conversation: Discord today, Microsoft
+Teams next. This module defines the *only* thing the session machinery
+(``EventProcessor`` and friends) is allowed to know about it.
+
+Why the vocabulary is semantic, not structural
+----------------------------------------------
+The tempting design is to lift Discord's own API::
+
+    async def send(self, content=None, embed=None, view=None) -> Message: ...
+
+That is a trap. It makes every other frontend's job "translate an embed into
+our native thing", and a translator can only ever lose. The Teams
+implementation would end up rendering a column of card-shaped embeds because
+that is what Discord happened to do — and every gap would read as "Teams is
+worse".
+
+So the protocol names *intents* instead:
+
+===============================  ==========================================
+Intent                           Discord does                Teams does
+===============================  ==========================================
+``open_activity``                one embed per tool,         folds into the
+                                 edited on completion        single session
+                                                             card it already
+                                                             keeps updating
+``set_status``                   emoji reaction on the       the status row of
+                                 user's message              that same card
+``prompt_choice``                Buttons / Select menu       Adaptive Card
+                                                             ``Action.Execute``
+``offer_interrupt``              a re-posted Stop button     a Stop action
+                                                             pinned in the card
+===============================  ==========================================
+
+Each frontend picks the best expression it has. Neither is a translation of
+the other, so neither has to be a degraded copy of the other.
+
+Capabilities, not feature flags
+-------------------------------
+Callers must not branch on ``if frontend == "teams"``. They ask
+:class:`SurfaceCapabilities`, whose defaults are deliberately *conservative*:
+an unset capability means "not supported". Adding a field to it is therefore
+backwards compatible — an out-of-date frontend keeps the plain-text fallback
+instead of silently claiming something it cannot do.
+
+The same object carries the hard limits that are easy to blow past by
+accident. Teams allows 1,800 updates per hour per conversation, so a naive
+port of a once-a-second live timer would kill the conversation partway through
+a long session. ``min_update_interval`` turns that from a bug you find in
+production into a number you read before you loop.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Awaitable, Callable, Sequence
+from dataclasses import dataclass, field
+from enum import StrEnum
+from pathlib import PurePosixPath, PureWindowsPath
+from typing import Literal, Protocol, runtime_checkable
+
+from .types import ToolCategory
+
+__all__ = [
+    "ActivityHandle",
+    "ActivitySpec",
+    "Choice",
+    "ChoicePrompt",
+    "ConversationSurface",
+    "FormField",
+    "FormPrompt",
+    "InboundAttachment",
+    "InboundMessage",
+    "InterruptHandle",
+    "Mention",
+    "Notice",
+    "NoticeLevel",
+    "OutboundFile",
+    "SessionFrontend",
+    "StatusKind",
+    "SurfaceCapabilities",
+    "TextStream",
+    "ThreadKey",
+    "derive_thread_key",
+]
+
+# ---------------------------------------------------------------------------
+# Thread identity
+# ---------------------------------------------------------------------------
+
+#: The primary key a session is filed under, shared by every frontend.
+#:
+#: It is an ``int`` because that is what ``sessions.thread_id`` has always
+#: been, and because the session ledger, AI Lounge, claims, rewind and
+#: collision detection all key off it. Keeping the type means a Teams session
+#: and a Discord session land in *one* ledger — which is the whole reason ccdb
+#: can notice that two live sessions are editing the same file.
+ThreadKey = int
+
+# Derived keys are pushed above this floor so they can never be mistaken for a
+# Discord snowflake, which is used verbatim as its own thread key. Snowflakes
+# encode milliseconds since 2015 in their high bits and stay below 2**53 well
+# past the year 2100, so the two spaces stay disjoint by construction.
+_DERIVED_KEY_FLOOR = 2**53
+_DERIVED_KEY_CEILING = 2**63 - 1
+_DERIVED_KEY_SPAN = _DERIVED_KEY_CEILING - _DERIVED_KEY_FLOOR
+
+
+def derive_thread_key(frontend: str, external_id: str) -> ThreadKey:
+    """Derive a stable :data:`ThreadKey` from a frontend's own conversation id.
+
+    Frontends whose conversation ids are not integers (Teams uses strings like
+    ``19:...@thread.tacv2;messageid=1481567603816``) mint a surrogate here and
+    record the pairing in the ``frontend_threads`` table, so the rest of ccdb
+    keeps seeing plain integers.
+
+    The result is deterministic, scoped by *frontend* so two platforms can
+    never collide on the same id, positive, and inside SQLite's signed 64-bit
+    INTEGER range.
+
+    Raises:
+        ValueError: if either argument is empty.
+    """
+    if not frontend:
+        raise ValueError("frontend must not be empty")
+    if not external_id:
+        raise ValueError("external_id must not be empty")
+
+    digest = hashlib.blake2b(
+        f"{frontend}\x00{external_id}".encode(),
+        digest_size=8,
+    ).digest()
+    return _DERIVED_KEY_FLOOR + (int.from_bytes(digest, "big") % _DERIVED_KEY_SPAN)
+
+
+# ---------------------------------------------------------------------------
+# Enums
+# ---------------------------------------------------------------------------
+
+
+class StatusKind(StrEnum):
+    """What the session is doing right now, in frontend-neutral terms."""
+
+    THINKING = "thinking"
+    TOOL_READ = "tool_read"
+    TOOL_EDIT = "tool_edit"
+    TOOL_COMMAND = "tool_command"
+    TOOL_WEB = "tool_web"
+    TOOL_OTHER = "tool_other"
+    HOOK = "hook"
+    COMPACTING = "compacting"
+    STALLED_SOFT = "stalled_soft"
+    STALLED_HARD = "stalled_hard"
+    DONE = "done"
+    ERROR = "error"
+
+    @classmethod
+    def for_tool(cls, category: ToolCategory) -> StatusKind:
+        """Map a tool category to a status.
+
+        Falls back to :attr:`TOOL_OTHER` so that adding a ``ToolCategory``
+        never leaves a session with a stale status indicator.
+        """
+        return _TOOL_STATUS.get(category, cls.TOOL_OTHER)
+
+
+_TOOL_STATUS: dict[ToolCategory, StatusKind] = {
+    ToolCategory.READ: StatusKind.TOOL_READ,
+    ToolCategory.EDIT: StatusKind.TOOL_EDIT,
+    ToolCategory.COMMAND: StatusKind.TOOL_COMMAND,
+    ToolCategory.WEB: StatusKind.TOOL_WEB,
+    ToolCategory.THINK: StatusKind.THINKING,
+    ToolCategory.PLAN: StatusKind.THINKING,
+    ToolCategory.ASK: StatusKind.TOOL_OTHER,
+    ToolCategory.TASK: StatusKind.TOOL_OTHER,
+    ToolCategory.OTHER: StatusKind.TOOL_OTHER,
+}
+
+
+class NoticeLevel(StrEnum):
+    """Severity of an out-of-band message (not the assistant's own reply)."""
+
+    INFO = "info"
+    SUCCESS = "success"
+    WARNING = "warning"
+    ERROR = "error"
+    SUBTLE = "subtle"
+
+
+# ---------------------------------------------------------------------------
+# Capabilities
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SurfaceCapabilities:
+    """What a surface can actually do. Defaults say "no".
+
+    Only ``max_message_chars`` is required, because a surface that cannot say
+    how long a message may be cannot be written to at all. Everything else
+    defaults to the most restrictive answer, so forgetting to declare a
+    capability degrades gracefully instead of failing at runtime.
+    """
+
+    max_message_chars: int
+
+    # Rendering
+    supports_tables: bool = False
+    supports_headings: bool = False
+    supports_inline_images: bool = False
+
+    # Message lifecycle
+    supports_message_edit: bool = False
+    supports_message_delete: bool = False
+    supports_reactions: bool = False
+
+    # Live updates. ``live_update_budget_per_hour`` is a hard platform quota
+    # (Teams: 1,800 per conversation); ``stream_min_interval`` is the pace the
+    # frontend prefers. Callers should read ``min_update_interval``, which
+    # respects whichever is stricter.
+    live_update_budget_per_hour: int = 1800
+    stream_min_interval: float = 1.5
+
+    # Files
+    max_files_per_message: int = 1
+    max_file_bytes: int = 8 * 1024 * 1024
+    file_delivery: Literal["inline", "consent", "link"] = "inline"
+
+    # Affordances
+    supports_slash_commands: bool = False
+    supports_pinned_dashboard: bool = False
+    supports_thread_rename: bool = False
+
+    def __post_init__(self) -> None:
+        if self.max_message_chars <= 0:
+            raise ValueError("max_message_chars must be positive")
+        if self.live_update_budget_per_hour <= 0:
+            raise ValueError("live_update_budget_per_hour must be positive")
+        if self.stream_min_interval < 0:
+            raise ValueError("stream_min_interval must not be negative")
+        if self.max_files_per_message <= 0:
+            raise ValueError("max_files_per_message must be positive")
+
+    @property
+    def min_update_interval(self) -> float:
+        """Seconds a caller must leave between edits of the same conversation.
+
+        Whichever is stricter: the frontend's preferred streaming pace, or the
+        pace implied by the platform's hourly update quota.
+        """
+        budget_floor = 3600.0 / self.live_update_budget_per_hour
+        return max(self.stream_min_interval, budget_floor)
+
+
+# ---------------------------------------------------------------------------
+# Outbound value objects
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Notice:
+    """Out-of-band information: session start/complete, compaction, thinking.
+
+    Deliberately *not* the assistant's reply — a surface is free to render
+    these as subtle text, a card, or to drop them entirely in a "chat only"
+    mode.
+    """
+
+    level: NoticeLevel
+    title: str | None = None
+    body: str | None = None
+    fields: tuple[tuple[str, str], ...] = ()
+    monospace_body: bool = False
+
+    def __post_init__(self) -> None:
+        if not (self.title or self.body or self.fields):
+            raise ValueError("Notice must carry a title, a body, or fields")
+
+
+@dataclass(frozen=True)
+class ActivitySpec:
+    """A unit of work that starts, optionally progresses, and finishes."""
+
+    kind: Literal["tool", "todo"]
+    title: str
+    detail: str | None = None
+    category: ToolCategory | None = None
+
+    def __post_init__(self) -> None:
+        if not self.title:
+            raise ValueError("ActivitySpec.title must not be empty")
+
+
+@dataclass(frozen=True)
+class Choice:
+    value: str
+    label: str
+    description: str | None = None
+    style: Literal["default", "positive", "destructive"] = "default"
+
+    def __post_init__(self) -> None:
+        if not self.value:
+            raise ValueError("Choice.value must not be empty")
+        if not self.label:
+            raise ValueError("Choice.label must not be empty")
+
+
+@dataclass(frozen=True)
+class Mention:
+    """A user to notify. Rendering is entirely up to the surface."""
+
+    external_user_id: str
+    display_name: str | None = None
+
+    def __post_init__(self) -> None:
+        if not self.external_user_id:
+            raise ValueError("Mention.external_user_id must not be empty")
+
+
+@dataclass(frozen=True)
+class ChoicePrompt:
+    """Ask the user to pick something. Covers AskUserQuestion, tool permission
+    requests and plan approval — they differ only in their choices."""
+
+    question: str
+    header: str | None = None
+    choices: tuple[Choice, ...] = ()
+    multi_select: bool = False
+    allow_free_text: bool = False
+    timeout_seconds: float | None = None
+    #: Answer to assume when the prompt times out. Permission requests set
+    #: this to the denying choice so an unattended session fails closed.
+    default_on_timeout: str | None = None
+    notify: Mention | None = None
+
+    def __post_init__(self) -> None:
+        if not self.question:
+            raise ValueError("ChoicePrompt.question must not be empty")
+        if not self.choices and not self.allow_free_text:
+            raise ValueError(
+                "ChoicePrompt needs choices or allow_free_text — otherwise it is unanswerable"
+            )
+        values = [c.value for c in self.choices]
+        if len(values) != len(set(values)):
+            raise ValueError("ChoicePrompt.choices must have unique values")
+        if self.default_on_timeout is not None and self.default_on_timeout not in values:
+            raise ValueError("default_on_timeout must be one of the offered choice values")
+
+
+@dataclass(frozen=True)
+class FormField:
+    key: str
+    label: str
+    kind: Literal["text", "multiline", "number", "choice", "toggle"]
+    required: bool = False
+    placeholder: str | None = None
+    choices: tuple[Choice, ...] = ()
+
+    def __post_init__(self) -> None:
+        if not self.key:
+            raise ValueError("FormField.key must not be empty")
+        if not self.label:
+            raise ValueError("FormField.label must not be empty")
+        if self.kind == "choice" and not self.choices:
+            raise ValueError(f"FormField {self.key!r} of kind 'choice' needs choices")
+
+
+@dataclass(frozen=True)
+class FormPrompt:
+    """A multi-field form. Backs MCP elicitation."""
+
+    title: str
+    fields: tuple[FormField, ...]
+    description: str | None = None
+    submit_label: str = "Submit"
+    timeout_seconds: float | None = None
+    notify: Mention | None = None
+
+    def __post_init__(self) -> None:
+        if not self.title:
+            raise ValueError("FormPrompt.title must not be empty")
+        if not self.fields:
+            raise ValueError("FormPrompt needs at least one field")
+        keys = [f.key for f in self.fields]
+        if len(keys) != len(set(keys)):
+            raise ValueError("FormPrompt.fields must have unique keys")
+
+
+@dataclass(frozen=True)
+class OutboundFile:
+    """A file to deliver, either from disk or already in memory.
+
+    ``display_name`` is reduced to a bare filename at construction: a path a
+    model wrote into the attachment marker must never turn into directory
+    components in an upload request.
+    """
+
+    display_name: str
+    path: str | None = None
+    blob: bytes | None = None
+    content_type: str | None = None
+
+    def __post_init__(self) -> None:
+        if (self.path is None) == (self.blob is None):
+            raise ValueError("OutboundFile needs exactly one of path or blob")
+        if not self.display_name:
+            raise ValueError("OutboundFile.display_name must not be empty")
+        # Strip directory components from both POSIX and Windows separators, so
+        # "../../etc/passwd" and "..\\..\\secret" both reduce to a bare name.
+        name = PureWindowsPath(PurePosixPath(self.display_name).name).name
+        if not name or name in (".", ".."):
+            raise ValueError(
+                f"OutboundFile.display_name has no usable filename: {self.display_name!r}"
+            )
+        object.__setattr__(self, "display_name", name)
+
+
+# ---------------------------------------------------------------------------
+# Inbound value objects
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class InboundAttachment:
+    filename: str
+    content_type: str | None = None
+    url: str | None = None
+    data: bytes | None = None
+
+
+@dataclass(frozen=True)
+class InboundMessage:
+    """A user message, normalised across frontends.
+
+    ``raw_text`` is what the platform delivered; ``text`` is what the model
+    should see. They differ when the surface requires an @mention to be
+    addressed at all — Teams channels do, unless the app is granted RSC.
+    """
+
+    surface: ConversationSurface
+    author_external_id: str
+    author_display: str
+    raw_text: str
+    text: str | None = None
+    attachments: tuple[InboundAttachment, ...] = ()
+    is_mention: bool = False
+    is_new_conversation: bool = False
+    mentions: tuple[Mention, ...] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        if self.text is None:
+            object.__setattr__(self, "text", self.raw_text)
+
+
+# ---------------------------------------------------------------------------
+# Protocols
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class TextStream(Protocol):
+    """An assistant reply being revealed as it is generated."""
+
+    @property
+    def has_content(self) -> bool: ...
+
+    async def append(self, delta: str) -> None: ...
+
+    async def finalize(self, transform: Callable[[str], str] | None = None) -> str:
+        """Flush and stop. Returns the full text that was shown."""
+        ...
+
+
+@runtime_checkable
+class ActivityHandle(Protocol):
+    """A started :class:`ActivitySpec`. Always end with ``complete`` or ``cancel``."""
+
+    async def update(self, detail: str) -> None: ...
+
+    async def complete(self, result: str | None, *, ok: bool = True) -> None: ...
+
+    async def cancel(self) -> None: ...
+
+
+@runtime_checkable
+class InterruptHandle(Protocol):
+    """The user's way to stop a running session."""
+
+    async def bump(self) -> None:
+        """Move the control back into view. A no-op where it never leaves."""
+        ...
+
+    async def disable(self) -> None: ...
+
+
+@runtime_checkable
+class ConversationSurface(Protocol):
+    """One conversation thread — the place a single session talks to a user."""
+
+    @property
+    def thread_key(self) -> ThreadKey: ...
+
+    @property
+    def external_id(self) -> str:
+        """The frontend's own id for this conversation."""
+        ...
+
+    @property
+    def frontend(self) -> str: ...
+
+    @property
+    def capabilities(self) -> SurfaceCapabilities: ...
+
+    # -- output ------------------------------------------------------------
+    async def send_text(self, text: str) -> str | None:
+        """Post assistant-authored text. Returns a message id if the surface has one."""
+        ...
+
+    async def send_notice(self, notice: Notice) -> str | None: ...
+
+    async def deliver_files(self, files: Sequence[OutboundFile]) -> None: ...
+
+    def open_stream(self) -> TextStream: ...
+
+    async def open_activity(self, spec: ActivitySpec) -> ActivityHandle: ...
+
+    # -- state -------------------------------------------------------------
+    async def set_status(self, status: StatusKind) -> None: ...
+
+    async def clear_status(self) -> None: ...
+
+    # -- interaction -------------------------------------------------------
+    async def prompt_choice(self, prompt: ChoicePrompt) -> tuple[str, ...] | None:
+        """Returns the chosen values, or None if unanswered."""
+        ...
+
+    async def prompt_form(self, prompt: FormPrompt) -> dict[str, str] | None: ...
+
+    async def prompt_url(self, title: str, url: str, *, notify: Mention | None = None) -> bool: ...
+
+    async def offer_interrupt(self, on_stop: Callable[[], Awaitable[None]]) -> InterruptHandle: ...
+
+    # -- management --------------------------------------------------------
+    async def rename(self, title: str) -> None:
+        """No-op where threads have no name (Teams reply chains do not)."""
+        ...
+
+    async def recent_transcript(self, days: int) -> str | None: ...
+
+
+@runtime_checkable
+class SessionFrontend(Protocol):
+    """A whole bot. The seam that scheduler, webhooks and the REST API use to
+    reach a conversation without knowing which platform it lives on."""
+
+    @property
+    def name(self) -> str: ...
+
+    async def start(self) -> None: ...
+
+    async def close(self) -> None: ...
+
+    async def resolve_surface(self, thread_key: ThreadKey) -> ConversationSurface | None:
+        """Find an existing conversation, e.g. to resume it on a schedule."""
+        ...
+
+    async def create_surface(self, *, parent_id: str, title: str) -> ConversationSurface:
+        """Start a new conversation under a channel/team."""
+        ...

--- a/tests/test_frontend_protocol.py
+++ b/tests/test_frontend_protocol.py
@@ -1,0 +1,277 @@
+"""Tests for the frontend-agnostic conversation surface protocol.
+
+This module has no implementations yet — it defines the vocabulary that both
+``claude_discord`` and (later) ``claude_teams`` speak. The tests pin the
+invariants that make the vocabulary safe to implement against:
+
+* value objects reject malformed input at construction (fail fast at the boundary)
+* ``SurfaceCapabilities`` defaults are *conservative*, so a frontend that
+  forgets to declare a capability is treated as not having it
+* ``derive_thread_key`` is deterministic, collision-scoped per frontend, and
+  fits SQLite's signed 64-bit INTEGER
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from claude_code_core.frontend import (
+    ActivitySpec,
+    Choice,
+    ChoicePrompt,
+    FormField,
+    FormPrompt,
+    InboundMessage,
+    Mention,
+    Notice,
+    NoticeLevel,
+    OutboundFile,
+    StatusKind,
+    SurfaceCapabilities,
+    derive_thread_key,
+)
+
+# ---------------------------------------------------------------------------
+# derive_thread_key
+# ---------------------------------------------------------------------------
+
+
+class TestDeriveThreadKey:
+    def test_is_deterministic(self) -> None:
+        cid = "19:aebd0ad4d6ab42c8b9ed19c251c2fc37@thread.tacv2;messageid=1481567603816"
+        assert derive_thread_key("teams", cid) == derive_thread_key("teams", cid)
+
+    def test_scoped_by_frontend(self) -> None:
+        """The same external id on two frontends must not collide."""
+        assert derive_thread_key("teams", "abc") != derive_thread_key("discord", "abc")
+
+    def test_distinct_ids_differ(self) -> None:
+        keys = {derive_thread_key("teams", f"19:conv{i}@thread.tacv2") for i in range(1000)}
+        assert len(keys) == 1000
+
+    def test_fits_signed_64bit_and_is_positive(self) -> None:
+        """SQLite INTEGER is signed 64-bit; a negative or oversized key corrupts the PK."""
+        for i in range(500):
+            key = derive_thread_key("teams", f"conversation-{i}")
+            assert 0 < key <= 2**63 - 1
+
+    def test_does_not_collide_with_discord_snowflakes(self) -> None:
+        """Discord thread ids are used verbatim as thread keys, so derived keys
+        must live above the snowflake range to stay unambiguous forever.
+
+        Snowflakes are 63-bit values whose high bits encode a millisecond
+        timestamp since 2015. Even in year 2100 they stay below 2**53, so
+        deriving into the top half of the range keeps the two spaces disjoint.
+        """
+        for i in range(500):
+            assert derive_thread_key("teams", f"c{i}") > 2**53
+
+    def test_rejects_empty_inputs(self) -> None:
+        with pytest.raises(ValueError):
+            derive_thread_key("", "abc")
+        with pytest.raises(ValueError):
+            derive_thread_key("teams", "")
+
+
+# ---------------------------------------------------------------------------
+# SurfaceCapabilities
+# ---------------------------------------------------------------------------
+
+
+class TestSurfaceCapabilities:
+    def test_defaults_are_conservative(self) -> None:
+        """A frontend that declares nothing must be assumed to support nothing.
+
+        This is what makes adding a capability field a non-breaking change: a
+        third-party frontend that has not been updated keeps rendering the
+        plain-text fallback instead of silently claiming a feature it lacks.
+        """
+        caps = SurfaceCapabilities(max_message_chars=2000)
+        assert caps.supports_tables is False
+        assert caps.supports_headings is False
+        assert caps.supports_inline_images is False
+        assert caps.supports_reactions is False
+        assert caps.supports_message_edit is False
+        assert caps.supports_message_delete is False
+        assert caps.supports_slash_commands is False
+        assert caps.supports_pinned_dashboard is False
+        assert caps.max_files_per_message == 1
+        assert caps.file_delivery == "inline"
+
+    def test_is_frozen(self) -> None:
+        caps = SurfaceCapabilities(max_message_chars=2000)
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            caps.supports_reactions = True  # type: ignore[misc]
+
+    def test_rejects_nonpositive_message_limit(self) -> None:
+        with pytest.raises(ValueError):
+            SurfaceCapabilities(max_message_chars=0)
+
+    def test_rejects_nonpositive_update_budget(self) -> None:
+        with pytest.raises(ValueError):
+            SurfaceCapabilities(max_message_chars=2000, live_update_budget_per_hour=0)
+
+    def test_update_interval_floor_derives_from_budget(self) -> None:
+        """Teams allows 1,800 updates/hour per conversation → 2 s between edits.
+
+        Callers should ask the capability rather than hardcoding a sleep, so a
+        frontend with a tighter budget slows them down automatically.
+        """
+        teams = SurfaceCapabilities(max_message_chars=80_000, live_update_budget_per_hour=1800)
+        assert teams.min_update_interval == pytest.approx(2.0)
+
+    def test_generous_budget_falls_back_to_declared_interval(self) -> None:
+        discord = SurfaceCapabilities(
+            max_message_chars=2000,
+            live_update_budget_per_hour=1_000_000,
+            stream_min_interval=1.5,
+        )
+        assert discord.min_update_interval == pytest.approx(1.5)
+
+
+# ---------------------------------------------------------------------------
+# Value objects
+# ---------------------------------------------------------------------------
+
+
+class TestOutboundFile:
+    def test_accepts_path_only(self) -> None:
+        f = OutboundFile(display_name="a.md", path="/tmp/a.md")
+        assert f.path == "/tmp/a.md"
+
+    def test_accepts_blob_only(self) -> None:
+        f = OutboundFile(display_name="a.md", blob=b"hello")
+        assert f.blob == b"hello"
+
+    def test_rejects_neither(self) -> None:
+        with pytest.raises(ValueError):
+            OutboundFile(display_name="a.md")
+
+    def test_rejects_both(self) -> None:
+        with pytest.raises(ValueError):
+            OutboundFile(display_name="a.md", path="/tmp/a.md", blob=b"x")
+
+    def test_rejects_empty_display_name(self) -> None:
+        with pytest.raises(ValueError):
+            OutboundFile(display_name="", path="/tmp/a.md")
+
+    def test_display_name_is_reduced_to_basename(self) -> None:
+        """A caller-supplied path must never embed directory components in the
+        name shown to (or uploaded on behalf of) the user."""
+        f = OutboundFile(display_name="../../etc/passwd", path="/tmp/a")
+        assert f.display_name == "passwd"
+
+
+class TestChoicePrompt:
+    def test_rejects_no_way_to_answer(self) -> None:
+        with pytest.raises(ValueError):
+            ChoicePrompt(question="?")
+
+    def test_free_text_only_is_valid(self) -> None:
+        p = ChoicePrompt(question="?", allow_free_text=True)
+        assert p.choices == ()
+
+    def test_rejects_duplicate_choice_values(self) -> None:
+        with pytest.raises(ValueError):
+            ChoicePrompt(
+                question="?",
+                choices=(Choice(value="a", label="A"), Choice(value="a", label="A again")),
+            )
+
+    def test_default_on_timeout_must_be_a_real_choice(self) -> None:
+        with pytest.raises(ValueError):
+            ChoicePrompt(
+                question="?",
+                choices=(Choice(value="allow", label="Allow"),),
+                default_on_timeout="deny",
+            )
+
+    def test_valid_default_on_timeout(self) -> None:
+        p = ChoicePrompt(
+            question="Run this command?",
+            choices=(Choice(value="allow", label="Allow"), Choice(value="deny", label="Deny")),
+            default_on_timeout="deny",
+            timeout_seconds=120,
+        )
+        assert p.default_on_timeout == "deny"
+
+
+class TestFormPrompt:
+    def test_rejects_empty_fields(self) -> None:
+        with pytest.raises(ValueError):
+            FormPrompt(title="t", fields=())
+
+    def test_rejects_duplicate_field_keys(self) -> None:
+        with pytest.raises(ValueError):
+            FormPrompt(
+                title="t",
+                fields=(
+                    FormField(key="name", label="Name", kind="text"),
+                    FormField(key="name", label="Name 2", kind="text"),
+                ),
+            )
+
+    def test_choice_field_requires_choices(self) -> None:
+        with pytest.raises(ValueError):
+            FormField(key="k", label="L", kind="choice")
+
+
+class TestNotice:
+    def test_requires_some_content(self) -> None:
+        with pytest.raises(ValueError):
+            Notice(level=NoticeLevel.INFO)
+
+    def test_fields_only_is_valid(self) -> None:
+        n = Notice(level=NoticeLevel.SUCCESS, fields=(("cost", "$0.01"),))
+        assert n.fields == (("cost", "$0.01"),)
+
+    def test_is_frozen(self) -> None:
+        n = Notice(level=NoticeLevel.INFO, body="hi")
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            n.body = "bye"  # type: ignore[misc]
+
+
+class TestActivitySpec:
+    def test_requires_title(self) -> None:
+        with pytest.raises(ValueError):
+            ActivitySpec(kind="tool", title="")
+
+
+class TestInboundMessage:
+    def test_text_defaults_to_raw_text(self) -> None:
+        msg = InboundMessage(
+            surface=None,  # type: ignore[arg-type]
+            author_external_id="29:abc",
+            author_display="Ebi",
+            raw_text="hello",
+        )
+        assert msg.text == "hello"
+
+    def test_mention_stripped_text_is_kept_separate(self) -> None:
+        msg = InboundMessage(
+            surface=None,  # type: ignore[arg-type]
+            author_external_id="29:abc",
+            author_display="Ebi",
+            raw_text="<at>ccdb</at> summarize this",
+            text="summarize this",
+            is_mention=True,
+        )
+        assert msg.raw_text != msg.text
+        assert msg.is_mention is True
+
+
+class TestStatusKind:
+    def test_every_tool_category_maps_to_a_status(self) -> None:
+        """A new ToolCategory must not silently fall through to no status."""
+        from claude_code_core.types import ToolCategory
+
+        for category in ToolCategory:
+            assert StatusKind.for_tool(category) is not None
+
+
+class TestMention:
+    def test_requires_external_user_id(self) -> None:
+        with pytest.raises(ValueError):
+            Mention(external_user_id="")


### PR DESCRIPTION
> Stacked on #559 (Python 3.12). Merge that first; this PR's base will retarget to `main` automatically.

Step 1 of Teams support. **Vocabulary only** — no implementation, no caller changes, no behaviour change. `claude_discord` is untouched.

## Why a semantic protocol, not a structural one

The obvious abstraction is to lift discord.py's own signature:

```python
async def send(self, content=None, embed=None, view=None) -> Message
```

That is a trap. It makes every non-Discord frontend a *translator of embeds and views*, and a translator can only lose. A Teams implementation written against it would render a column of card-shaped embeds because that is what Discord happens to do — and every gap would read to the user as "Teams is the worse one".

So the protocol names **intents**:

| Intent | Discord does | Teams can do |
|---|---|---|
| `open_activity` | one embed per tool call, edited on completion | fold into the single session card it already keeps updating |
| `set_status` | emoji reaction on the user's message | the status row of that same card |
| `prompt_choice` | Buttons / Select menu | Adaptive Card `Action.Execute` |
| `offer_interrupt` | a re-posted Stop button | a Stop action pinned in the card |

Each frontend picks the best expression it actually has. Teams folding tool activity into one card is not a downgrade — it is less scrolling, and it costs far fewer API calls.

## Capabilities instead of platform checks

Callers must never write `if frontend == "teams"`. They ask `SurfaceCapabilities`, whose defaults are deliberately **conservative**: an undeclared capability means "not supported". That makes adding a field backwards compatible — an out-of-date third-party frontend keeps the plain-text fallback instead of silently claiming something it cannot do.

The same object carries limits that are otherwise easy to blow past. Teams allows **1,800 updates per hour per conversation**; a naive port of ccdb's once-a-second `LiveToolTimer` would exhaust that partway through a long session and take the conversation down with it. `min_update_interval` returns whichever is stricter — the frontend's preferred pace, or the pace implied by its hourly budget — so that becomes a number you read before you loop rather than an outage you diagnose afterwards.

## `ThreadKey` stays an `int`

`sessions.thread_id` is an `INTEGER PRIMARY KEY`, 73 signatures spell it `int`, and the session ledger, AI Lounge, claims, rewind and collision detection all key off it. Teams conversation ids are strings like `19:...@thread.tacv2;messageid=1481567603816`.

Widening the column would touch all of that to gain nothing but tidiness. `derive_thread_key()` mints a deterministic surrogate instead, scoped per frontend so two platforms cannot collide on the same id. Derived keys are placed above `2**53` so they can never be mistaken for a Discord snowflake, which is used verbatim as its own key — snowflakes encode milliseconds since 2015 in their high bits and stay below that floor well past 2100, so the two spaces are disjoint **by construction**, not by convention.

Keeping one key type is what lets a Teams session and a Discord session land in the *same* ledger — which is the whole reason ccdb can notice that two live sessions are editing the same file.

## Fail fast at the boundary

Value objects validate at construction:

- a `ChoicePrompt` with neither choices nor free text is unanswerable
- `default_on_timeout` must name a real choice (so a permission prompt cannot silently fail *open*)
- an `OutboundFile` needs exactly one of `path` or `blob`
- `display_name` is reduced to its basename, so a path a model wrote into `.ccdb-attachments-*` can never smuggle directory components into an upload request

## Verification

- 34 new tests; **1877 pass** in total (`test_run_helper.py` excluded locally — it shells out to the developer's real `statusLine` command; it passes with an isolated `HOME`)
- `ruff check` + `ruff format --check` clean, `pyright` 0 errors
- `test_architecture.py` still green: `claude_code_core` remains free of any Discord import

## Next

PR2 moves `chunker.py` / `table_renderer.py` into core behind `capabilities`; PR3 adds `DiscordSurface` plus a **conformance test suite** that both frontends must pass — which is the mechanism that stops "Teams is missing a feature" from ever being possible.