### PR TITLE
fix: ignore intentional Codex interrupt exits

### DIFF
--- a/claude_code_core/codex_runner.py
+++ b/claude_code_core/codex_runner.py
@@ -288,6 +288,7 @@ class CodexRunner:
         self.append_system_prompt = append_system_prompt
         self.images = images
         self._process: asyncio.subprocess.Process | None = None
+        self._interrupt_requested = False
 
     async def run(
         self,
@@ -300,6 +301,7 @@ class CodexRunner:
         retried_without_resume = False
 
         while True:
+            self._interrupt_requested = False
             args = self._build_args(attempt_prompt, attempt_session_id)
             env = self._build_env()
             cwd = self.working_dir or os.getcwd()
@@ -409,6 +411,7 @@ class CodexRunner:
     async def interrupt(self) -> None:
         """Interrupt the subprocess with SIGINT."""
         if self._process and self._process.returncode is None:
+            self._interrupt_requested = True
             if os.name == "nt":
                 self._process.terminate()
             else:
@@ -555,6 +558,12 @@ class CodexRunner:
             await asyncio.wait_for(self._process.wait(), timeout=10)
 
         if self._process.returncode is not None and self._process.returncode > 0:
+            if self._interrupt_requested:
+                logger.info(
+                    "Codex CLI exited with code %d after an intentional interrupt",
+                    self._process.returncode,
+                )
+                return
             stderr_data = b""
             if self._process.stderr:
                 stderr_data = await self._process.stderr.read()

--- a/tests/test_codex_runner.py
+++ b/tests/test_codex_runner.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -51,6 +52,32 @@ class _FakeProcess:
 
     def kill(self) -> None:
         self.returncode = -9
+
+
+class _InterruptibleStream:
+    def __init__(self, interrupted: asyncio.Event) -> None:
+        self._interrupted = interrupted
+
+    async def readline(self) -> bytes:
+        await self._interrupted.wait()
+        return b""
+
+
+class _InterruptibleProcess(_FakeProcess):
+    def __init__(self) -> None:
+        super().__init__(returncode=0)
+        self.returncode = None
+        self.interrupted = asyncio.Event()
+        self.stdout = _InterruptibleStream(self.interrupted)
+
+    async def wait(self) -> int:
+        await self.interrupted.wait()
+        assert self.returncode is not None
+        return self.returncode
+
+    def send_signal(self, _signum: int) -> None:
+        self.returncode = 1
+        self.interrupted.set()
 
 
 class TestCodexRunnerIsBackend:
@@ -221,6 +248,34 @@ class TestCodexRunnerClone:
 
 
 class TestCodexRunnerRun:
+    @pytest.mark.asyncio
+    async def test_intentional_interrupt_is_not_reported_as_cli_error(
+        self, monkeypatch, caplog
+    ) -> None:
+        process = _InterruptibleProcess()
+        process_started = asyncio.Event()
+
+        async def fake_create_subprocess_exec(*args, **kwargs):
+            process_started.set()
+            return process
+
+        monkeypatch.setattr(
+            "claude_code_core.codex_runner.asyncio.create_subprocess_exec",
+            fake_create_subprocess_exec,
+        )
+        runner = CodexRunner(command="codex")
+
+        async def collect_events() -> list:
+            return [event async for event in runner.run("hello")]
+
+        run_task = asyncio.create_task(collect_events())
+        await process_started.wait()
+        await runner.interrupt()
+        events = await run_task
+
+        assert events == []
+        assert "Codex CLI exited with code 1" not in caplog.text
+
     @pytest.mark.asyncio
     async def test_resume_missing_rollout_falls_back_to_new_session(self, monkeypatch) -> None:
         stale_session = "13f2eb43-93cf-4df6-86d0-a20c035cc26e"


### PR DESCRIPTION
## Summary

- track interrupts requested through `CodexRunner.interrupt()`
- treat the resulting non-zero Codex CLI exit as expected control flow
- preserve error reporting for unexpected non-zero exits
- add an async regression test that exercises the real interrupt/run interaction

Closes #573

## Verification

- `uv run pytest tests/test_codex_runner.py -q` — 54 passed
- `env -u CCDB_API_URL timeout 900 uv run pytest tests/ -x -q` — passed
- `uv run ruff check claude_discord/ claude_code_core/ tests/test_codex_runner.py`
- `uv run ruff format --check claude_discord/ claude_code_core/ tests/test_codex_runner.py`
- `uv run pyright claude_discord/ claude_code_core/`

## Security

No subprocess arguments, prompt handling, session validation, or environment-secret handling changed.