### PR TITLE
feat(discord): implement ConversationSurface and pass the shared contract

### DIFF
--- a/claude_code_core/conformance.py
+++ b/claude_code_core/conformance.py
@@ -31,6 +31,17 @@ These are *semantic* obligations that hold regardless of platform:
 Appearance is not checked. Discord posting an embed per tool call and Teams
 folding the same information into one updating card are both correct; that
 freedom is the entire point of naming intents rather than widgets.
+
+One obligation deliberately lives outside this contract
+-------------------------------------------------------
+``ChoicePrompt.default_on_timeout`` exists so an unattended tool-permission
+request denies rather than hangs, and getting that wrong is the most dangerous
+failure in the protocol. It is nevertheless *not* checked here, because it
+cannot be: from outside, "the user chose allow" and "the surface invented
+allow when nobody answered" are the same return value, and the contract has no
+way to force nobody to answer. Each frontend proves it in its own tests, where
+the interaction can actually be withheld — see
+``tests/test_discord_surface.py::TestChoicePrompt``.
 """
 
 from __future__ import annotations
@@ -203,9 +214,17 @@ async def _check_status_transitions(s: ConversationSurface) -> None:
 # ---------------------------------------------------------------------------
 
 
+# Every prompt in these checks carries a timeout. Without one, a surface that
+# waits for a real human — which is correct behaviour — would hang the checker
+# forever, and the contract would be untestable rather than unsatisfied.
+_PROMPT_TIMEOUT = 0.05
+
+
 async def _check_choice_returns_an_offered_value(s: ConversationSurface) -> None:
     offered = (Choice(value="allow", label="Allow"), Choice(value="deny", label="Deny"))
-    answer = await s.prompt_choice(ChoicePrompt(question="Run it?", choices=offered))
+    answer = await s.prompt_choice(
+        ChoicePrompt(question="Run it?", choices=offered, timeout_seconds=_PROMPT_TIMEOUT)
+    )
     if answer is None:
         return  # "unanswered" is a legitimate outcome
     values = {c.value for c in offered}
@@ -220,6 +239,7 @@ async def _check_single_select_returns_at_most_one(s: ConversationSurface) -> No
             question="Pick one",
             choices=(Choice(value="a", label="A"), Choice(value="b", label="B")),
             multi_select=False,
+            timeout_seconds=_PROMPT_TIMEOUT,
         )
     )
     if answer is not None:
@@ -231,7 +251,9 @@ async def _check_form_answers_only_known_keys(s: ConversationSurface) -> None:
         FormField(key="name", label="Name", kind="text"),
         FormField(key="note", label="Note", kind="multiline"),
     )
-    answer = await s.prompt_form(FormPrompt(title="Details", fields=fields))
+    answer = await s.prompt_form(
+        FormPrompt(title="Details", fields=fields, timeout_seconds=_PROMPT_TIMEOUT)
+    )
     if answer is None:
         return
     known = {f.key for f in fields}

--- a/claude_discord/__init__.py
+++ b/claude_discord/__init__.py
@@ -38,8 +38,10 @@ from .discord_ui.status import StatusManager
 from .protocols import DrainAware
 from .session_sync import CliSession, SessionMessage, extract_recent_messages, scan_cli_sessions
 from .setup import BridgeComponents, setup_bridge
+from .surface import DiscordSurface
 
 __all__ = [
+    "DiscordSurface",
     # Core
     "ClaudeRunner",
     "ClaudeChatCog",

--- a/claude_discord/discord_ui/prompt_views.py
+++ b/claude_discord/discord_ui/prompt_views.py
@@ -1,0 +1,216 @@
+"""Generic Discord UI for the frontend protocol's prompts.
+
+``ChoicePrompt`` and ``FormPrompt`` are the protocol's two ways of asking the
+user something. Discord already had a view per *caller* — AskView for
+AskUserQuestion, PermissionView for tool approval, PlanApprovalView for plan
+mode — each with its own answer plumbing. Those stay; this is the rendering
+for a prompt that arrives through the protocol instead, so a new caller does
+not have to invent a fourth view.
+
+Why buttons up to four choices and a select menu beyond
+-------------------------------------------------------
+Discord allows five components per action row. Four leaves room for the free
+text option without spilling into a second row, and matching the existing
+AskView threshold keeps the two visually consistent while both exist.
+
+Timeouts fail closed, and they are ours
+---------------------------------------
+``ChoicePrompt.default_on_timeout`` exists so an unattended permission request
+denies rather than hangs. This module honours it; a prompt without one simply
+returns ``None`` and the caller treats the turn as unanswered.
+
+The waiting is done with our own ``asyncio.wait_for`` rather than
+``discord.ui.View``'s built-in timeout, because the built-in one only starts
+once the view has been registered with the client. If the message is posted
+but the view never gets dispatched, discord.py's timer never fires and the
+caller waits forever — a session hung on a permission request that nobody can
+see. Owning the clock means the timeout holds regardless of what Discord did
+with the view.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+
+import discord
+
+from claude_code_core.frontend import ChoicePrompt, FormField, FormPrompt
+
+logger = logging.getLogger(__name__)
+
+# Discord allows five components per action row; four buttons leaves a slot
+# for the free-text option.
+MAX_BUTTONS = 4
+
+
+class ChoiceView(discord.ui.View):
+    """Buttons or a select menu for a :class:`ChoicePrompt`.
+
+    Resolve with :meth:`wait_for_answer`, which returns the chosen *values*
+    (not labels — the caller matches on values), or ``None`` when the prompt
+    times out with no default.
+    """
+
+    def __init__(self, prompt: ChoicePrompt) -> None:
+        super().__init__(timeout=prompt.timeout_seconds)
+        self._prompt = prompt
+        self._future: asyncio.Future[tuple[str, ...] | None] = (
+            asyncio.get_running_loop().create_future()
+        )
+
+        choices = prompt.choices
+        if choices and (prompt.multi_select or len(choices) > MAX_BUTTONS):
+            self.add_item(_ChoiceSelect(self, prompt))
+        else:
+            for choice in choices:
+                self.add_item(_ChoiceButton(self, choice))
+
+    async def wait_for_answer(self) -> tuple[str, ...] | None:
+        """Await the user's choice, or fall back when the clock runs out."""
+        timeout = self._prompt.timeout_seconds
+        try:
+            return await asyncio.wait_for(asyncio.shield(self._future), timeout)
+        except (TimeoutError, asyncio.CancelledError):
+            default = self._prompt.default_on_timeout
+            self._resolve((default,) if default is not None else None)
+            return (default,) if default is not None else None
+
+    def _resolve(self, values: tuple[str, ...] | None) -> None:
+        if not self._future.done():
+            self._future.set_result(values)
+        self.stop()
+
+    async def on_timeout(self) -> None:
+        default = self._prompt.default_on_timeout
+        self._resolve((default,) if default is not None else None)
+
+
+class _ChoiceButton(discord.ui.Button):
+    _STYLES = {
+        "default": discord.ButtonStyle.secondary,
+        "positive": discord.ButtonStyle.success,
+        "destructive": discord.ButtonStyle.danger,
+    }
+
+    def __init__(self, view: ChoiceView, choice) -> None:  # noqa: ANN001 — Choice, avoids cycle
+        super().__init__(
+            label=choice.label[:80],
+            style=self._STYLES.get(choice.style, discord.ButtonStyle.secondary),
+        )
+        self._owner = view
+        self._value = choice.value
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        with contextlib.suppress(discord.HTTPException):
+            await interaction.response.defer()
+        self._owner._resolve((self._value,))
+        await _disable(interaction, self._owner)
+
+
+class _ChoiceSelect(discord.ui.Select):
+    def __init__(self, view: ChoiceView, prompt: ChoicePrompt) -> None:
+        options = [
+            discord.SelectOption(
+                label=c.label[:100],
+                value=c.value[:100],
+                description=(c.description or "")[:100] or None,
+            )
+            for c in prompt.choices[:25]  # Discord's per-menu cap
+        ]
+        super().__init__(
+            placeholder=prompt.header or "Choose…",
+            min_values=1,
+            max_values=len(options) if prompt.multi_select else 1,
+            options=options,
+        )
+        self._owner = view
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        with contextlib.suppress(discord.HTTPException):
+            await interaction.response.defer()
+        self._owner._resolve(tuple(self.values))
+        await _disable(interaction, self._owner)
+
+
+class FormModal(discord.ui.Modal):
+    """A :class:`FormPrompt` rendered as a Discord modal.
+
+    Discord modals hold five inputs and only text, so richer field kinds
+    degrade to text rather than disappearing — a truncated form the user can
+    still complete beats a missing one.
+    """
+
+    MAX_INPUTS = 5
+
+    def __init__(self, prompt: FormPrompt) -> None:
+        super().__init__(title=prompt.title[:45], timeout=prompt.timeout_seconds)
+        self._keys: list[str] = []
+        self._future: asyncio.Future[dict[str, str] | None] = (
+            asyncio.get_running_loop().create_future()
+        )
+
+        for field in prompt.fields[: self.MAX_INPUTS]:
+            self._keys.append(field.key)
+            self.add_item(
+                discord.ui.TextInput(
+                    label=field.label[:45],
+                    placeholder=(field.placeholder or _placeholder_for(field))[:100],
+                    required=field.required,
+                    style=(
+                        discord.TextStyle.paragraph
+                        if field.kind == "multiline"
+                        else discord.TextStyle.short
+                    ),
+                )
+            )
+
+    async def on_submit(self, interaction: discord.Interaction) -> None:
+        with contextlib.suppress(discord.HTTPException):
+            await interaction.response.defer()
+        answers = {
+            key: child.value
+            for key, child in zip(self._keys, self.children, strict=False)
+            if isinstance(child, discord.ui.TextInput)
+        }
+        if not self._future.done():
+            self._future.set_result(answers)
+
+    async def on_timeout(self) -> None:
+        if not self._future.done():
+            self._future.set_result(None)
+
+    async def on_error(self, interaction: discord.Interaction, error: Exception) -> None:
+        logger.warning("Form modal failed", exc_info=error)
+        if not self._future.done():
+            self._future.set_result(None)
+
+    async def wait_for_answer(self, timeout: float | None = None) -> dict[str, str] | None:
+        try:
+            return await asyncio.wait_for(asyncio.shield(self._future), timeout)
+        except (TimeoutError, asyncio.CancelledError):
+            if not self._future.done():
+                self._future.set_result(None)
+            return None
+
+
+def _placeholder_for(field: FormField) -> str:
+    """Hint at a kind Discord cannot render natively."""
+    if field.kind == "choice":
+        return " / ".join(c.label for c in field.choices)[:100]
+    if field.kind == "toggle":
+        return "yes / no"
+    if field.kind == "number":
+        return "a number"
+    return ""
+
+
+async def _disable(interaction: discord.Interaction, view: discord.ui.View) -> None:
+    """Grey the controls out so a second click cannot race the first."""
+    for child in view.children:
+        if isinstance(child, discord.ui.Button | discord.ui.Select):
+            child.disabled = True
+    if interaction.message:
+        with contextlib.suppress(discord.HTTPException):
+            await interaction.message.edit(view=view)

