### PR TITLE
Carry conversation history across Claude/Codex switches

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,12 +331,13 @@ ccdb 3.0 introduces three slash commands that change which AI handles the next s
 
 All three commands persist to SQLite via `SettingsRepository`, so the choice survives bot restarts. Calling them with no arguments prints the current global default plus any thread override.
 
-**What happens to a thread that already has a session?** Session IDs are not interoperable between the two CLIs — handing a Codex rollout ID to `claude --resume` (or a Claude UUID to `codex exec resume`) fails at the CLI level. ccdb records which backend minted each session ID, so a switch never leaves a thread stranded:
+**What happens to a thread that already has a session?** Session IDs are not interoperable between the two CLIs — handing a Codex rollout ID to `claude --resume` (or a Claude UUID to `codex exec resume`) fails at the CLI level. ccdb therefore performs a **file-backed conversation handoff** for both thread-scoped and global switches:
 
-- **Thread-scoped switch** — the stored session ID is dropped so the next message starts fresh in the new backend, *unless* the record is known to belong to the backend you switched **to**. Switching back is therefore a valid way to pick a thread's earlier conversation back up.
-- **Global switch** — per-thread records are deliberately left untouched. If a thread is still holding the other backend's session ID, the next message starts a fresh session and posts a one-line notice explaining why, instead of resuming.
+1. It keeps the old session ID long enough to locate that backend's local JSONL (`~/.claude/projects` or `~/.codex/sessions`).
+2. It extracts a bounded transcript of user and assistant text. System/developer instructions, hidden reasoning, tool calls/results, and image payloads are excluded.
+3. It starts a native session in the new backend and prepends that transcript to the first new user message. The new session ID then replaces the old mapping normally.
 
-Records written before ccdb tracked backend ownership have no stored backend. A global switch resumes them exactly as it always did; a thread-scoped switch clears them rather than risk a broken resume.
+If the local JSONL is missing or unreadable, ccdb safely degrades to a fresh session and logs the missing handoff. Records written before ccdb tracked backend ownership keep the legacy resume behaviour because their source backend cannot be identified reliably.
 
 Visual cues so you never forget which one you're talking to:
 
@@ -376,6 +377,7 @@ Behind the scenes:
 - **Thread = Session** — 1:1 mapping between Discord thread and Claude Code session
 - **Goal tracking** — `/goal <condition>` sets a completion condition; Claude keeps working until the condition is met. Omit the condition to check status; pass `clear` to cancel
 - **Session persistence** — Resume conversations across messages via `--resume`
+- **Cross-backend conversation handoff** — Switching a live thread between Claude and Codex seeds the new native session from a bounded, text-only reading of the previous backend's local JSONL; no manual summary or copy/paste required
 - **Automatic Codex resume recovery** — If a resumed Codex session repeatedly loses its WebSocket before producing output, ccdb starts a replacement session with a bounded, text-only transcript of the prior conversation; image and tool payloads are excluded
 - **Concurrent sessions** — Multiple parallel sessions with configurable limit
 - **Stop without clearing** — `/stop` halts a session while preserving it for resume

--- a/claude_discord/cogs/backend_command.py
+++ b/claude_discord/cogs/backend_command.py
@@ -190,40 +190,9 @@ class BackendCommandCog(commands.Cog):
             )
             return
 
-        # Persist the new backend. Capture the previous one first so we can
-        # detect a real change (and decide whether to wipe the thread's
-        # stored session ID, which is not interoperable across backends).
-        prev_backend = await self._settings.current_backend(target_thread_id)
+        # Persist the new backend. Keep the old session record: its ID points to
+        # the JSONL transcript used for the first cross-backend handoff turn.
         await self._settings.set_backend(name, thread_id=target_thread_id)
