### PR TITLE
feat(core): ship the surface conformance contract and a reference implementation

### DIFF
--- a/claude_code_core/__init__.py
+++ b/claude_code_core/__init__.py
@@ -11,6 +11,8 @@ that needs to invoke the Claude Code CLI and process its stream-json output:
   implements so the session machinery never names a platform
 - **rendering**: capability-driven table rendering and message chunking, shared
   by every frontend
+- **conformance**: the contract a frontend must satisfy, importable so anyone
+  building one can check their own implementation
 
 Usage::
 
@@ -37,6 +39,7 @@ from .codex_runner import CodexRunner, parse_codex_line
 
 # Database
 # Frontend protocol
+from .conformance import ConformanceReport, check_surface
 from .frontend import (
     ActivityHandle,
     ActivitySpec,
@@ -60,6 +63,7 @@ from .frontend import (
     derive_thread_key,
 )
 from .lounge_repo import LoungeMessage, LoungeRepository
+from .memory_surface import MemorySurface
 from .models import init_db
 
 # Parser
@@ -132,6 +136,9 @@ __all__ = [
     "init_db",
     # Frontend protocol
     "ActivityHandle",
+    "ConformanceReport",
+    "MemorySurface",
+    "check_surface",
     "ActivitySpec",
     "Choice",
     "ChoicePrompt",

--- a/claude_code_core/conformance.py
+++ b/claude_code_core/conformance.py
@@ -1,0 +1,325 @@
+"""The contract every :class:`~claude_code_core.frontend.ConversationSurface` owes.
+
+Why this ships in the package rather than living in ``tests/``
+--------------------------------------------------------------
+A protocol only prevents divergence if there is something that *checks*. Type
+hints say a surface has ``prompt_choice``; nothing in the type system says the
+value it returns has to be one of the choices that were offered, or that
+``deliver_files`` on a surface allowing one file per message must still deliver
+all five. Those are the rules a second frontend silently breaks, and "Teams is
+missing something" is exactly how it would surface — months later, to a user.
+
+So the checks are importable. Anyone writing a frontend — the Teams one here,
+a Slack one later, or one built by somebody deploying this — runs
+:func:`check_surface` against their implementation and gets the same verdict
+this repository's own Discord implementation gets.
+
+Deliberately framework-free: plain async functions returning a report, not
+pytest fixtures. A consumer should not have to adopt our test runner to find
+out whether their surface is correct.
+
+What is checked, and what is not
+--------------------------------
+These are *semantic* obligations that hold regardless of platform:
+
+* the surface reports capabilities consistent with its own behaviour
+* text comes back out the way it went in, split only when it must be
+* a choice prompt returns something that was actually offered
+* files are all delivered even when the surface batches them
+* handles are idempotent — completing twice is not an error
+
+Appearance is not checked. Discord posting an embed per tool call and Teams
+folding the same information into one updating card are both correct; that
+freedom is the entire point of naming intents rather than widgets.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+
+from .frontend import (
+    ActivitySpec,
+    Choice,
+    ChoicePrompt,
+    ConversationSurface,
+    FormField,
+    FormPrompt,
+    Notice,
+    NoticeLevel,
+    OutboundFile,
+    StatusKind,
+)
+
+__all__ = ["ConformanceReport", "check_surface"]
+
+
+@dataclass
+class ConformanceReport:
+    """Outcome of :func:`check_surface`."""
+
+    passed: list[str] = field(default_factory=list)
+    failures: list[str] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return not self.failures
+
+    def summary(self) -> str:
+        if self.ok:
+            return f"all {len(self.passed)} conformance checks passed"
+        lines = [f"{len(self.failures)} of {len(self.passed) + len(self.failures)} checks failed:"]
+        lines.extend(f"  - {f}" for f in self.failures)
+        return "\n".join(lines)
+
+
+SurfaceFactory = Callable[[], Awaitable[ConversationSurface]]
+
+
+async def check_surface(make_surface: SurfaceFactory) -> ConformanceReport:
+    """Run every contract check against surfaces produced by *make_surface*.
+
+    A fresh surface is requested per check so one check's leftovers cannot
+    make the next one pass or fail spuriously.
+
+    Args:
+        make_surface: Async callable returning a ready-to-use surface. It is
+            called once per check.
+
+    Returns:
+        A report. ``report.ok`` is the verdict; ``report.summary()`` explains.
+    """
+    report = ConformanceReport()
+    for name, check in _CHECKS:
+        try:
+            surface = await make_surface()
+            await check(surface)
+        except AssertionError as exc:
+            report.failures.append(f"{name}: {exc}")
+        except Exception as exc:  # noqa: BLE001 — an unexpected raise is also a failure
+            report.failures.append(f"{name}: raised {type(exc).__name__}: {exc}")
+        else:
+            report.passed.append(name)
+    return report
+
+
+# ---------------------------------------------------------------------------
+# Identity
+# ---------------------------------------------------------------------------
+
+
+async def _check_identity(s: ConversationSurface) -> None:
+    assert isinstance(s.thread_key, int), "thread_key must be an int — it is the ledger's key"
+    assert s.thread_key > 0, "thread_key must be positive"
+    assert s.external_id, "external_id must not be empty"
+    assert s.frontend, "frontend must name the platform"
+
+
+async def _check_capabilities_are_sane(s: ConversationSurface) -> None:
+    caps = s.capabilities
+    assert caps.max_message_chars > 0, "max_message_chars must be positive"
+    assert caps.min_update_interval > 0, "min_update_interval must be positive"
+    assert caps.max_files_per_message >= 1, "a surface must accept at least one file per message"
+
+
+# ---------------------------------------------------------------------------
+# Text
+# ---------------------------------------------------------------------------
+
+
+async def _check_send_text_roundtrip(s: ConversationSurface) -> None:
+    await s.send_text("hello")
+    sent = _sent_text(s)
+    assert sent, "send_text produced nothing"
+    assert "hello" in "".join(sent), "the text sent did not reach the surface"
+
+
+async def _check_long_text_is_split_to_fit(s: ConversationSurface) -> None:
+    limit = s.capabilities.max_message_chars
+    await s.send_text("x" * (limit * 3))
+    for part in _sent_text(s):
+        assert len(part) <= limit, (
+            f"a message of {len(part)} chars exceeds the declared limit of {limit}"
+        )
+
+
+async def _check_empty_text_sends_nothing(s: ConversationSurface) -> None:
+    await s.send_text("")
+    assert not _sent_text(s), "an empty message must not be posted"
+
+
+async def _check_stream_accumulates(s: ConversationSurface) -> None:
+    stream = s.open_stream()
+    assert not stream.has_content, "a fresh stream must report no content"
+    await stream.append("Hello, ")
+    assert stream.has_content, "has_content must be True once text has been appended"
+    await stream.append("world")
+    final = await stream.finalize()
+    assert "Hello, world" in final, f"stream lost text: {final!r}"
+
+
+async def _check_stream_finalize_is_idempotent(s: ConversationSurface) -> None:
+    stream = s.open_stream()
+    await stream.append("done")
+    first = await stream.finalize()
+    second = await stream.finalize()
+    assert first == second, "finalizing twice must not change or duplicate the result"
+
+
+# ---------------------------------------------------------------------------
+# Notices and activities
+# ---------------------------------------------------------------------------
+
+
+async def _check_notice_is_accepted(s: ConversationSurface) -> None:
+    for level in NoticeLevel:
+        await s.send_notice(Notice(level=level, title="t", body="b"))
+
+
+async def _check_activity_lifecycle(s: ConversationSurface) -> None:
+    handle = await s.open_activity(ActivitySpec(kind="tool", title="Read", detail="a.py"))
+    await handle.update("still reading")
+    await handle.complete("42 lines")
+    # Completing twice must be harmless: a session that errors after finishing
+    # a tool would otherwise take the surface down with it.
+    await handle.complete("42 lines")
+
+
+async def _check_activity_cancel(s: ConversationSurface) -> None:
+    handle = await s.open_activity(ActivitySpec(kind="tool", title="Bash"))
+    await handle.cancel()
+    await handle.cancel()
+
+
+async def _check_status_transitions(s: ConversationSurface) -> None:
+    for status in StatusKind:
+        await s.set_status(status)
+    await s.clear_status()
+    await s.clear_status()
+
+
+# ---------------------------------------------------------------------------
+# Interaction
+# ---------------------------------------------------------------------------
+
+
+async def _check_choice_returns_an_offered_value(s: ConversationSurface) -> None:
+    offered = (Choice(value="allow", label="Allow"), Choice(value="deny", label="Deny"))
+    answer = await s.prompt_choice(ChoicePrompt(question="Run it?", choices=offered))
+    if answer is None:
+        return  # "unanswered" is a legitimate outcome
+    values = {c.value for c in offered}
+    assert set(answer) <= values, (
+        f"prompt_choice returned {answer!r}, which is not among the offered {sorted(values)}"
+    )
+
+
+async def _check_single_select_returns_at_most_one(s: ConversationSurface) -> None:
+    answer = await s.prompt_choice(
+        ChoicePrompt(
+            question="Pick one",
+            choices=(Choice(value="a", label="A"), Choice(value="b", label="B")),
+            multi_select=False,
+        )
+    )
+    if answer is not None:
+        assert len(answer) <= 1, "multi_select=False must not return more than one value"
+
+
+async def _check_form_answers_only_known_keys(s: ConversationSurface) -> None:
+    fields = (
+        FormField(key="name", label="Name", kind="text"),
+        FormField(key="note", label="Note", kind="multiline"),
+    )
+    answer = await s.prompt_form(FormPrompt(title="Details", fields=fields))
+    if answer is None:
+        return
+    known = {f.key for f in fields}
+    unknown = set(answer) - known
+    assert not unknown, f"prompt_form returned keys that were never asked for: {sorted(unknown)}"
+
+
+async def _check_interrupt_handle(s: ConversationSurface) -> None:
+    stopped: list[bool] = []
+
+    async def on_stop() -> None:
+        stopped.append(True)
+
+    handle = await s.offer_interrupt(on_stop)
+    await handle.bump()
+    await handle.disable()
+    # Disabling twice must be harmless — the session-end path and the user
+    # clicking Stop can both reach it.
+    await handle.disable()
+
+
+# ---------------------------------------------------------------------------
+# Files
+# ---------------------------------------------------------------------------
+
+
+async def _check_all_files_are_delivered(s: ConversationSurface) -> None:
+    files = [OutboundFile(display_name=f"f{i}.txt", blob=b"data") for i in range(5)]
+    await s.deliver_files(files)
+    delivered = _delivered_files(s)
+    assert len(delivered) == len(files), (
+        f"{len(files)} files were handed over but {len(delivered)} arrived — "
+        "a surface that batches must still send every batch"
+    )
+
+
+async def _check_empty_file_list_is_a_noop(s: ConversationSurface) -> None:
+    await s.deliver_files([])
+    assert not _delivered_files(s), "delivering an empty list must send nothing"
+
+
+# ---------------------------------------------------------------------------
+# Management
+# ---------------------------------------------------------------------------
+
+
+async def _check_rename_never_raises(s: ConversationSurface) -> None:
+    """Rename is a no-op where threads have no name — Teams reply chains do
+    not. It must degrade quietly rather than break a session."""
+    await s.rename("a new title")
+
+
+# ---------------------------------------------------------------------------
+# Introspection helpers
+# ---------------------------------------------------------------------------
+#
+# The contract needs to see what a surface actually emitted. Rather than add
+# recording to the protocol — which would make every production implementation
+# carry test scaffolding — a surface under test exposes two optional hooks.
+# A surface that offers neither is still checked for "did not raise"; it simply
+# skips the assertions that need evidence.
+
+
+def _sent_text(surface: ConversationSurface) -> list[str]:
+    return list(getattr(surface, "conformance_sent_text", None) or [])
+
+
+def _delivered_files(surface: ConversationSurface) -> list[str]:
+    return list(getattr(surface, "conformance_delivered_files", None) or [])
+
+
+_CHECKS: list[tuple[str, Callable[[ConversationSurface], Awaitable[None]]]] = [
+    ("identity", _check_identity),
+    ("capabilities are sane", _check_capabilities_are_sane),
+    ("send_text round-trips", _check_send_text_roundtrip),
+    ("long text is split to fit", _check_long_text_is_split_to_fit),
+    ("empty text sends nothing", _check_empty_text_sends_nothing),
+    ("stream accumulates", _check_stream_accumulates),
+    ("stream finalize is idempotent", _check_stream_finalize_is_idempotent),
+    ("every notice level is accepted", _check_notice_is_accepted),
+    ("activity lifecycle", _check_activity_lifecycle),
+    ("activity cancel is idempotent", _check_activity_cancel),
+    ("status transitions", _check_status_transitions),
+    ("choice returns an offered value", _check_choice_returns_an_offered_value),
+    ("single select returns at most one", _check_single_select_returns_at_most_one),
+    ("form answers only known keys", _check_form_answers_only_known_keys),
+    ("interrupt handle is idempotent", _check_interrupt_handle),
+    ("all files are delivered", _check_all_files_are_delivered),
+    ("empty file list is a no-op", _check_empty_file_list_is_a_noop),
+    ("rename never raises", _check_rename_never_raises),
+]

--- a/claude_code_core/memory_surface.py
+++ b/claude_code_core/memory_surface.py
@@ -1,0 +1,246 @@
+"""An in-memory :class:`~claude_code_core.frontend.ConversationSurface`.
+
+Two jobs, both about keeping the protocol honest.
+
+**It proves the contract is satisfiable.** A protocol nobody has implemented is
+a wish. This is the smallest thing that passes every check in
+:mod:`claude_code_core.conformance`, so a failing check means the surface under
+test is wrong — not that the contract is impossible.
+
+**It is the worked example.** Someone writing a Slack surface, or a frontend
+for their own deployment, can read one short file that does the whole protocol
+rather than reverse-engineer it from the Discord implementation, where the
+interesting parts are tangled with discord.py.
+
+It is also genuinely useful in tests: drive a whole session against it and
+assert on what the model *said*, with no network and no mocks.
+
+This is a reference implementation, not a toy — where the protocol has a real
+obligation (splitting to the message limit, batching files, idempotent
+handles), this honours it, because otherwise it would not be proving anything.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Sequence
+from dataclasses import dataclass, field
+
+from .frontend import (
+    ActivitySpec,
+    ChoicePrompt,
+    FormPrompt,
+    Mention,
+    Notice,
+    OutboundFile,
+    StatusKind,
+    SurfaceCapabilities,
+    ThreadKey,
+    derive_thread_key,
+)
+from .rendering import render_for
+
+__all__ = ["MemoryActivity", "MemorySurface", "MemoryTextStream"]
+
+
+@dataclass
+class MemoryActivity:
+    """A started activity, recorded rather than rendered."""
+
+    spec: ActivitySpec
+    updates: list[str] = field(default_factory=list)
+    result: str | None = None
+    ok: bool = True
+    finished: bool = False
+
+    async def update(self, detail: str) -> None:
+        if self.finished:
+            return
+        self.updates.append(detail)
+
+    async def complete(self, result: str | None, *, ok: bool = True) -> None:
+        if self.finished:
+            return  # completing twice is harmless by contract
+        self.result = result
+        self.ok = ok
+        self.finished = True
+
+    async def cancel(self) -> None:
+        if self.finished:
+            return
+        self.finished = True
+        self.ok = False
+
+
+class MemoryTextStream:
+    """Accumulates deltas; on finalize, hands the text to the surface."""
+
+    def __init__(self, surface: MemorySurface) -> None:
+        self._surface = surface
+        self._buffer = ""
+        self._finalized = False
+        self._result = ""
+
+    @property
+    def has_content(self) -> bool:
+        return bool(self._buffer)
+
+    async def append(self, delta: str) -> None:
+        if self._finalized:
+            return
+        self._buffer += delta
+
+    async def finalize(self, transform: Callable[[str], str] | None = None) -> str:
+        if self._finalized:
+            return self._result
+        self._finalized = True
+        text = transform(self._buffer) if transform and self._buffer else self._buffer
+        if text:
+            await self._surface.send_text(text)
+        self._result = text
+        return text
+
+
+class _MemoryInterrupt:
+    def __init__(self, on_stop: Callable[[], Awaitable[None]]) -> None:
+        self._on_stop = on_stop
+        self.bumps = 0
+        self.disabled = False
+
+    async def bump(self) -> None:
+        if not self.disabled:
+            self.bumps += 1
+
+    async def disable(self) -> None:
+        self.disabled = True
+
+    async def fire(self) -> None:
+        """Simulate the user pressing Stop."""
+        if not self.disabled:
+            await self._on_stop()
+
+
+class MemorySurface:
+    """A surface that records instead of sending.
+
+    Args:
+        capabilities: The surface being simulated. Pass Teams' or Slack's
+            numbers to see how the same session would render there.
+        answers: Values ``prompt_choice`` returns, in order. Exhausted or
+            empty means "unanswered", which the protocol allows.
+        form_answers: Values ``prompt_form`` returns, in order.
+    """
+
+    def __init__(
+        self,
+        capabilities: SurfaceCapabilities | None = None,
+        *,
+        external_id: str = "memory:1",
+        answers: Sequence[Sequence[str]] = (),
+        form_answers: Sequence[dict[str, str]] = (),
+        working_dir: str | None = None,
+    ) -> None:
+        self._caps = capabilities or SurfaceCapabilities(max_message_chars=2000)
+        self._external_id = external_id
+        self._thread_key = derive_thread_key("memory", external_id)
+        self.working_dir = working_dir
+
+        self._answers = list(answers)
+        self._form_answers = list(form_answers)
+
+        # Recorded output. The ``conformance_*`` names are the hooks the
+        # contract checker looks for; the others are for readable assertions.
+        self.conformance_sent_text: list[str] = []
+        self.conformance_delivered_files: list[str] = []
+        self.notices: list[Notice] = []
+        self.activities: list[MemoryActivity] = []
+        self.statuses: list[StatusKind] = []
+        self.prompts: list[ChoicePrompt] = []
+        self.forms: list[FormPrompt] = []
+        self.urls: list[tuple[str, str]] = []
+        self.titles: list[str] = []
+        self.interrupts: list[_MemoryInterrupt] = []
+
+    # -- identity ----------------------------------------------------------
+    @property
+    def thread_key(self) -> ThreadKey:
+        return self._thread_key
+
+    @property
+    def external_id(self) -> str:
+        return self._external_id
+
+    @property
+    def frontend(self) -> str:
+        return "memory"
+
+    @property
+    def capabilities(self) -> SurfaceCapabilities:
+        return self._caps
+
+    # -- output ------------------------------------------------------------
+    async def send_text(self, text: str) -> str | None:
+        parts = render_for(text, self._caps)
+        if not parts:
+            return None
+        self.conformance_sent_text.extend(parts)
+        return f"msg-{len(self.conformance_sent_text)}"
+
+    async def send_notice(self, notice: Notice) -> str | None:
+        self.notices.append(notice)
+        return f"notice-{len(self.notices)}"
+
+    async def deliver_files(self, files: Sequence[OutboundFile]) -> None:
+        # Batching is where a real surface loses files: Discord caps a message
+        # at 10 attachments, Teams at one consent card. Honour the cap here so
+        # the contract check has something real to verify.
+        batch = max(self._caps.max_files_per_message, 1)
+        for start in range(0, len(files), batch):
+            for f in files[start : start + batch]:
+                self.conformance_delivered_files.append(f.display_name)
+
+    def open_stream(self) -> MemoryTextStream:
+        return MemoryTextStream(self)
+
+    async def open_activity(self, spec: ActivitySpec) -> MemoryActivity:
+        activity = MemoryActivity(spec=spec)
+        self.activities.append(activity)
+        return activity
+
+    # -- state -------------------------------------------------------------
+    async def set_status(self, status: StatusKind) -> None:
+        self.statuses.append(status)
+
+    async def clear_status(self) -> None:
+        pass
+
+    # -- interaction -------------------------------------------------------
+    async def prompt_choice(self, prompt: ChoicePrompt) -> tuple[str, ...] | None:
+        self.prompts.append(prompt)
+        if not self._answers:
+            return None
+        chosen = tuple(self._answers.pop(0))
+        if not prompt.multi_select:
+            chosen = chosen[:1]
+        return chosen
+
+    async def prompt_form(self, prompt: FormPrompt) -> dict[str, str] | None:
+        self.forms.append(prompt)
+        if not self._form_answers:
+            return None
+        return dict(self._form_answers.pop(0))
+
+    async def prompt_url(self, title: str, url: str, *, notify: Mention | None = None) -> bool:
+        self.urls.append((title, url))
+        return True
+
+    async def offer_interrupt(self, on_stop: Callable[[], Awaitable[None]]) -> _MemoryInterrupt:
+        handle = _MemoryInterrupt(on_stop)
+        self.interrupts.append(handle)
+        return handle
+
+    # -- management --------------------------------------------------------
+    async def rename(self, title: str) -> None:
+        self.titles.append(title)
+
+    async def recent_transcript(self, days: int) -> str | None:
+        return None

--- a/tests/test_surface_conformance.py
+++ b/tests/test_surface_conformance.py
@@ -1,0 +1,238 @@
+"""The conformance contract, and proof that the vocabulary survives a third platform.
+
+Two things are pinned here.
+
+**The contract is satisfiable and it bites.** ``MemorySurface`` passes every
+check; deliberately broken surfaces fail the specific check that should catch
+them. A contract that only ever passes is decoration.
+
+**Discord, Teams and Slack all fit in one capability vocabulary.** The
+direction is Discord → Teams → Slack, and the cheapest possible moment to
+discover that the vocabulary cannot express Slack is now, before a second
+implementation is written against it. So Slack's real numbers are checked
+against the model here even though no Slack frontend exists yet.
+
+Capability figures below are from vendor documentation, cited inline. They are
+test data, not configuration — the real presets live with each frontend.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import pytest
+
+from claude_code_core.conformance import check_surface
+from claude_code_core.frontend import (
+    ActivitySpec,
+    Choice,
+    ChoicePrompt,
+    OutboundFile,
+    SurfaceCapabilities,
+)
+from claude_code_core.memory_surface import MemorySurface
+
+# --- Capability presets under test -----------------------------------------
+# Discord: 2,000 chars/message; bot reactions; no hourly edit budget.
+DISCORD = SurfaceCapabilities(
+    max_message_chars=2000,
+    supports_reactions=True,
+    supports_message_edit=True,
+    supports_message_delete=True,
+    supports_slash_commands=True,
+    supports_pinned_dashboard=True,
+    supports_thread_rename=True,
+    live_update_budget_per_hour=1_000_000,
+    stream_min_interval=1.5,
+    max_files_per_message=10,
+    monospace_width=55,
+)
+# Teams: ~100 KB/message (80 KB recommended); no bot reaction API; 1,800
+# operations per hour per conversation.
+# https://learn.microsoft.com/microsoftteams/platform/bots/how-to/rate-limit
+TEAMS = SurfaceCapabilities(
+    max_message_chars=80_000,
+    supports_reactions=False,
+    supports_message_edit=True,
+    supports_message_delete=True,
+    supports_slash_commands=False,
+    supports_pinned_dashboard=False,
+    supports_thread_rename=False,
+    live_update_budget_per_hour=1800,
+    stream_min_interval=1.0,
+    max_files_per_message=1,
+    file_delivery="link",
+    monospace_width=100,
+)
+# Slack: 4,000 chars recommended per message; bots may add reactions;
+# chat.postMessage is limited to ~1 message per second per channel with no
+# hourly cap. https://docs.slack.dev/apis/web-api/rate-limits
+SLACK = SurfaceCapabilities(
+    max_message_chars=4000,
+    supports_reactions=True,
+    supports_message_edit=True,
+    supports_message_delete=True,
+    supports_slash_commands=True,
+    supports_thread_rename=False,
+    live_update_budget_per_hour=1_000_000,
+    stream_min_interval=1.0,
+    max_files_per_message=10,
+    monospace_width=80,
+)
+
+
+class TestMemorySurfaceIsConformant:
+    async def test_reference_implementation_passes_every_check(self) -> None:
+        report = await check_surface(lambda: _make(DISCORD))
+        assert report.ok, report.summary()
+
+    @pytest.mark.parametrize("caps", [DISCORD, TEAMS, SLACK], ids=["discord", "teams", "slack"])
+    async def test_conformance_holds_under_every_capability_set(
+        self, caps: SurfaceCapabilities
+    ) -> None:
+        """The same implementation must stay correct when the numbers change.
+
+        This is the check that would have caught a surface that only splits
+        correctly at Discord's limit, or only delivers files correctly when
+        ten fit in a message.
+        """
+        report = await check_surface(lambda: _make(caps))
+        assert report.ok, report.summary()
+
+
+class TestTheContractActuallyBites:
+    """A contract that cannot fail is not a contract."""
+
+    async def test_catches_a_surface_that_ignores_its_own_message_limit(self) -> None:
+        class Oversharing(MemorySurface):
+            async def send_text(self, text: str) -> str | None:
+                self.conformance_sent_text.append(text)  # never splits
+                return "msg-1"
+
+        report = await check_surface(lambda: _make(DISCORD, cls=Oversharing))
+        assert not report.ok
+        assert any("long text is split to fit" in f for f in report.failures)
+
+    async def test_catches_a_surface_that_drops_files_when_batching(self) -> None:
+        class Forgetful(MemorySurface):
+            async def deliver_files(self, files: Sequence[OutboundFile]) -> None:
+                # A plausible bug: send only the first batch.
+                cap = self.capabilities.max_files_per_message
+                for f in list(files)[:cap]:
+                    self.conformance_delivered_files.append(f.display_name)
+
+        report = await check_surface(lambda: _make(TEAMS, cls=Forgetful))
+        assert not report.ok
+        assert any("all files are delivered" in f for f in report.failures)
+
+    async def test_catches_a_surface_that_invents_an_answer(self) -> None:
+        class Inventive(MemorySurface):
+            async def prompt_choice(self, prompt: ChoicePrompt) -> tuple[str, ...] | None:
+                return ("something-nobody-offered",)
+
+        report = await check_surface(lambda: _make(DISCORD, cls=Inventive))
+        assert not report.ok
+        assert any("choice returns an offered value" in f for f in report.failures)
+
+    async def test_catches_a_handle_that_is_not_idempotent(self) -> None:
+        class Brittle(MemorySurface):
+            async def open_activity(self, spec: ActivitySpec):  # type: ignore[override]
+                handle = await super().open_activity(spec)
+
+                async def complete(result, *, ok=True):
+                    if handle.finished:
+                        raise RuntimeError("already completed")
+                    handle.finished = True
+
+                handle.complete = complete  # type: ignore[method-assign]
+                return handle
+
+        report = await check_surface(lambda: _make(DISCORD, cls=Brittle))
+        assert not report.ok
+        assert any("activity lifecycle" in f for f in report.failures)
+
+    async def test_report_summary_names_the_broken_check(self) -> None:
+        class Nameless(MemorySurface):
+            @property
+            def external_id(self) -> str:
+                return ""
+
+        report = await check_surface(lambda: _make(DISCORD, cls=Nameless))
+        assert "identity" in report.summary()
+
+
+class TestVocabularySurvivesSlack:
+    """Slack is the planned third frontend. Fixing the vocabulary after two
+    implementations exist is far more expensive than checking it now."""
+
+    def test_update_pacing_expresses_all_three_shapes(self) -> None:
+        """Teams caps total operations per hour; Slack and Discord cap the
+        rate. One expression covers both because the two limits are held
+        separately and the stricter one wins.
+        """
+        # Teams: 1,800/hour dominates → 2s between updates.
+        assert TEAMS.min_update_interval == pytest.approx(2.0)
+        # Slack: no hourly cap, 1/sec per channel dominates.
+        assert SLACK.min_update_interval == pytest.approx(1.0)
+        # Discord: its own preferred streaming pace dominates.
+        assert DISCORD.min_update_interval == pytest.approx(1.5)
+
+    def test_each_platform_differs_from_the_others_somewhere(self) -> None:
+        """If the three presets were identical the tests above would prove
+        nothing, so assert they actually diverge."""
+        assert TEAMS.supports_reactions != SLACK.supports_reactions
+        assert DISCORD.max_message_chars != SLACK.max_message_chars != TEAMS.max_message_chars
+        assert TEAMS.max_files_per_message != SLACK.max_files_per_message
+
+    async def test_the_same_answer_renders_appropriately_on_each(self) -> None:
+        long_answer = "\n\n".join(f"Point {i}. " + "detail " * 50 for i in range(30))
+        counts = {}
+        for name, caps in (("discord", DISCORD), ("teams", TEAMS), ("slack", SLACK)):
+            surface = _make_sync(caps)
+            await surface.send_text(long_answer)
+            counts[name] = len(surface.conformance_sent_text)
+
+        # Teams takes it whole; the narrower surfaces split, Discord most.
+        assert counts["teams"] == 1
+        assert counts["slack"] > 1
+        assert counts["discord"] > counts["slack"]
+
+
+class TestMemorySurfaceIsUsefulForAssertions:
+    async def test_records_what_the_model_said(self) -> None:
+        surface = _make_sync(DISCORD)
+        await surface.send_text("the answer is 42")
+        assert surface.conformance_sent_text == ["the answer is 42"]
+
+    async def test_answers_are_served_in_order(self) -> None:
+        surface = MemorySurface(DISCORD, answers=[["allow"], ["deny"]])
+        prompt = ChoicePrompt(
+            question="?",
+            choices=(Choice(value="allow", label="A"), Choice(value="deny", label="D")),
+        )
+        assert await surface.prompt_choice(prompt) == ("allow",)
+        assert await surface.prompt_choice(prompt) == ("deny",)
+        assert await surface.prompt_choice(prompt) is None  # exhausted → unanswered
+
+    async def test_stream_lands_in_the_transcript(self) -> None:
+        surface = _make_sync(DISCORD)
+        stream = surface.open_stream()
+        await stream.append("par")
+        await stream.append("tial")
+        await stream.finalize()
+        assert surface.conformance_sent_text == ["partial"]
+
+
+# --- helpers ---------------------------------------------------------------
+
+
+def _make_sync(
+    caps: SurfaceCapabilities, cls: type[MemorySurface] = MemorySurface
+) -> MemorySurface:
+    return cls(caps, answers=[["allow"]], form_answers=[{"name": "Ebi", "note": "hi"}])
+
+
+async def _make(
+    caps: SurfaceCapabilities, cls: type[MemorySurface] = MemorySurface
+) -> MemorySurface:
+    return _make_sync(caps, cls)

--- a/uv.lock
+++ b/uv.lock
@@ -204,7 +204,7 @@ wheels = [
 
 [[package]]
 name = "claude-code-discord-bridge"
-version = "3.3.8"
+version = "3.3.9"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Step 3a of Teams support. Follows #562 (protocol) and #563 (rendering). **Still no Discord changes.**

## Why the contract ships in the package, not in `tests/`

A protocol only prevents divergence if something *checks*. Type hints say a surface has `prompt_choice`; nothing in the type system says the value it returns must be one of the choices that were **offered**, or that `deliver_files` on a surface allowing one file per message must still send all five.

Those are exactly the rules a second implementation breaks quietly — and "Teams is missing something" is how it would eventually surface: months later, to a user.

So `check_surface()` is importable. Whoever writes a frontend — the Teams one here, the Slack one after it, or one written by somebody **deploying** this — runs the same checks the Discord implementation will have to pass.

```python
from claude_code_core import check_surface

report = await check_surface(make_my_surface)
assert report.ok, report.summary()
```

Deliberately framework-free (plain async functions returning a report, not pytest fixtures) — a consumer should not have to adopt our test runner to find out whether their surface is correct.

## What is checked — and what is not

Semantic obligations that hold on any platform: identity, text round-tripping, splitting to the *declared* limit, streams accumulating, every notice level accepted, handles being idempotent, choices coming back from the offered set, forms answering only keys that were asked, and **every file arriving even when the surface batches**.

**Appearance is deliberately not checked.** Discord posting an embed per tool call and Teams folding the same information into one updating card are both correct — that freedom is the whole point of naming intents instead of widgets.

## The contract has to bite

Five tests deliberately break a surface and assert the specific check that catches it:

| broken surface | check that fires |
|---|---|
| never splits long text | `long text is split to fit` |
| drops files after the first batch | `all files are delivered` |
| returns an answer nobody offered | `choice returns an offered value` |
| activity handle raises on second `complete()` | `activity lifecycle` |
| empty `external_id` | `identity` |

A contract that only ever passes is decoration.

## `MemorySurface`

The reference implementation, also shipped. Three jobs:

1. **Proves the contract is satisfiable** — a failing check means the surface under test is wrong, not that the contract is impossible
2. **The worked example** — one short file that does the whole protocol, instead of reverse-engineering it from the Discord implementation where the interesting parts are tangled with discord.py
3. **Useful** — drive a whole session against it and assert on what the model *said*, with no network and no mocks

## Checking the vocabulary against Slack now, not later

The frontend order is **Discord → Teams → Slack**. The cheapest moment to discover the vocabulary cannot express Slack is *before* a second implementation is written against it. So Slack's real numbers are tested here even though no Slack frontend exists.

It survives — and the interesting case is update pacing. Teams caps **total operations per conversation per hour** (1,800). Slack caps the **rate** instead (~1 message/second/channel, [no hourly cap](https://docs.slack.dev/apis/web-api/rate-limits)). Completely different shapes, one expression:

```python
min_update_interval = max(stream_min_interval, 3600 / live_update_budget_per_hour)
```

→ Teams 2.0s, Slack 1.0s, Discord 1.5s. Each dominated by a different term.

Conformance runs against all three capability sets, which is what catches an implementation that only happens to be correct at Discord's numbers.

## Verification

- 15 new tests; **1910 pass** in total, plus 62 in `test_run_helper.py` with an isolated `HOME`
- `ruff check` / `ruff format --check` clean, `pyright` 0 errors on both packages
- Capability figures cited inline from vendor docs; they are test data, not configuration — the real presets live with each frontend

## Next

PR3b: `DiscordSurface` — the real implementation, wrapping the existing `StreamingMessageManager` / `StatusManager` / `file_sender` / views, passing this same contract.