### PR TITLE
docs: adopt Ebi Agent Chat Relay naming strategy (#571)

### DIFF
--- a/docs/DESIGN_DECISIONS.md
+++ b/docs/DESIGN_DECISIONS.md
@@ -2,6 +2,11 @@
 
 This document captures the "why" behind key architectural choices. Each decision includes the alternatives considered and the reasoning for the chosen approach.
 
+Repository-level product and architecture decisions that need an immutable history live
+in the [Architecture Decision Records](adr/_index.md). The first record adopts
+**Ebi Agent Chat Relay** as the product name and links its compatibility-first
+[phased rename plan](RENAME_PLAN.md).
+
 ## 1. CLI Subprocess, Not Direct API
 
 **Decision:** Invoke `claude -p --output-format stream-json` as a subprocess rather than calling the Anthropic API directly.

--- a/docs/RENAME_PLAN.md
+++ b/docs/RENAME_PLAN.md
@@ -1,0 +1,150 @@
+# Ebi Agent Chat Relay: Phased Rename Plan
+
+This plan implements [ADR-0001](adr/0001-adopt-ebi-agent-chat-relay.md) without a
+big-bang rename. Every phase is independently releasable and reversible.
+
+## Invariants
+
+The following rules apply to every phase:
+
+1. Existing installations must keep starting with their current configuration.
+2. The `ccdb` CLI command remains supported.
+3. Existing `CCDB_*` environment variables, REST routes, persisted database paths,
+   attachment filenames, and Python imports remain valid.
+4. A new identifier is additive before any old identifier is deprecated.
+5. No old identifier is removed without a separate accepted ADR and a major release.
+6. Branding changes do not authorize a bot restart or deployment migration.
+
+## Phase 0 — Record the decision
+
+**Scope**
+
+- Add ADR-0001 and this plan.
+- Keep all runtime, packaging, repository, and service identifiers unchanged.
+
+**Exit gate**
+
+- Documentation links are valid.
+- The repository test and documentation checks remain green.
+
+**Rollback**
+
+- Revert the documentation PR. Runtime is unaffected.
+
+## Phase 1 — Introduce the product brand
+
+**Scope**
+
+- Use **Ebi Agent Chat Relay** in the primary README, website, screenshots, and release
+  notes.
+- On first mention, write “Ebi Agent Chat Relay (formerly Claude Code Discord Bridge;
+  `ccdb`)”.
+- Update translated documentation through the existing documentation-sync workflow.
+
+**Compatibility gate**
+
+- Installation and command examples continue to use identifiers that actually exist.
+- Search for the old product name and classify every occurrence as compatibility,
+  history, translation, or stale branding before changing it.
+
+**Rollback**
+
+- Revert brand-only documentation and assets. No code or persisted data changes.
+
+## Phase 2 — Add external artifact aliases
+
+**Scope**
+
+- Recheck GitHub and package-index availability immediately before acting.
+- If the repository is renamed, verify GitHub redirects for clones, issues, releases,
+  Actions, and raw documentation links.
+- If a new `ebi-agent-chat-relay` distribution is published, make it install the same
+  implementation while the existing distribution remains available.
+- Keep the Python import package unchanged initially.
+
+**Compatibility gate**
+
+- A clean environment can install using both the legacy and new distribution names.
+- Existing lockfiles can update without manual source edits.
+- Git fetch, release automation, dependency graph updates, and documentation sync pass
+  through the repository redirect.
+
+**Rollback**
+
+- Restore the prior repository name or stop advertising the new distribution.
+- Keep the legacy artifact as the canonical installation path until failures are fixed.
+
+## Phase 3 — Add command and configuration aliases
+
+**Scope**
+
+- Choose any new CLI command in a separate decision; do not infer one from the product
+  initials.
+- If added, route the new command and `ccdb` to the same entry point.
+- Add new environment-variable aliases only with explicit precedence rules and conflict
+  warnings.
+- Continue writing existing data paths unless a migration design proves dual-version
+  rollback safety.
+
+**Compatibility gate**
+
+- Contract tests run the same setup, start, and control-plane flows through both command
+  names.
+- Tests cover legacy-only, new-only, equal dual configuration, and conflicting dual
+  configuration.
+- Upgrade and rollback tests use a copy of a real legacy data directory.
+
+**Rollback**
+
+- Stop advertising the new aliases while retaining them in code.
+- Prefer legacy configuration when rollback behavior is ambiguous.
+
+## Phase 4 — Rename internal implementation symbols selectively
+
+**Scope**
+
+- Rename internal symbols only where the old name materially harms maintainability.
+- Keep compatibility imports or wrappers for public Python APIs.
+- Migrate one namespace at a time: imports, environment, files, API, and service names
+  must never move in one release.
+
+**Compatibility gate**
+
+- Public API and import contract tests pass for both names.
+- Database migration tests prove forward upgrade and rollback.
+- EbiBot and at least one clean reference deployment pass real end-to-end checks.
+
+**Rollback**
+
+- Restore the previous internal implementation behind the compatibility facade.
+- Do not delete migrated data until the rollback window has closed.
+
+## Phase 5 — Consider legacy retirement
+
+This phase is not authorized by ADR-0001.
+
+Removing `ccdb` or another legacy identifier requires:
+
+- a separate accepted ADR;
+- a major-version release;
+- a published deprecation window;
+- evidence that maintained consumers have migrated;
+- explicit data backup and rollback procedures.
+
+The valid outcome may be to retain small aliases permanently when their maintenance cost
+is lower than the migration risk.
+
+## Pull request boundaries
+
+Keep review and rollback small:
+
+1. ADR and plan only.
+2. Brand documentation and assets.
+3. Repository rename and redirect verification.
+4. Distribution alias.
+5. CLI alias.
+6. Configuration aliases.
+7. Any internal or persisted identifier, one namespace per PR.
+
+Do not combine deployment topology, Teams implementation, or customer tenant changes
+with a rename phase.

--- a/docs/adr/0001-adopt-ebi-agent-chat-relay.md
+++ b/docs/adr/0001-adopt-ebi-agent-chat-relay.md
@@ -1,0 +1,116 @@
+---
+type: adr
+id: ADR-0001
+title: Adopt Ebi Agent Chat Relay as the product name
+decision: Use Ebi Agent Chat Relay as the product name and retain ccdb as a compatibility alias during a phased migration.
+status: accepted
+date: 2026-08-05
+deciders: [Masahiko Ebi, Claude Code]
+scope: repository
+supersedes:
+superseded_by:
+---
+
+# ADR-0001: Adopt Ebi Agent Chat Relay as the product name
+
+## Context
+
+The original name, **Claude Code Discord Bridge**, accurately described the first
+implementation but no longer describes the product boundary:
+
+- the runtime supports both Claude Code and OpenAI Codex;
+- the frontend abstraction is intended to support Discord, Teams, and later surfaces;
+- its distinguishing behavior is relaying interactive agent sessions while sharing a
+  coordination ledger that lets parallel sessions detect collisions;
+- deployment may be shared, customer-dedicated, or customer-hosted.
+
+The existing short name, `ccdb`, is widely embedded in commands, environment variables,
+database and attachment paths, API examples, service names, and operational habits. A
+big-bang rename would create migration risk without improving runtime behavior.
+
+## Options considered
+
+### Keep Claude Code Discord Bridge
+
+Rejected as the product name because it hard-codes both one backend and one surface.
+Keeping it would make Teams and additional agent backends look incidental.
+
+### Agent Bridge
+
+Rejected because the words are generic and crowded. The name is difficult to search for
+and does not express the conversational relay behavior.
+
+### Session Bridge
+
+Rejected because it is architecturally accurate but unclear to people discovering the
+product. It describes an implementation concept rather than the user-facing job.
+
+### CodeRelay
+
+Rejected because it is memorable but narrows the product to code even though sessions
+also handle operations, research, documents, scheduling, and other agent work.
+
+### Ebi Agent Chat Relay
+
+Accepted because it is distinctive, backend-neutral, surface-neutral, and describes the
+observable job: relaying agent conversations and their work across chat surfaces.
+
+## Decision
+
+1. The product name is **Ebi Agent Chat Relay**.
+2. `ebi-agent-chat-relay` is the candidate repository and Python distribution name.
+   Availability must be checked again immediately before either external rename or
+   publication.
+3. `ccdb` remains a supported migration alias.
+4. The migration is additive and phased. No release may rename every public identifier
+   at once.
+5. Existing public identifiers—including the `ccdb` command, `CCDB_*` environment
+   variables, API routes, persisted data locations, and Python import paths—remain
+   supported until a separate removal ADR approves a major-version transition.
+
+The implementation sequence and compatibility gates are defined in the
+[phased rename plan](../RENAME_PLAN.md).
+
+## Rationale
+
+The chosen name separates the stable product concept from replaceable technical details.
+It remains accurate when a customer chooses Discord or Teams, Claude or Codex, and a
+shared or isolated deployment.
+
+An additive migration protects existing installations and automation. The old name is
+not merely documentation: it is part of scripts, configuration, service management, and
+stored paths. Treating those identifiers as compatibility contracts lets branding move
+without turning a naming decision into an outage.
+
+## Consequences and trade-offs
+
+### Positive
+
+- The name remains accurate as backends and chat surfaces expand.
+- Searchability and ownership are stronger than with generic “bridge” names.
+- Existing users can upgrade without an immediate configuration or data migration.
+- Each migration phase has an independent rollback point.
+
+### Negative
+
+- Documentation and support will carry two names during the transition.
+- Some legacy identifiers may remain indefinitely.
+- Publishing or renaming external artifacts requires additional availability,
+  redirect, packaging, and consumer verification.
+
+## Non-goals
+
+This ADR does not:
+
+- rename the repository, package, CLI, import module, environment variables, API routes,
+  service, or data paths now;
+- choose a replacement command for `ccdb`;
+- change deployment topology or customer isolation policy;
+- implement the Teams surface;
+- authorize a service restart.
+
+## Related
+
+- [Phased rename plan](../RENAME_PLAN.md)
+- [Design decisions](../DESIGN_DECISIONS.md)
+- [Issue #571](https://github.com/ebibibi/claude-code-discord-bridge/issues/571)

--- a/docs/adr/_index.md
+++ b/docs/adr/_index.md
@@ -1,0 +1,9 @@
+# Architecture Decision Records
+
+This directory is the canonical history of repository-specific architectural and
+product decisions. ADRs are immutable once accepted: a later decision supersedes an
+earlier ADR instead of rewriting its history.
+
+## Records
+
+- [ADR-0001: Adopt Ebi Agent Chat Relay as the product name](0001-adopt-ebi-agent-chat-relay.md)


### PR DESCRIPTION
## Summary

- records **Ebi Agent Chat Relay** as the product name while retaining `ccdb` as a compatibility alias
- documents the rejected naming alternatives and why a big-bang rename is unsafe
- defines five independently reversible migration phases and explicit compatibility gates
- links the new ADR index from the existing design decisions document

## Compatibility policy

- no runtime or deployment changes in this PR
- no repository, distribution, CLI, import, environment, API, service, or data-path rename
- legacy identifiers remain supported until a separate ADR approves a major-version removal

## Verification

- `2019 passed`
- 84% coverage
- ruff clean
- pyright: 0 errors
- import check passed
- documentation diff check passed

Closes #571