-
-        # When the EFFECTIVE backend actually changed, drop the stored session
-        # ID unless the NEW backend can still resume it. Codex and Claude
-        # session stores are not interoperable (passing a Claude session UUID
-        # to `codex exec resume` -- or vice versa -- fails at the CLI level),
-        # but switching *back* to the backend that minted the ID is a valid
-        # way to recover a thread, so that case must keep the record.
-        if prev_backend != name and target_thread_id is not None:
-            try:
-                # Keep the record only when it is KNOWN to belong to the new
-                # backend. Unknown (pre-backend-column) records are wiped, as
-                # they always were — an unknown owner is not worth the risk of
-                # a broken resume.
-                record = await self._chat_cog.repo.get(target_thread_id)
-                deleted = False
-                if record is None or record.backend != name:
-                    deleted = await self._chat_cog.repo.delete(target_thread_id)
-                if deleted:
-                    logger.info(
-                        "Cleared stored session for thread %d on backend switch %s -> %s",
-                        target_thread_id,
-                        prev_backend,
-                        name,
-                    )
-            except Exception:
-                logger.exception(
-                    "Failed to clear thread %d session on backend change",
-                    target_thread_id,
-                )
 
         # If global change, also swap the shared default runner so the next
         # ClaudeChatCog session inherits it (thread overrides will be honoured

--- a/claude_discord/cogs/claude_chat.py
+++ b/claude_discord/cogs/claude_chat.py
@@ -29,6 +29,7 @@ from ..backend_settings import BackendSettings, session_is_resumable
 from ..claude.rewind import find_session_jsonl, parse_user_turns
 from ..claude.types import ImageData
 from ..concurrency import SessionRegistry
+from ..cross_backend_handoff import ConversationHistoryReader, build_handoff_prompt
 from ..database.ask_repo import PendingAskRepository
 from ..database.lounge_repo import LoungeRepository
 from ..database.repository import SessionRecord, SessionRepository
@@ -118,6 +119,7 @@ class ClaudeChatCog(commands.Cog):
         thread_context_days: int = DEFAULT_DAYS,
         factory: BackendFactory | None = None,
         backend_settings: BackendSettings | None = None,
+        conversation_history: ConversationHistoryReader | None = None,
     ) -> None:
         self.bot = bot
         self.repo = repo
@@ -127,6 +129,7 @@ class ClaudeChatCog(commands.Cog):
         # When either is None, we fall back to self.runner.clone() (legacy).
         self._factory = factory
         self._backend_settings = backend_settings
+        self._conversation_history = conversation_history or ConversationHistoryReader()
         self._max_concurrent = max_concurrent
         self._allowed_user_ids = allowed_user_ids
         # When True, skip channel-ID filtering and accept all guild channels.
@@ -1151,9 +1154,55 @@ class ClaudeChatCog(commands.Cog):
             await thread.send(
                 f"-# 🔀 Backend changed (`{record.backend}` → `{current}`). "
                 f"`{current}` cannot resume a `{record.backend}` session, "
-                "so this thread starts a fresh one."
+                "so its file-backed conversation history will be carried into a fresh session."
             )
         return None