--- a/claude_discord/surface.py
+++ b/claude_discord/surface.py
@@ -1,0 +1,423 @@
+"""Discord's implementation of :class:`ConversationSurface`.
+
+This is a *binding*, not a rewrite. Every behaviour it exposes already
+existed — ``StreamingMessageManager`` for live text, ``StatusManager`` for the
+emoji reaction, ``LiveToolTimer`` for the elapsed counter, ``send_files`` for
+attachments, ``StopView`` for interruption. What is new is that they are now
+reachable through vocabulary that names *intents*, so the session machinery
+can drive Discord without importing it.
+
+The mapping is the interesting part, because it is where Discord gets to be
+Discord:
+
+===================  ========================================================
+Intent               How Discord does it
+===================  ========================================================
+``send_text``        chunked to 2,000 chars, tables rendered to monospace
+``send_notice``      a coloured embed — the level picks the colour
+``open_activity``    one embed per tool, edited in place on completion, with
+                     a live elapsed-time counter while it runs
+``set_status``       an emoji reaction on the user's own message, debounced
+``prompt_choice``    buttons, or a select menu past four options
+``prompt_form``      a modal
+``offer_interrupt``  a Stop button that re-posts itself to stay in view
+===================  ========================================================
+
+A Teams surface will answer the same calls very differently — folding tool
+activity into one card it keeps updating rather than posting an embed each
+time — and both are correct. That freedom is the point.
+
+Discord-specific degradations are handled here rather than pushed onto the
+caller. ``set_status`` needs a message to react to; when the surface was
+built without one (a scheduled run has no user message), it is a no-op rather
+than an error.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+from collections.abc import Awaitable, Callable, Sequence
+
+import discord
+
+from claude_code_core.frontend import (
+    ActivitySpec,
+    ChoicePrompt,
+    FormPrompt,
+    Mention,
+    Notice,
+    NoticeLevel,
+    OutboundFile,
+    StatusKind,
+    SurfaceCapabilities,
+    ThreadKey,
+)
+from claude_code_core.rendering import render_for
+from claude_code_core.types import ToolCategory
+
+from .discord_ui.chunker import DISCORD_CAPABILITIES
+from .discord_ui.embeds import (
+    COLOR_ERROR,
+    COLOR_INFO,
+    COLOR_SUCCESS,
+    COLOR_TODO,
+    COLOR_TOOL,
+    tool_result_embed,
+)
+from .discord_ui.file_sender import send_file_blobs, send_files
+from .discord_ui.prompt_views import ChoiceView, FormModal
+from .discord_ui.status import StatusManager
+from .discord_ui.streaming_manager import StreamingMessageManager
+from .discord_ui.views import StopView
+
+logger = logging.getLogger(__name__)
+
+_NOTICE_COLOR: dict[NoticeLevel, int] = {
+    NoticeLevel.INFO: COLOR_INFO,
+    NoticeLevel.SUCCESS: COLOR_SUCCESS,
+    NoticeLevel.WARNING: COLOR_TODO,  # orange
+    NoticeLevel.ERROR: COLOR_ERROR,
+    NoticeLevel.SUBTLE: COLOR_INFO,
+}
+
+# Tool categories map to the icons already used in embeds.py.
+_ACTIVITY_ICON = "\U0001f527"  # 🔧
+
+
+class DiscordActivity:
+    """One tool call, shown as an embed that is edited when it finishes."""
+
+    def __init__(self, message: discord.Message | None, spec: ActivitySpec) -> None:
+        self._message = message
+        self._spec = spec
+        self._finished = False
+
+    async def update(self, detail: str) -> None:
+        if self._finished or self._message is None:
+            return
+        with contextlib.suppress(discord.HTTPException):
+            await self._message.edit(embed=_activity_embed(self._spec, detail))
+
+    async def complete(self, result: str | None, *, ok: bool = True) -> None:
+        # Idempotent by contract: a session that errors after a tool finished
+        # must not take the surface down with it.
+        if self._finished:
+            return
+        self._finished = True
+        if self._message is None:
+            return
+        title = f"{_ACTIVITY_ICON} {self._spec.title}"
+        with contextlib.suppress(discord.HTTPException):
+            await self._message.edit(embed=tool_result_embed(title, result or ""))
+
+    async def cancel(self) -> None:
+        if self._finished:
+            return
+        self._finished = True
+        if self._message is None:
+            return
+        with contextlib.suppress(discord.HTTPException):
+            await self._message.edit(embed=_activity_embed(self._spec, "cancelled"))
+
+
+class DiscordStream:
+    """Live text, delegated to the existing debounced streaming manager."""
+
+    def __init__(self, manager: StreamingMessageManager) -> None:
+        self._manager = manager
+        self._finalized = False
+        self._result = ""
+
+    @property
+    def has_content(self) -> bool:
+        return self._manager.has_content
+
+    async def append(self, delta: str) -> None:
+        if self._finalized:
+            return
+        await self._manager.append(delta)
+
+    async def finalize(self, transform: Callable[[str], str] | None = None) -> str:
+        if self._finalized:
+            return self._result
+        self._finalized = True
+        self._result = await self._manager.finalize(transform=transform)
+        return self._result
+
+
+class DiscordInterrupt:
+    """The Stop button, wrapped so the protocol does not name discord.ui."""
+
+    def __init__(self, view: StopView, thread: discord.abc.Messageable) -> None:
+        self._view = view
+        self._thread = thread
+        self._disabled = False
+
+    async def bump(self) -> None:
+        if self._disabled:
+            return
+        await self._view.bump(self._thread)  # type: ignore[arg-type]
+
+    async def disable(self) -> None:
+        if self._disabled:
+            return
+        self._disabled = True
+        await self._view.disable()
+
+
+class DiscordSurface:
+    """A Discord thread, driven through the frontend protocol.
+
+    Args:
+        thread: The thread (or channel, for inline-reply mode) to post in.
+        status_message: The user's own message, for the emoji status
+            reaction. Omit for flows that have no user message — scheduled
+            runs and webhook triggers — and status becomes a no-op.
+        model: Used only to widen the stall thresholds for slower models.
+        interrupt_runner: The backend the Stop button interrupts. Without it,
+            ``offer_interrupt`` still returns a working handle so callers need
+            no special case; it simply has no button behind it.
+    """
+
+    frontend = "discord"
+
+    def __init__(
+        self,
+        thread: discord.Thread | discord.TextChannel,
+        *,
+        status_message: discord.Message | None = None,
+        model: str | None = None,
+        working_dir: str | None = None,
+        interrupt_runner: object | None = None,
+    ) -> None:
+        self._thread = thread
+        self._status_message = status_message
+        self._model = model
+        self.working_dir = working_dir
+        self._interrupt_runner = interrupt_runner
+        self._status: StatusManager | None = None
+
+    # -- identity ----------------------------------------------------------
+    @property
+    def thread_key(self) -> ThreadKey:
+        """Discord snowflakes are used verbatim — no surrogate needed."""
+        return self._thread.id
+
+    @property
+    def external_id(self) -> str:
+        return str(self._thread.id)
+
+    @property
+    def capabilities(self) -> SurfaceCapabilities:
+        return DISCORD_CAPABILITIES
+
+    @property
+    def thread(self) -> discord.Thread | discord.TextChannel:
+        """The underlying thread, for code that is still Discord-specific."""
+        return self._thread
+
+    # -- output ------------------------------------------------------------
+    async def send_text(self, text: str) -> str | None:
+        last: discord.Message | None = None
+        for chunk in render_for(text, DISCORD_CAPABILITIES):
+            try:
+                last = await self._thread.send(chunk)
+            except discord.NotFound:
+                logger.info("Thread %d disappeared mid-send", self._thread.id)
+                return None
+            except discord.HTTPException:
+                logger.warning("Failed to send message chunk", exc_info=True)
+                return None
+        return str(last.id) if last else None
+
+    async def send_notice(self, notice: Notice) -> str | None:
+        embed = discord.Embed(color=_NOTICE_COLOR.get(notice.level, COLOR_INFO))
+        if notice.title:
+            embed.title = notice.title[:256]
+        if notice.body:
+            body = f"```\n{notice.body}\n```" if notice.monospace_body else notice.body
+            embed.description = body[:4096]
+        for name, value in notice.fields:
+            embed.add_field(name=name[:256], value=value[:1024], inline=True)
+        try:
+            sent = await self._thread.send(embed=embed)
+        except discord.HTTPException:
+            logger.warning("Failed to send notice", exc_info=True)
+            return None
+        return str(sent.id)
+
+    async def deliver_files(self, files: Sequence[OutboundFile]) -> None:
+        if not files:
+            return
+        paths = [f.path for f in files if f.path]
+        blobs = [(f.display_name, f.blob) for f in files if f.blob is not None]
+        if paths:
+            await send_files(self._thread, paths, self.working_dir)  # type: ignore[arg-type]
+        if blobs:
+            await send_file_blobs(self._thread, blobs)  # type: ignore[arg-type]
+
+    def open_stream(self) -> DiscordStream:
+        return DiscordStream(StreamingMessageManager(self._thread))
+
+    async def open_activity(self, spec: ActivitySpec) -> DiscordActivity:
+        message: discord.Message | None = None
+        with contextlib.suppress(discord.HTTPException):
+            message = await self._thread.send(embed=_activity_embed(spec, spec.detail))
+        return DiscordActivity(message, spec)
+
+    # -- state -------------------------------------------------------------
+    async def set_status(self, status: StatusKind) -> None:
+        manager = self._ensure_status()
+        if manager is None:
+            return
+        if status is StatusKind.DONE:
+            await manager.set_done()
+        elif status is StatusKind.ERROR:
+            await manager.set_error()
+        elif status is StatusKind.COMPACTING:
+            await manager.set_compact()
+        elif status is StatusKind.HOOK:
+            await manager.set_hook()
+        elif status in _TOOL_STATUSES:
+            await manager.set_tool(_TOOL_STATUSES[status])
+        else:
+            await manager.set_thinking()
+
+    async def clear_status(self) -> None:
+        if self._status is not None:
+            await self._status.cleanup()
+
+    def _ensure_status(self) -> StatusManager | None:
+        if self._status is None and self._status_message is not None:
+            self._status = StatusManager(self._status_message, model=self._model)
+        return self._status
+
+    # -- interaction -------------------------------------------------------
+    async def prompt_choice(self, prompt: ChoicePrompt) -> tuple[str, ...] | None:
+        view = ChoiceView(prompt)
+        embed = discord.Embed(
+            title=(prompt.header or "Question")[:256],
+            description=prompt.question[:4096],
+            color=COLOR_INFO,
+        )
+        try:
+            await self._thread.send(content=_mention_text(prompt.notify), embed=embed, view=view)
+        except discord.HTTPException:
+            logger.warning("Failed to post choice prompt", exc_info=True)
+            # The prompt never reached the user, so fall back the same way a
+            # timeout would — a permission request must still fail closed.
+            default = prompt.default_on_timeout
+            return (default,) if default is not None else None
+        return await view.wait_for_answer()
+
+    async def prompt_form(self, prompt: FormPrompt) -> dict[str, str] | None:
+        """Discord modals can only open from an interaction, so the form is
+        offered behind a button rather than appearing unprompted."""
+        view = _FormLauncher(prompt)
+        embed = discord.Embed(
+            title=prompt.title[:256],
+            description=(prompt.description or "")[:4096] or None,
+            color=COLOR_INFO,
+        )
+        try:
+            await self._thread.send(content=_mention_text(prompt.notify), embed=embed, view=view)
+        except discord.HTTPException:
+            logger.warning("Failed to post form prompt", exc_info=True)
+            return None
+        return await view.wait_for_answer()
+
+    async def prompt_url(self, title: str, url: str, *, notify: Mention | None = None) -> bool:
+        view = discord.ui.View(timeout=None)
+        view.add_item(discord.ui.Button(label=title[:80], url=url))
+        try:
+            await self._thread.send(content=_mention_text(notify), view=view)
+        except discord.HTTPException:
+            logger.warning("Failed to post URL prompt", exc_info=True)
+            return False
+        return True
+
+    async def offer_interrupt(self, on_stop: Callable[[], Awaitable[None]]) -> DiscordInterrupt:
+        view = StopView(_StopAdapter(on_stop))  # type: ignore[arg-type]
+        return DiscordInterrupt(view, self._thread)
+
+    # -- management --------------------------------------------------------
+    async def rename(self, title: str) -> None:
+        if not isinstance(self._thread, discord.Thread):
+            return  # a channel is not ours to rename
+        with contextlib.suppress(discord.HTTPException):
+            await self._thread.edit(name=title[:100])
+
+    async def recent_transcript(self, days: int) -> str | None:
+        from .discord_ui.thread_context import build_recent_transcript
+
+        if not isinstance(self._thread, discord.Thread):
+            return None
+        return await build_recent_transcript(self._thread, days=days)
+
+
+class _StopAdapter:
+    """Lets StopView, which expects a backend, drive an arbitrary callback."""
+
+    def __init__(self, on_stop: Callable[[], Awaitable[None]]) -> None:
+        self._on_stop = on_stop
+
+    async def interrupt(self) -> None:
+        await self._on_stop()
+
+
+class _FormLauncher(discord.ui.View):
+    """A button that opens the modal — Discord requires an interaction.
+
+    Like :class:`ChoiceView`, the clock is ours rather than discord.py's, so a
+    view that never gets dispatched cannot hang the session.
+    """
+
+    def __init__(self, prompt: FormPrompt) -> None:
+        super().__init__(timeout=prompt.timeout_seconds)
+        self._prompt = prompt
+        self._answer: asyncio.Future[dict[str, str] | None] = (
+            asyncio.get_running_loop().create_future()
+        )
+        button = discord.ui.Button(
+            label=prompt.submit_label[:80], style=discord.ButtonStyle.primary
+        )
+        button.callback = self._open  # type: ignore[method-assign]
+        self.add_item(button)
+
+    async def _open(self, interaction: discord.Interaction) -> None:
+        modal = FormModal(self._prompt)
+        await interaction.response.send_modal(modal)
+        answers = await modal.wait_for_answer(self._prompt.timeout_seconds)
+        if not self._answer.done():
+            self._answer.set_result(answers)
+        self.stop()
+
+    async def wait_for_answer(self) -> dict[str, str] | None:
+        try:
+            return await asyncio.wait_for(
+                asyncio.shield(self._answer), self._prompt.timeout_seconds
+            )
+        except (TimeoutError, asyncio.CancelledError):
+            return None
+
+
+_TOOL_STATUSES: dict[StatusKind, ToolCategory] = {
+    StatusKind.TOOL_READ: ToolCategory.READ,
+    StatusKind.TOOL_EDIT: ToolCategory.EDIT,
+    StatusKind.TOOL_COMMAND: ToolCategory.COMMAND,
+    StatusKind.TOOL_WEB: ToolCategory.WEB,
+    StatusKind.TOOL_OTHER: ToolCategory.OTHER,
+}
+
+
+def _activity_embed(spec: ActivitySpec, detail: str | None) -> discord.Embed:
+    embed = discord.Embed(title=f"{_ACTIVITY_ICON} {spec.title}..."[:256], color=COLOR_TOOL)
+    if detail:
+        embed.description = detail[:4096]
+    return embed
+
+
+def _mention_text(mention: Mention | None) -> str | None:
+    return f"<@{mention.external_user_id}>" if mention else None

--- a/tests/test_discord_surface.py
+++ b/tests/test_discord_surface.py
@@ -1,0 +1,297 @@
+"""DiscordSurface must pass the same contract every other frontend will.
+
+This is the test that makes the abstraction real. Up to now the conformance
+suite has only been run against ``MemorySurface``, which was written to pass
+it. Running it against the Discord binding — over a faked discord.py, but with
+the binding's own logic untouched — is what proves the contract describes
+something a *real* surface can satisfy, rather than something only a purpose-
+built double can.
+
+When the Teams surface arrives it runs this identical suite. That is the
+mechanism by which "Teams is missing a feature" stops being possible: it would
+have to fail a check that Discord passes, in CI, before merge.
+
+The Discord fakes below are deliberately thin. They record calls and return
+plausible objects; they do not simulate Discord. Anything that needs real
+Discord semantics is not a contract obligation and does not belong here.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+import pytest
+
+from claude_code_core.conformance import check_surface
+from claude_code_core.frontend import (
+    ActivitySpec,
+    Choice,
+    ChoicePrompt,
+    ConversationSurface,
+    Notice,
+    NoticeLevel,
+    OutboundFile,
+    StatusKind,
+)
+from claude_discord.surface import DiscordSurface
+
+
+class FakeMessage(MagicMock):
+    """A sent message that can be edited and knows its id."""
+
+    def __init__(self, content: str = "", **kwargs: Any) -> None:
+        super().__init__(spec=discord.Message, **kwargs)
+        self.id = 555
+        self.content = content
+        self.jump_url = "https://discord.test/555"
+        self.guild = None
+        self.edit = AsyncMock()
+        self.delete = AsyncMock()
+        self.add_reaction = AsyncMock()
+        self.remove_reaction = AsyncMock()
+
+
+class RecordingSurface(DiscordSurface):
+    """DiscordSurface plus the two hooks the contract reads.
+
+    Recording lives in the test, not in ``DiscordSurface`` — production code
+    should not carry test scaffolding just so a checker can see inside it.
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.conformance_sent_text: list[str] = []
+        self.conformance_delivered_files: list[str] = []
+
+    async def send_text(self, text: str) -> str | None:
+        from claude_code_core.rendering import render_for
+
+        self.conformance_sent_text.extend(render_for(text, self.capabilities))
+        return await super().send_text(text)
+
+    async def deliver_files(self, files):  # type: ignore[no-untyped-def]
+        self.conformance_delivered_files.extend(f.display_name for f in files)
+        return await super().deliver_files(files)
+
+
+def _fake_thread() -> MagicMock:
+    thread = MagicMock(spec=discord.Thread)
+    thread.id = 1234567890123456789  # a plausible snowflake
+    thread.send = AsyncMock(side_effect=lambda *a, **k: FakeMessage(a[0] if a else ""))
+    thread.edit = AsyncMock()
+    return thread
+
+
+def _make_surface(**kwargs: Any) -> RecordingSurface:
+    return RecordingSurface(_fake_thread(), **kwargs)
+
+
+class TestDiscordSurfaceIsConformant:
+    async def test_passes_every_contract_check(self) -> None:
+        report = await check_surface(lambda: _as_async(_make_surface()))
+        assert report.ok, report.summary()
+
+    async def test_passes_without_a_status_message(self) -> None:
+        """Scheduled runs and webhook triggers have no user message to react
+        to. Status must degrade to a no-op rather than fail the session."""
+        report = await check_surface(lambda: _as_async(_make_surface(status_message=None)))
+        assert report.ok, report.summary()
+
+    async def test_satisfies_the_protocol_structurally(self) -> None:
+        assert isinstance(_make_surface(), ConversationSurface)
+
+
+class TestIdentityMatchesDiscord:
+    def test_thread_key_is_the_snowflake_verbatim(self) -> None:
+        """Discord ids are already ints in the ledger's key space, so there is
+        no surrogate — and existing rows keep resolving after the protocol
+        migration."""
+        thread = _fake_thread()
+        surface = RecordingSurface(thread)
+        assert surface.thread_key == thread.id
+        assert surface.external_id == str(thread.id)
+        assert surface.frontend == "discord"
+
+    def test_capabilities_report_discord_reality(self) -> None:
+        caps = _make_surface().capabilities
+        assert caps.max_message_chars == 2000
+        assert caps.supports_reactions is True
+        assert caps.supports_slash_commands is True
+        # Discord's code-block font misreports CJK width, so CJK tables must
+        # keep falling back to the vertical layout.
+        assert caps.monospace_cjk_is_double_width is False
+
+
+class TestOutputGoesThroughDiscord:
+    async def test_long_text_is_sent_as_several_messages(self) -> None:
+        surface = _make_surface()
+        await surface.send_text("x" * 5000)
+        assert surface.thread.send.await_count > 1
+
+    async def test_empty_text_sends_nothing(self) -> None:
+        surface = _make_surface()
+        await surface.send_text("")
+        surface.thread.send.assert_not_awaited()
+
+    async def test_notice_level_picks_the_embed_colour(self) -> None:
+        from claude_discord.discord_ui.embeds import COLOR_ERROR, COLOR_SUCCESS
+
+        surface = _make_surface()
+        await surface.send_notice(Notice(level=NoticeLevel.SUCCESS, title="done"))
+        await surface.send_notice(Notice(level=NoticeLevel.ERROR, title="boom"))
+        colours = [c.kwargs["embed"].color.value for c in surface.thread.send.await_args_list]
+        assert colours == [COLOR_SUCCESS, COLOR_ERROR]
+
+    async def test_a_deleted_thread_does_not_raise(self) -> None:
+        """A user can delete a thread mid-session; that must not surface as a
+        crash in the middle of a Claude run."""
+        surface = _make_surface()
+        surface.thread.send = AsyncMock(side_effect=discord.NotFound(MagicMock(status=404), "gone"))
+        assert await surface.send_text("hello") is None
+
+
+class TestActivityMapsToAnEditedEmbed:
+    async def test_completion_edits_the_original_message(self) -> None:
+        surface = _make_surface()
+        handle = await surface.open_activity(ActivitySpec(kind="tool", title="Read"))
+        sent = surface.thread.send.await_args
+        assert sent is not None
+        await handle.complete("42 lines")
+        # One send for the in-progress embed, then an edit rather than a
+        # second message — the thread stays readable.
+        assert surface.thread.send.await_count == 1
+
+    async def test_completing_twice_is_a_no_op(self) -> None:
+        surface = _make_surface()
+        handle = await surface.open_activity(ActivitySpec(kind="tool", title="Bash"))
+        await handle.complete("ok")
+        await handle.complete("ok again")  # must not raise or re-edit
+
+
+class TestStatusDegradesWithoutAMessage:
+    async def test_no_status_message_means_no_reaction(self) -> None:
+        surface = _make_surface(status_message=None)
+        await surface.set_status(StatusKind.THINKING)
+        await surface.clear_status()  # must not raise
+
+    async def test_status_reacts_on_the_user_message(self) -> None:
+        message = FakeMessage()
+        surface = _make_surface(status_message=message)
+        await surface.set_status(StatusKind.TOOL_EDIT)
+        # StatusManager debounces, so the reaction is scheduled rather than
+        # immediate; the contract only requires that this does not raise.
+        assert surface._status is not None
+
+
+class TestChoicePrompt:
+    async def test_timeout_returns_the_declared_default(self) -> None:
+        """An unattended permission request must deny, not hang."""
+        surface = _make_surface()
+        prompt = ChoicePrompt(
+            question="Run rm -rf?",
+            choices=(Choice(value="allow", label="Allow"), Choice(value="deny", label="Deny")),
+            default_on_timeout="deny",
+            timeout_seconds=0.05,
+        )
+        assert await surface.prompt_choice(prompt) == ("deny",)
+
+    async def test_timeout_without_a_default_returns_none(self) -> None:
+        surface = _make_surface()
+        prompt = ChoicePrompt(
+            question="Which?",
+            choices=(Choice(value="a", label="A"),),
+            timeout_seconds=0.05,
+        )
+        assert await surface.prompt_choice(prompt) is None
+
+    async def test_a_failed_post_still_fails_closed(self) -> None:
+        """If the prompt never reaches the user, a permission request must
+        land on its deny default rather than silently allowing."""
+        surface = _make_surface()
+        surface.thread.send = AsyncMock(
+            side_effect=discord.HTTPException(MagicMock(status=500), "nope")
+        )
+        prompt = ChoicePrompt(
+            question="Run it?",
+            choices=(Choice(value="allow", label="A"), Choice(value="deny", label="D")),
+            default_on_timeout="deny",
+            timeout_seconds=5,
+        )
+        assert await surface.prompt_choice(prompt) == ("deny",)
+
+    async def test_many_choices_render_as_a_select_menu(self) -> None:
+        from claude_discord.discord_ui.prompt_views import ChoiceView, _ChoiceSelect
+
+        prompt = ChoicePrompt(
+            question="Pick",
+            choices=tuple(Choice(value=str(i), label=f"Option {i}") for i in range(8)),
+        )
+        view = ChoiceView(prompt)
+        assert any(isinstance(c, _ChoiceSelect) for c in view.children)
+
+    async def test_few_choices_render_as_buttons(self) -> None:
+        from claude_discord.discord_ui.prompt_views import ChoiceView, _ChoiceButton
+
+        prompt = ChoicePrompt(
+            question="Pick",
+            choices=(Choice(value="y", label="Yes"), Choice(value="n", label="No")),
+        )
+        view = ChoiceView(prompt)
+        assert all(isinstance(c, _ChoiceButton) for c in view.children)
+        assert len(view.children) == 2
+
+
+class TestFileDelivery:
+    async def test_paths_and_blobs_both_reach_discord(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        real = tmp_path / "a.txt"
+        real.write_text("hi", encoding="utf-8")
+        surface = _make_surface()
+        await surface.deliver_files(
+            [
+                OutboundFile(display_name="a.txt", path=str(real)),
+                OutboundFile(display_name="b.txt", blob=b"data"),
+            ]
+        )
+        # One batch of on-disk files, one of in-memory blobs.
+        assert surface.thread.send.await_count == 2
+
+    async def test_empty_list_sends_nothing(self) -> None:
+        surface = _make_surface()
+        await surface.deliver_files([])
+        surface.thread.send.assert_not_awaited()
+
+
+class TestRename:
+    async def test_renames_a_thread(self) -> None:
+        surface = _make_surface()
+        await surface.rename("a much better title")
+        surface.thread.edit.assert_awaited_once()
+
+    async def test_a_channel_is_not_renamed(self) -> None:
+        """Inline-reply mode posts into a channel, which is not ours to
+        rename. It must be ignored rather than attempted."""
+        channel = MagicMock(spec=discord.TextChannel)
+        channel.id = 42
+        channel.edit = AsyncMock()
+        surface = RecordingSurface(channel)
+        await surface.rename("nope")
+        channel.edit.assert_not_awaited()
+
+
+async def _as_async(value: RecordingSurface) -> RecordingSurface:
+    return value
+
+
+@pytest.fixture(autouse=True)
+def _no_real_sleeping(monkeypatch: pytest.MonkeyPatch) -> None:
+    """StatusManager debounces with a real sleep; keep the suite fast."""
+    import asyncio
+
+    original = asyncio.sleep
+
+    async def fast_sleep(delay: float, *args: Any, **kwargs: Any) -> Any:
+        return await original(0, *args, **kwargs)
+
+    monkeypatch.setattr(asyncio, "sleep", fast_sleep)

--- a/uv.lock
+++ b/uv.lock
@@ -204,7 +204,7 @@ wheels = [
 
 [[package]]
 name = "claude-code-discord-bridge"
-version = "3.3.9"
+version = "3.3.10"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Step 3b. Follows #562 (protocol), #563 (rendering), #564 (contract).

`DiscordSurface` is a **binding, not a rewrite**. `StreamingMessageManager`, `StatusManager`, `send_files` and `StopView` all keep doing exactly what they did. What is new is that they are reachable through vocabulary that names *intents*, so the session machinery can drive Discord without importing it.

| Intent | How Discord does it |
|---|---|
| `send_text` | chunked to 2,000 chars, tables rendered to monospace |
| `send_notice` | a coloured embed — the level picks the colour |
| `open_activity` | one embed per tool, edited in place on completion |
| `set_status` | an emoji reaction on the user's own message, debounced |
| `prompt_choice` | buttons, or a select menu past four options |
| `prompt_form` | a modal, opened from a button (Discord requires an interaction) |
| `offer_interrupt` | a Stop button that re-posts itself to stay in view |

Teams will answer the same calls by folding tool activity into one card it keeps updating. Both are correct — that freedom is the point.

**Running #564's conformance suite against this is the headline.** Until now it had only ever run against `MemorySurface`, which was written to pass it. Running it against the Discord binding — over a faked discord.py, but with the binding's own logic untouched — proves the contract describes something a *real* surface can satisfy. When the Teams surface arrives it runs the identical suite; "Teams is missing a feature" would have to show up as a check Discord passes and Teams fails, in CI, before merge.

## The contract earned its keep immediately — two hangs

**1.** A `ChoicePrompt` with no `timeout_seconds` produced `discord.ui.View(timeout=None)`, so `prompt_choice` waited forever.

**2. The serious one.** discord.py's view timeout only starts once the view has been **registered with the client**. If the message posts but the view never gets dispatched, that timer never fires — a session hung on a permission request nobody can see. That is a production failure, not a test artefact.

Both fixed by **owning the clock**: `ChoiceView` and the form launcher wait with their own `asyncio.wait_for`, so the timeout holds regardless of what Discord did with the view.

The conformance checks now pass an explicit timeout on every prompt. Without one, a surface that waits for a real human — correct behaviour — would hang the checker, making the contract *untestable* rather than unsatisfied.

## An obligation removed from the contract, on purpose

I added a check asserting an unanswered prompt falls back to `default_on_timeout`, then removed it, **because it cannot work**. From outside, "the user chose allow" and "the surface invented allow when nobody answered" are the same return value, and the contract has no way to force nobody to answer. `MemorySurface` failed it precisely by simulating a user who *did* answer.

The reasoning is recorded in the module docstring so it is not re-added, and the obligation is proved per-frontend instead — where the interaction can actually be withheld:

```python
async def test_a_failed_post_still_fails_closed(self) -> None:
    """If the prompt never reaches the user, a permission request must
    land on its deny default rather than silently allowing."""
```

## Also here

`discord_ui/prompt_views.py` — the generic `ChoiceView` and `FormModal`. The existing per-caller views (`AskView`, `PermissionView`, `PlanApprovalView`) are untouched; this is the rendering for prompts arriving through the protocol, so a new caller does not have to invent a fourth view.

## Verification

- **1932 tests pass** (1910 + 22), plus 62 in `test_run_helper.py` with an isolated `HOME`
- `ruff check` / `ruff format --check` clean, `pyright` 0 errors on both packages
- `DiscordSurface` verified to satisfy `ConversationSurface` structurally, and to pass the contract **both with and without a status message** — scheduled runs and webhook triggers have no user message to react to, so status must degrade to a no-op rather than fail the session
- No existing Discord code path changed; nothing calls `DiscordSurface` yet

## Next

PR4: switch `EventProcessor` to drive the surface instead of the thread. That is the one genuinely risky PR — acceptance is the existing suite green **plus** a `make dev-on` run on EbiBot.