+
+    async def _prepare_cross_backend_handoff(
+        self,
+        thread: discord.Thread | discord.TextChannel,
+        prompt: str,
+        session_id: str | None,
+    ) -> tuple[str | None, str]:
+        """Replace an incompatible native resume with a text transcript handoff."""
+        if self._backend_settings is None:
+            return session_id, prompt
+
+        record = await self.repo.get(thread.id)
+        if record is None or not record.backend or not record.session_id:
+            return session_id, prompt
+        current = await self._backend_settings.current_backend(thread.id)
+        if session_is_resumable(record.backend, current):
+            return session_id, prompt
+
+        transcript = await asyncio.to_thread(
+            self._conversation_history.read,
+            record.backend,
+            record.session_id,
+        )
+        if not transcript:
+            logger.warning(
+                "No file-backed transcript found for cross-backend handoff: "
+                "thread=%d backend=%s session=%s",
+                thread.id,
+                record.backend,
+                record.session_id,
+            )
+            return None, prompt
+
+        logger.info(
+            "Injecting cross-backend transcript: thread=%d %s->%s chars=%d",
+            thread.id,
+            record.backend,
+            current,
+            len(transcript),
+        )
+        return None, build_handoff_prompt(
+            source_backend=record.backend,
+            target_backend=current,
+            transcript=transcript,
+            current_prompt=prompt,
+        )
 
     async def _build_prompt_and_images(
         self, message: discord.Message
@@ -1260,6 +1309,11 @@ class ClaudeChatCog(commands.Cog):
         thread. The subprocess itself runs *outside* the lock so a later message
         can still interrupt this run.
         """
+        session_id, prompt = await self._prepare_cross_backend_handoff(
+            thread,
+            prompt,
+            session_id,
+        )
         dashboard = self._get_dashboard()
         description = prompt[:100].replace("\n", " ")
 

--- a/claude_discord/cross_backend_handoff.py
+++ b/claude_discord/cross_backend_handoff.py
@@ -1,0 +1,187 @@
+"""Read local CLI transcripts for a text-only cross-backend session handoff.
+
+Claude and Codex cannot resume each other's native session IDs.  Their local
+JSONL files are still sufficient to seed a replacement session with the human
+and assistant text from the previous backend.  This module deliberately drops
+system/developer messages, reasoning, tool calls, tool results, and images.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_SESSION_ID_PATTERN = re.compile(r"^[a-f0-9-]+$")
+_DEFAULT_MAX_MESSAGES = 16
+_DEFAULT_MAX_MESSAGE_CHARS = 4_000
+_DEFAULT_MAX_TRANSCRIPT_CHARS = 32_000
+_MAX_JSONL_LINE_CHARS = 2_000_000
+
+
+class ConversationHistoryReader:
+    """Extract a bounded user/assistant transcript from Claude or Codex JSONL."""
+
+    def __init__(
+        self,
+        *,
+        claude_sessions_root: str | Path | None = None,
+        codex_home: str | Path | None = None,
+        max_messages: int = _DEFAULT_MAX_MESSAGES,
+        max_message_chars: int = _DEFAULT_MAX_MESSAGE_CHARS,
+        max_transcript_chars: int = _DEFAULT_MAX_TRANSCRIPT_CHARS,
+    ) -> None:
+        claude_root = claude_sessions_root or os.getenv("CLI_SESSIONS_PATH")
+        codex_root = codex_home or os.getenv("CODEX_HOME")
+        self._claude_sessions_root = Path(claude_root or Path.home() / ".claude" / "projects")
+        self._codex_home = Path(codex_root or Path.home() / ".codex")
+        self._max_messages = max(1, max_messages)
+        self._max_message_chars = max(1, max_message_chars)
+        self._max_transcript_chars = max(1, max_transcript_chars)
+
+    def read(self, backend: str, session_id: str) -> str:
+        """Return chronological user/assistant text for *session_id*, or empty."""
+        if not _SESSION_ID_PATTERN.fullmatch(session_id):
+            logger.warning("Refusing transcript lookup for invalid session ID")
+            return ""
+
+        if backend == "claude":
+            path = self._find_claude_session(session_id)
+            messages = self._read_claude(path) if path is not None else []
+        elif backend == "codex":
+            path = self._find_codex_session(session_id)
+            messages = self._read_codex(path) if path is not None else []
+        else:
+            logger.warning("Cannot read transcript for unknown backend %r", backend)
+            return ""
+
+        return self._format_bounded(messages)
+
+    def _find_claude_session(self, session_id: str) -> Path | None:
+        root = self._claude_sessions_root
+        if not root.is_dir():
+            return None
+        return next(root.rglob(f"{session_id}.jsonl"), None)
+
+    def _find_codex_session(self, session_id: str) -> Path | None:
+        sessions = self._codex_home / "sessions"
+        if not sessions.is_dir():
+            return None
+        return next(sessions.rglob(f"*-{session_id}.jsonl"), None)
+
+    @staticmethod
+    def _text_content(content: object) -> str:
+        if isinstance(content, str):
+            return content
+        if not isinstance(content, list):
+            return ""
+        return "\n".join(
+            block.get("text", "")
+            for block in content
+            if isinstance(block, dict)
+            and block.get("type") in {"text", "input_text", "output_text"}
+            and isinstance(block.get("text"), str)
+        )
+
+    def _read_claude(self, path: Path) -> list[tuple[str, str]]:
+        messages: list[tuple[str, str]] = []
+        try:
+            with path.open(encoding="utf-8", errors="replace") as stream:
+                for line in stream:
+                    if len(line) > _MAX_JSONL_LINE_CHARS:
+                        continue
+                    try:
+                        record = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    role = record.get("type")
+                    if role not in {"user", "assistant"} or record.get("isMeta"):
+                        continue
+                    content = self._text_content(record.get("message", {}).get("content", ""))
+                    content = content.strip()
+                    if not content or content.startswith("<"):
+                        continue
+                    messages.append(("User" if role == "user" else "Assistant", content))
+        except OSError:
+            logger.warning("Could not read Claude transcript for handoff", exc_info=True)
+        return messages
+
+    def _read_codex(self, path: Path) -> list[tuple[str, str]]:
+        messages: list[tuple[str, str]] = []
+        try:
+            with path.open(encoding="utf-8", errors="replace") as stream:
+                for line in stream:
+                    if len(line) > _MAX_JSONL_LINE_CHARS or '"event_msg"' not in line:
+                        continue
+                    try:
+                        record = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    if record.get("type") != "event_msg":
+                        continue
+                    payload = record.get("payload", {})
+                    event_type = payload.get("type")
+                    content = payload.get("message")
+                    if event_type not in {"user_message", "agent_message"} or not isinstance(
+                        content, str
+                    ):
+                        continue
+                    content = content.strip()
+                    if content:
+                        role = "User" if event_type == "user_message" else "Assistant"
+                        messages.append((role, content))
+        except OSError:
+            logger.warning("Could not read Codex transcript for handoff", exc_info=True)
+        return messages
+
+    def _format_bounded(self, messages: list[tuple[str, str]]) -> str:
+        """Keep complete turns and distribute the character budget across them."""
+        last_assistant = next(
+            (
+                index
+                for index in range(len(messages) - 1, -1, -1)
+                if messages[index][0] == "Assistant"
+            ),
+            None,
+        )
+        if last_assistant is None:
+            return ""
+        selected = messages[: last_assistant + 1][-self._max_messages :]
+
+        overhead = sum(len(role) + 2 for role, _ in selected)
+        overhead += max(0, len(selected) - 1) * 2
+        content_budget = max(1, self._max_transcript_chars - overhead)
+        per_message = max(1, content_budget // len(selected))
+        content_limit = min(self._max_message_chars, per_message)
+        transcript = "\n\n".join(
+            f"{role}:\n{content[:content_limit]}" for role, content in selected
+        )
+        return transcript[: self._max_transcript_chars]
+
+
+def build_handoff_prompt(
+    *,
+    source_backend: str,
+    target_backend: str,
+    transcript: str,
+    current_prompt: str,
+) -> str:
+    """Wrap old conversation text and the current user message for a fresh session."""
+    source = source_backend.capitalize()
+    target = target_backend.capitalize()
+    return (
+        f"[Cross-backend session handoff: {source} → {target}]\n"
+        f"The native {source} session cannot be resumed by {target}. Continue the same task "
+        "from the text-only conversation transcript below. Treat it as conversation context, "
+        "inspect the current workspace for authoritative state, and do not repeat completed work. "
+        "Tool calls, tool results, hidden reasoning, and system/developer instructions were "
+        "intentionally omitted.\n\n"
+        "Previous conversation:\n"
+        f"{transcript}\n\n"
+        "Current user message:\n"
+        f"{current_prompt}"
+    )

--- a/claude_discord/setup.py
+++ b/claude_discord/setup.py
@@ -191,6 +191,7 @@ async def setup_bridge(
     from .cogs.scheduler import SchedulerCog
     from .cogs.session_manage import SessionManageCog
     from .cogs.skill_command import SkillCommandCog
+    from .cross_backend_handoff import ConversationHistoryReader
     from .database.ask_repo import PendingAskRepository
     from .database.claims_repo import ClaimRepository
     from .database.inbox_repo import ThreadInboxRepository
@@ -365,6 +366,9 @@ async def setup_bridge(
         runner=runner,
         factory=backend_factory,
         backend_settings=backend_settings,
+        conversation_history=ConversationHistoryReader(
+            claude_sessions_root=cli_sessions_path,
+        ),
         max_concurrent=max_concurrent,
         allowed_user_ids=allowed_user_ids,
         ask_repo=ask_repo,

--- a/tests/test_backend_command_session_clear.py
+++ b/tests/test_backend_command_session_clear.py
@@ -1,4 +1,4 @@
-"""Tests for BackendCommandCog clear-thread-session-on-backend-change."""
+"""Tests for preserving the source session across backend changes."""
 
 from __future__ import annotations
 
@@ -77,12 +77,10 @@ def _make_thread_interaction(thread_id: int) -> MagicMock:
     return interaction
 
 
-class TestBackendCommandClearsSession:
-    """When /backend changes a thread's effective backend, the stored session
-    must be cleared so Codex doesn't try to resume a Claude session id (or
-    vice versa)."""
+class TestBackendCommandPreservesSourceSession:
+    """A backend switch retains the old session until its JSONL is handed off."""
 
-    async def test_clears_session_on_thread_backend_change(self) -> None:
+    async def test_preserves_session_on_thread_backend_change(self) -> None:
         repo = await _new_settings_repo()
         settings = BackendSettings(
             repo,
@@ -96,8 +94,8 @@ class TestBackendCommandClearsSession:
         # Run /backend codex scope:thread on a thread defaulting to claude.
         await cog.backend_command.callback(cog, interaction, name="codex", scope="thread")
 
-        # The session for thread 42 should have been wiped.
-        cog._chat_cog.repo.delete.assert_awaited_once_with(42)
+        # The old session ID is the pointer to the file-backed handoff history.
+        cog._chat_cog.repo.delete.assert_not_awaited()
 
     async def test_no_clear_when_backend_is_same(self) -> None:
         repo = await _new_settings_repo()
@@ -117,7 +115,7 @@ class TestBackendCommandClearsSession:
 
         cog._chat_cog.repo.delete.assert_not_awaited()
 
-    async def test_clears_session_when_switching_back(self) -> None:
+    async def test_preserves_session_when_switching_back(self) -> None:
         repo = await _new_settings_repo()
         settings = BackendSettings(
             repo,
@@ -129,10 +127,10 @@ class TestBackendCommandClearsSession:
         cog = _make_cog(settings)
         interaction = _make_thread_interaction(thread_id=42)
 
-        # Now switching back to claude should also wipe.
+        # Switching back also keeps the source pointer until the next turn.
         await cog.backend_command.callback(cog, interaction, name="claude", scope="thread")
 
-        cog._chat_cog.repo.delete.assert_awaited_once_with(42)
+        cog._chat_cog.repo.delete.assert_not_awaited()
 
     async def test_keeps_session_owned_by_the_target_backend(self) -> None:
         """Switching *to* the backend that minted the stored session keeps it.

--- a/tests/test_backend_session_mismatch.py
+++ b/tests/test_backend_session_mismatch.py
@@ -10,13 +10,17 @@ from __future__ import annotations
 
 import tempfile
 from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
 
+import discord
 import pytest
 
 from claude_code_core.models import init_db
 from claude_code_core.parser import parse_line
 from claude_code_core.session_repo import SessionRepository
 from claude_discord.backend_settings import session_is_resumable
+from claude_discord.cogs.claude_chat import ClaudeChatCog
+from claude_discord.database.repository import SessionRecord
 
 
 class TestSessionIsResumable:
@@ -92,3 +96,95 @@ class TestErrorDuringExecutionIsSurfaced:
         assert event is not None
         assert event.error is None
         assert event.text == "done"
+
+
+class TestCrossBackendHandoffPreparation:
+    @staticmethod
+    def _record(*, backend: str = "claude") -> SessionRecord:
+        return SessionRecord(
+            thread_id=42,
+            session_id="aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb",
+            working_dir="/work",
+            model=None,
+            origin="discord",
+            summary=None,
+            created_at="",
+            last_used_at="",
+            backend=backend,
+        )
+
+    @staticmethod
+    def _thread() -> MagicMock:
+        thread = MagicMock(spec=discord.Thread)
+        thread.id = 42
+        thread.send = AsyncMock()
+        return thread
+
+    @staticmethod
+    def _cog(record: SessionRecord, *, current_backend: str, transcript: str) -> ClaudeChatCog:
+        bot = MagicMock()
+        repo = MagicMock()
+        repo.get = AsyncMock(return_value=record)
+        settings = MagicMock()
+        settings.current_backend = AsyncMock(return_value=current_backend)
+        history = MagicMock()
+        history.read.return_value = transcript
+        runner = MagicMock()
+        return ClaudeChatCog(
+            bot=bot,
+            repo=repo,
+            runner=runner,
+            backend_settings=settings,
+            conversation_history=history,
+        )
+
+    async def test_mismatch_injects_file_transcript_and_starts_new_native_session(self) -> None:
+        cog = self._cog(
+            self._record(backend="claude"),
+            current_backend="codex",
+            transcript="User:\nold\n\nAssistant:\ndone",
+        )
+
+        session_id, prompt = await cog._prepare_cross_backend_handoff(
+            self._thread(),
+            "continue please",
+            None,
+        )
+
+        assert session_id is None
+        assert "Claude → Codex" in prompt
+        assert "Assistant:\ndone" in prompt
+        assert prompt.endswith("Current user message:\ncontinue please")
+        cog._conversation_history.read.assert_called_once_with(
+            "claude", "aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb"
+        )
+
+    async def test_missing_file_degrades_to_fresh_session_with_original_prompt(self) -> None:
+        cog = self._cog(
+            self._record(backend="codex"),
+            current_backend="claude",
+            transcript="",
+        )
+
+        session_id, prompt = await cog._prepare_cross_backend_handoff(
+            self._thread(),
+            "current",
+            None,
+        )
+
+        assert session_id is None
+        assert prompt == "current"
+
+    async def test_same_backend_keeps_native_resume_without_reading_file(self) -> None:
+        record = self._record(backend="claude")
+        cog = self._cog(record, current_backend="claude", transcript="unused")
+
+        session_id, prompt = await cog._prepare_cross_backend_handoff(
+            self._thread(),
+            "current",
+            record.session_id,
+        )
+
+        assert session_id == record.session_id
+        assert prompt == "current"
+        cog._conversation_history.read.assert_not_called()

--- a/tests/test_cross_backend_handoff.py
+++ b/tests/test_cross_backend_handoff.py
@@ -1,0 +1,139 @@
+"""Cross-backend conversation history handoff tests."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from claude_discord.cross_backend_handoff import (
+    ConversationHistoryReader,
+    build_handoff_prompt,
+)
+
+
+def _write_jsonl(path: Path, records: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "".join(json.dumps(record, ensure_ascii=False) + "\n" for record in records),
+        encoding="utf-8",
+    )
+
+
+class TestConversationHistoryReader:
+    def test_reads_claude_user_and_assistant_text_only(self, tmp_path: Path) -> None:
+        session_id = "aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb"
+        _write_jsonl(
+            tmp_path / "project" / f"{session_id}.jsonl",
+            [
+                {"type": "user", "isMeta": True, "message": {"content": "internal"}},
+                {"type": "user", "message": {"content": "最初の質問"}},
+                {
+                    "type": "assistant",
+                    "message": {
+                        "content": [
+                            {"type": "thinking", "thinking": "secret reasoning"},
+                            {"type": "text", "text": "最初の回答"},
+                            {"type": "tool_use", "name": "Bash"},
+                        ]
+                    },
+                },
+                {
+                    "type": "user",
+                    "message": {"content": [{"type": "tool_result", "content": "noise"}]},
+                },
+                # An unanswered tail is excluded: the current Discord message is
+                # supplied separately and must not be duplicated.
+                {"type": "user", "message": {"content": "未回答の末尾"}},
+            ],
+        )
+
+        reader = ConversationHistoryReader(claude_sessions_root=tmp_path)
+
+        transcript = reader.read("claude", session_id)
+
+        assert transcript == "User:\n最初の質問\n\nAssistant:\n最初の回答"
+        assert "internal" not in transcript
+        assert "secret reasoning" not in transcript
+        assert "noise" not in transcript
+        assert "未回答の末尾" not in transcript
+
+    def test_reads_codex_event_messages_only(self, tmp_path: Path) -> None:
+        session_id = "cccccccc-1111-2222-3333-dddddddddddd"
+        rollout = (
+            tmp_path
+            / "sessions"
+            / "2026"
+            / "08"
+            / "05"
+            / (f"rollout-2026-08-05T12-00-00-{session_id}.jsonl")
+        )
+        _write_jsonl(
+            rollout,
+            [
+                {
+                    "type": "response_item",
+                    "payload": {"type": "message", "role": "developer", "content": "ignore"},
+                },
+                {"type": "event_msg", "payload": {"type": "user_message", "message": "依頼"}},
+                {
+                    "type": "event_msg",
+                    "payload": {"type": "agent_message", "message": "対応したよ"},
+                },
+                {
+                    "type": "event_msg",
+                    "payload": {"type": "token_count", "message": "ignore"},
+                },
+            ],
+        )
+
+        reader = ConversationHistoryReader(codex_home=tmp_path)
+
+        assert reader.read("codex", session_id) == "User:\n依頼\n\nAssistant:\n対応したよ"
+
+    def test_rejects_invalid_session_id_before_path_lookup(self, tmp_path: Path) -> None:
+        reader = ConversationHistoryReader(
+            claude_sessions_root=tmp_path,
+            codex_home=tmp_path,
+        )
+
+        assert reader.read("claude", "../../etc/passwd") == ""
+        assert reader.read("codex", "not valid") == ""
+
+    def test_bounds_message_and_total_transcript_size(self, tmp_path: Path) -> None:
+        session_id = "eeeeeeee-1111-2222-3333-ffffffffffff"
+        records: list[dict] = []
+        for number in range(20):
+            role = "user" if number % 2 == 0 else "assistant"
+            records.append(
+                {"type": role, "message": {"content": f"message-{number}-" + ("x" * 200)}}
+            )
+        _write_jsonl(tmp_path / f"{session_id}.jsonl", records)
+        reader = ConversationHistoryReader(
+            claude_sessions_root=tmp_path,
+            max_messages=4,
+            max_message_chars=40,
+            max_transcript_chars=140,
+        )
+
+        transcript = reader.read("claude", session_id)
+
+        assert "message-16" in transcript
+        assert "message-19" in transcript
+        assert "message-15" not in transcript
+        assert len(transcript) <= 140
+
+
+def test_build_handoff_prompt_marks_history_and_current_message() -> None:
+    prompt = build_handoff_prompt(
+        source_backend="claude",
+        target_backend="codex",
+        transcript="User:\nold question\n\nAssistant:\nold answer",
+        current_prompt="new question",
+    )
+
+    assert "Claude" in prompt
+    assert "Codex" in prompt
+    assert "old question" in prompt
+    assert "old answer" in prompt
+    assert prompt.endswith("Current user message:\nnew question")
+    assert "do not repeat completed work" in prompt


### PR DESCRIPTION
## Summary

- preserve the source session mapping when /backend changes a live thread
- parse bounded user/assistant text directly from Claude and Codex local JSONL stores
- inject that transcript into the first turn of a fresh native target-backend session
- omit system/developer prompts, hidden reasoning, tools, and image payloads
- degrade to a fresh session when the source JSONL is unavailable

Closes #568

## Validation

- full suite: 2016 passed
- ruff check and format check passed
- pyright passed
- Bandit: no high-severity findings; no new findings in the handoff module