### PR TITLE
feat: standard reminders (/remind + conditional checks) and cross-platform CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,8 +84,10 @@ jobs:
       # question only: does the suite still pass off Linux?
       # Per-test timeout because the first Windows run hung: without it a
       # blocked test looks like a slow runner and reports nothing at all.
+      # pytest-timeout kills the process on Windows, so a hang costs the rest of
+      # the run — that is the trade for ever learning the hanging test's name.
       - name: Test
-        run: uv run pytest tests/ -v --timeout=60 --timeout-method=thread
+        run: uv run pytest tests/ -q --timeout=120 --timeout-method=thread
         env:
           HOME: ${{ runner.temp }}/fakehome
           USERPROFILE: ${{ runner.temp }}/fakehome

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,8 @@ jobs:
   # the self-hosted fleet is Linux-only; free for a public repository.
   cross-platform:
     runs-on: ${{ matrix.os }}
+    # A hung test must fail, not sit for six hours on a hosted runner.
+    timeout-minutes: 25
     strategy:
       fail-fast: false
       matrix:
@@ -80,8 +82,10 @@ jobs:
 
       # No coverage gate here — the Linux job owns that. This job answers one
       # question only: does the suite still pass off Linux?
+      # Per-test timeout because the first Windows run hung: without it a
+      # blocked test looks like a slow runner and reports nothing at all.
       - name: Test
-        run: uv run pytest tests/ -q
+        run: uv run pytest tests/ -q --timeout=120 --timeout-method=thread
         env:
           HOME: ${{ runner.temp }}/fakehome
           USERPROFILE: ${{ runner.temp }}/fakehome

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
       # Per-test timeout because the first Windows run hung: without it a
       # blocked test looks like a slow runner and reports nothing at all.
       - name: Test
-        run: uv run pytest tests/ -q --timeout=120 --timeout-method=thread
+        run: uv run pytest tests/ -v --timeout=60 --timeout-method=thread
         env:
           HOME: ${{ runner.temp }}/fakehome
           USERPROFILE: ${{ runner.temp }}/fakehome

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,8 +51,43 @@ jobs:
         env:
           HOME: ${{ runner.temp }}/fakehome
 
+  # The README claims macOS and Windows support. This job is what makes that
+  # claim checkable: the package ships sys.platform branches (signal handling,
+  # .cmd/.bat resolution) that no Linux run can exercise. Hosted runners, since
+  # the self-hosted fleet is Linux-only; free for a public repository.
+  cross-platform:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: uv sync --dev
+
+      # No coverage gate here — the Linux job owns that. This job answers one
+      # question only: does the suite still pass off Linux?
+      - name: Test
+        run: uv run pytest tests/ -q
+        env:
+          HOME: ${{ runner.temp }}/fakehome
+          USERPROFILE: ${{ runner.temp }}/fakehome
+
   notify-failure:
-    needs: [test]
+    needs: [test, cross-platform]
     if: failure()
     runs-on: [self-hosted, linux, x64]
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,8 +37,9 @@ Discord frontend for Claude Code CLI. **This is a framework (OSS library), not a
 7. **REST API as the control plane**: Claude Code subprocesses communicate back to ccdb via REST API (`CCDB_API_URL` env var), not via stdout markers or special output formats. This makes the interface explicit, testable, and usable by external systems (GitHub Actions, etc.). See `ext/api_server.py`.
 8. **SQLite-backed dynamic scheduler**: Scheduled tasks are stored in `scheduled_tasks` DB table and executed by a single `discord.ext.tasks` master loop (every 30s). Tasks are registered at runtime via REST API — no code changes needed to add new tasks. `discord.ext.tasks` decorators are only used for the master loop, not per-task (they're static/compile-time constructs).
 9. **Claude handles "what", ccdb handles "when"**: For scheduled tasks, ccdb only manages the schedule. All domain logic (what to check, how to deduplicate, what to post) lives in the Claude prompt. No GitHub/AzureDevOps-specific code in ccdb itself.
-10. **CLI env overlay** (`CCDB_CLI_ENV_FILE`): Optional `KEY=VALUE` file read on every CLI spawn to inject env vars into the subprocess. Enables live configuration changes (e.g., switching to Azure Foundry) without restarting the bot. The file is read by `_build_env()` in `runner.py`.
-11. **Model suggestions are discovered, not hardcoded** (`model_catalog.py`): the `/model` autocomplete asks `GET /v1/models` (reusing the CLI's own credentials) instead of shipping a constant that goes stale on every model launch. This is the *only* sanctioned direct Anthropic API call, and it is strictly non-essential: no credentials, no network, a 3P provider, or `CCDB_MODEL_DISCOVERY=0` all degrade to the static `SUGGESTED_MODELS` fallback. Never let it raise into a command path, and never log the token.
+10. **Reminders are two mechanisms behind one command** (`cogs/reminder.py`): an unconditional reminder is a row in `scheduled_notifications` — one Discord message, no agent. A *conditional* one ("only if it is still not done") is a `scheduled_tasks` row whose prompt tells the session to verify first and stay silent when satisfied. Picking the cheap path for the cheap case is the point; do not "simplify" by spawning a session for every reminder. The same Cog owns the notification send loop, because `POST /api/schedule` without a drain loop in the framework is a black hole that silently swallows reminders.
+11. **CLI env overlay** (`CCDB_CLI_ENV_FILE`): Optional `KEY=VALUE` file read on every CLI spawn to inject env vars into the subprocess. Enables live configuration changes (e.g., switching to Azure Foundry) without restarting the bot. The file is read by `_build_env()` in `runner.py`.
+12. **Model suggestions are discovered, not hardcoded** (`model_catalog.py`): the `/model` autocomplete asks `GET /v1/models` (reusing the CLI's own credentials) instead of shipping a constant that goes stale on every model launch. This is the *only* sanctioned direct Anthropic API call, and it is strictly non-essential: no credentials, no network, a 3P provider, or `CCDB_MODEL_DISCOVERY=0` all degrade to the static `SUGGESTED_MODELS` fallback. Never let it raise into a command path, and never log the token.
 
 ### Why REST API over stdout markers for Claude→ccdb communication
 
@@ -64,7 +65,9 @@ uv sync --dev
 uv run pytest tests/ -v --cov=claude_discord
 ```
 
-All tests must pass before submitting a PR. CI runs on Python 3.12 and 3.13.
+All tests must pass before submitting a PR. CI runs the suite on Python 3.12 and 3.13 on
+Linux, plus a `cross-platform` job on macOS and Windows (hosted runners) that guards the
+`sys.platform` branches — a change that only works on Linux fails there, not in a user's issue.
 
 ### Linting & Formatting
 
@@ -205,6 +208,7 @@ claude_discord/          # Installable Python package
   bot.py                 # Discord Bot class
   protocols.py           # Shared protocols (DrainAware)
   concurrency.py         # Worktree instructions + active session registry
+  reminders.py           # Reminder time parsing + prompt templates (pure)
   lounge.py              # AI Lounge prompt builder
   session_sync.py        # CLI session discovery and import
   worktree.py            # WorktreeManager — safe git worktree lifecycle
@@ -217,6 +221,7 @@ claude_discord/          # Installable Python package
     webhook_trigger.py   # Webhook → Claude Code task execution (CI/CD)
     auto_upgrade.py      # Webhook → package upgrade + drain-aware restart
     scheduler.py         # Scheduled task executor (SQLite-backed, master loop)
+    reminder.py          # /remind, /reminders, and the notification send loop
     event_processor.py   # EventProcessor — state machine for stream-json events
     run_config.py        # RunConfig dataclass — bundles all CLI execution params
     _run_helper.py       # Thin orchestration layer (run_claude_with_config)
@@ -348,6 +353,6 @@ Project-specific skills that help AI agents work effectively on this codebase:
 
 - Personal bot configuration (tokens, channel IDs, user IDs)
 - Server-specific Cogs or workflows
-- Direct Anthropic API calls (we use Claude Code CLI, not the API). Sole exception: the read-only model lookup in `model_catalog.py`, because the CLI can't enumerate models — see Key Design Decision 11 for the rules it has to obey
+- Direct Anthropic API calls (we use Claude Code CLI, not the API). Sole exception: the read-only model lookup in `model_catalog.py`, because the CLI can't enumerate models — see Key Design Decision 12 for the rules it has to obey
 - Heavy dependencies that most users won't need
 - Anything that requires secrets to import the package

--- a/README.md
+++ b/README.md
@@ -430,6 +430,13 @@ Behind the scenes:
 - **Self-registration** — Claude registers tasks via `POST /api/tasks` during a chat session
 - **No code changes** — Add, remove, or modify tasks at runtime
 - **Enable/disable** — Pause tasks without deleting them (`PATCH /api/tasks/{id}`)
+- **Absolute and expiring schedules** — `run_at` fires once at a given instant (`"21:30"`, `"2h"`, ISO 8601); `until` retires a repeating task on its own instead of relying on someone to remember
+
+### Reminders
+- **`/remind`** — "remind me at 21:30", and optionally *only if it is still not done*
+- **Conditional reminders** — pass `check` and a real session verifies the condition first, then stays silent when the thing is already done. No new bot code per reminder: the condition is a sentence, not a plugin
+- **Cheapest mechanism that fits** — an unconditional reminder is delivered as a notification (one Discord message, no agent run); a conditional one spawns a session because it needs judgement
+- **`/reminders`** — list what is still pending, both kinds
 
 ### CI/CD Automation
 - **Webhook triggers** — Trigger Claude Code tasks from GitHub Actions or any CI/CD system
@@ -479,7 +486,7 @@ Behind the scenes:
   - [OpenAI Codex CLI](https://github.com/openai/codex) — `npm install -g @openai/codex` then `codex login`. Uses your existing ChatGPT Plus/Pro/Business subscription.
 - You can install both. Switch between them at runtime with `/backend` (see [Backend Switching](#backend-switching--claude--codex-on-demand)).
 
-**Platform support:** Primarily developed and tested on **Linux**. macOS and Windows are supported and pass CI, but receive less real-world testing — bug reports welcome.
+**Platform support:** Primarily developed and tested on **Linux**. CI runs the full test suite on Linux (Python 3.12 and 3.13), macOS, and Windows, so the platform branches in the package stay honest — but macOS and Windows receive far less real-world testing, and bug reports are welcome.
 
 ### Step 1 — Create a Discord Bot (one-time, ~2 minutes)
 
@@ -1006,6 +1013,33 @@ curl -X POST http://localhost:8080/api/tasks \
 
 The 30-second master loop picks up due tasks and spawns Claude Code sessions automatically.
 
+### One-shot and self-retiring tasks
+
+`interval_seconds` alone can only say "every N seconds". Three fields cover the
+rest, and reminders are built entirely out of them:
+
+| Field | Meaning |
+|-------|---------|
+| `run_at` | First run at an absolute instant — `"21:30"` (next occurrence), `"2h"`, or ISO 8601 |
+| `until` | Stop after this — `"2026-08-08"` (covers that whole day) or `"2d"`. The task is disabled, not deleted, so it can still explain itself |
+| `one_shot` | Disable after a single run |
+
+```bash
+# Wake me up in this thread tonight, once, and never again:
+curl -X POST "$CCDB_API_URL/api/tasks" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "remind-1234-idr", "prompt": "Check whether the survey went out; if not, say so", \
+       "interval_seconds": 86400, "thread_id": 1234, "run_at": "21:30", "one_shot": true}'
+```
+
+`thread_id` posts into an existing thread instead of creating one, and makes
+`channel_id` optional. A session that satisfies its own reminder retires it with
+`DELETE /api/tasks/by-name/{name}` — it knows its name, never its row id.
+
+Every session is told this mechanism exists as part of its system context, so
+"I'll check back later" becomes a registered task rather than a promise nothing
+can keep.
+
 ---
 
 ## Auto-Upgrade
@@ -1073,6 +1107,7 @@ uv add "claude-code-discord-bridge[api]"
 | POST | `/api/tasks` | Register a scheduled Claude Code task |
 | GET | `/api/tasks` | List registered tasks |
 | DELETE | `/api/tasks/{id}` | Remove a task |
+| DELETE | `/api/tasks/by-name/{name}` | Remove a task by name (how a scheduled session retires itself) |
 | PATCH | `/api/tasks/{id}` | Update a task (enable/disable, change schedule) |
 | POST | `/api/spawn` | Create a new Discord thread and start a Claude Code session (non-blocking); pass `auto_start: false` to defer Claude until the first user reply |
 | POST | `/api/ingest` | Authenticated external spawn (browser extension / webhook) with base64 attachments; returns a `result_id` when result retrieval is configured |

--- a/claude_code_core/rewind.py
+++ b/claude_code_core/rewind.py
@@ -79,7 +79,7 @@ def parse_user_turns(jsonl_path: Path, *, max_turns: int = 25) -> list[TurnEntry
     chronological order so the select menu reads oldest-to-newest.
     """
     try:
-        with open(jsonl_path) as f:
+        with open(jsonl_path, encoding="utf-8") as f:
             lines = f.readlines()
     except OSError:
         logger.warning("Cannot read JSONL for rewind: %s", jsonl_path)
@@ -126,9 +126,9 @@ def truncate_jsonl_at_line(jsonl_path: Path, line_index: int) -> bool:
     Returns ``True`` on success, ``False`` on I/O error.
     """
     try:
-        with open(jsonl_path) as f:
+        with open(jsonl_path, encoding="utf-8") as f:
             lines = f.readlines()
-        with open(jsonl_path, "w") as f:
+        with open(jsonl_path, "w", encoding="utf-8") as f:
             f.writelines(lines[:line_index])
         logger.info(
             "Rewound JSONL %s: truncated %d -> %d lines",

--- a/claude_code_core/runner.py
+++ b/claude_code_core/runner.py
@@ -345,7 +345,7 @@ class ClaudeRunner:
         overlay_path = os.environ.get("CCDB_CLI_ENV_FILE")
         if overlay_path:
             try:
-                for line in Path(overlay_path).read_text().splitlines():
+                for line in Path(overlay_path).read_text(encoding="utf-8").splitlines():
                     line = line.strip()
                     if line and not line.startswith("#") and "=" in line:
                         key, value = line.split("=", 1)

--- a/claude_discord/__init__.py
+++ b/claude_discord/__init__.py
@@ -17,6 +17,7 @@ from .cogs.claude_chat import ClaudeChatCog
 from .cogs.collision_watch import CollisionWatchCog
 from .cogs.context_links import ContextLinksCog
 from .cogs.event_processor import EventProcessor
+from .cogs.reminder import ReminderCog
 from .cogs.run_config import RunConfig
 from .cogs.scheduler import SchedulerCog
 from .cogs.session_manage import SessionManageCog
@@ -67,6 +68,7 @@ __all__ = [
     "AutoUpgradeCog",
     "UpgradeConfig",
     # Scheduling
+    "ReminderCog",
     "SchedulerCog",
     "ScheduledTaskRepository",
     "DrainAware",

--- a/claude_discord/cogs/__init__.py
+++ b/claude_discord/cogs/__init__.py
@@ -5,6 +5,7 @@ from .claude_chat import ClaudeChatCog
 from .collision_watch import CollisionWatchCog
 from .context_links import ContextLinksCog
 from .event_processor import EventProcessor
+from .reminder import ReminderCog
 from .run_config import RunConfig
 from .scheduler import SchedulerCog
 from .session_manage import SessionManageCog
@@ -18,6 +19,7 @@ __all__ = [
     "ContextLinksCog",
     "EventProcessor",
     "RunConfig",
+    "ReminderCog",
     "SchedulerCog",
     "SessionManageCog",
     "SkillCommandCog",

--- a/claude_discord/cogs/_run_helper.py
+++ b/claude_discord/cogs/_run_helper.py
@@ -183,6 +183,12 @@ async def _build_system_context(config: RunConfig) -> str | None:
         "asked to receive."
     )
 
+    # Scheduling: sessions kept rebuilding this with host cron because nothing
+    # told them ccdb can wake them up. It is four lines; the confusion was not.
+    from ..reminders import build_scheduling_notice
+
+    parts.append(build_scheduling_notice(config.thread.id))
+
     # Post-compact guardrail: prevent auto-execution of "pending tasks" from summary.
     if config.post_compact_rerun:
         parts.append(_POST_COMPACT_GUARDRAIL)

--- a/claude_discord/cogs/claude_chat.py
+++ b/claude_discord/cogs/claude_chat.py
@@ -87,10 +87,18 @@ _HELP_CATEGORY: dict[str, str | None] = {
     "worktree-list": "🔧 Advanced",
     "worktree-cleanup": "🔧 Advanced",
     "upgrade": "🔧 Advanced",
+    "remind": "⏰ Reminders",
+    "reminders": "⏰ Reminders",
 }
 
 # Section display order in the embed.
-_HELP_SECTION_ORDER: list[str] = ["📌 Session", "🤖 Model", "⚡ Effort", "🔧 Advanced"]
+_HELP_SECTION_ORDER: list[str] = [
+    "📌 Session",
+    "🤖 Model",
+    "⚡ Effort",
+    "⏰ Reminders",
+    "🔧 Advanced",
+]
 
 
 class ClaudeChatCog(commands.Cog):

--- a/claude_discord/cogs/reminder.py
+++ b/claude_discord/cogs/reminder.py
@@ -1,0 +1,331 @@
+"""ReminderCog — ``/remind``, ``/reminders``, and the notification send loop.
+
+Two jobs, one Cog, because they are the two halves of the same feature.
+
+**Delivery.** A 30-second loop drains ``scheduled_notifications`` and posts them.
+Without it, ``POST /api/schedule`` is a black hole: rows accumulate and nothing
+ever sends them.  The loop lives in the framework so every deployment gets it —
+a consumer must not have to write a Cog to make a documented endpoint work.
+
+**Scheduling.** ``/remind`` picks the cheapest mechanism that can express what
+was asked:
+
+* no ``check`` → a notification row.  One Discord message, no agent, no cost.
+* with ``check`` → a scheduled task, so a real session verifies the condition
+  first and stays silent when the thing is already done.
+
+That split is the whole point.  An unconditional reminder does not need
+judgement, and a conditional one cannot work without it.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+
+import discord
+from discord import app_commands
+from discord.ext import commands, tasks
+
+from ..reminders import (
+    build_conditional_prompt,
+    build_plain_reminder_text,
+    extract_reminder_what,
+    parse_until,
+    parse_when,
+    repeat_interval_seconds,
+)
+
+if TYPE_CHECKING:
+    from ..database.notification_repo import NotificationRepository
+    from ..database.task_repo import TaskRepository
+
+logger = logging.getLogger(__name__)
+
+DRAIN_INTERVAL_SECONDS = 30
+_REMINDER_COLOR = 0x00BFFF
+_MAX_LISTED = 20
+# Discord stores notification times as naive local strings; keep the format in
+# one place so the drain query and the writer cannot drift apart.
+_TIME_FORMAT = "%Y-%m-%dT%H:%M:%S"
+
+
+def _reminder_embed(message: str, title: str | None = None) -> discord.Embed:
+    return discord.Embed(
+        title=title or "⏰ Reminder",
+        description=message,
+        color=_REMINDER_COLOR,
+        timestamp=datetime.now().astimezone(),
+    )
+
+
+class ReminderCog(commands.Cog):
+    """Scheduled reminders: plain notifications and condition-checked ones.
+
+    Args:
+        bot: The Discord bot instance.
+        notification_repo: Store for plain (unconditional) reminders.
+        task_repo: Scheduler store, used for conditional reminders. When None
+            (scheduler disabled) ``/remind`` still handles plain reminders and
+            says plainly that conditional ones are unavailable.
+    """
+
+    def __init__(
+        self,
+        bot: commands.Bot,
+        *,
+        notification_repo: NotificationRepository,
+        task_repo: TaskRepository | None = None,
+    ) -> None:
+        self.bot = bot
+        self.notification_repo = notification_repo
+        self.task_repo = task_repo
+
+    async def cog_load(self) -> None:
+        self._drain_loop.start()
+        logger.info("ReminderCog loaded — notification drain loop started")
+
+    def cog_unload(self) -> None:
+        self._drain_loop.cancel()
+
+    # ------------------------------------------------------------------
+    # Delivery
+    # ------------------------------------------------------------------
+
+    @tasks.loop(seconds=DRAIN_INTERVAL_SECONDS)
+    async def _drain_loop(self) -> None:
+        await self.drain_notifications()
+
+    @_drain_loop.before_loop
+    async def _before_drain_loop(self) -> None:
+        await self.bot.wait_until_ready()
+
+    async def drain_notifications(self) -> None:
+        """Send every notification whose time has come.
+
+        One failure never blocks the rest of the queue, and a failed row is
+        marked failed rather than retried forever — a reminder that is hours
+        late is noise, not a reminder.
+        """
+        now = datetime.now().strftime(_TIME_FORMAT)
+        for notification in await self.notification_repo.get_pending(before=now):
+            notification_id = notification["id"]
+            try:
+                target = await self._resolve_target(notification.get("channel_id"))
+                if target is None:
+                    await self.notification_repo.mark_failed(notification_id, "No channel")
+                    continue
+                embed = _reminder_embed(notification["message"], notification.get("title"))
+                if notification.get("color"):
+                    embed.color = notification["color"]
+                await target.send(embed=embed)
+                await self.notification_repo.mark_sent(notification_id)
+            except Exception as exc:  # noqa: BLE001 — one bad row must not stop the queue
+                logger.warning("Reminder %d could not be sent: %s", notification_id, exc)
+                await self.notification_repo.mark_failed(notification_id, str(exc))
+
+    async def _resolve_target(self, channel_id: int | None) -> Any:
+        """Resolve a channel or thread to post into, falling back to the default."""
+        resolved_id = channel_id or getattr(self.bot, "default_channel_id", None)
+        if not resolved_id:
+            return None
+        channel = self.bot.get_channel(int(resolved_id))
+        if channel is None:
+            channel = await self.bot.fetch_channel(int(resolved_id))
+        return channel
+
+    # ------------------------------------------------------------------
+    # Commands
+    # ------------------------------------------------------------------
+
+    @app_commands.command(
+        name="remind",
+        description="Remind me later — optionally only if it is still not done",
+    )
+    @app_commands.describe(
+        when="21:30, 2h, or 2026-08-08T09:00",
+        what="What to remind you about",
+        check="Optional: how to tell it is already done (stays silent if so)",
+        every="Optional repeat: daily, hourly, weekly, 6h, 30m",
+        until="Optional expiry: 2026-08-08 or 2d — required when repeating",
+    )
+    async def remind(
+        self,
+        interaction: discord.Interaction,
+        when: str,
+        what: str,
+        check: str | None = None,
+        every: str | None = None,
+        until: str | None = None,
+    ) -> None:
+        """Schedule a reminder, conditional if *check* is given."""
+        try:
+            fire_at = parse_when(when)
+            expires_at = parse_until(until)
+            interval = repeat_interval_seconds(every)
+        except ValueError as exc:
+            await self._reject(interaction, str(exc))
+            return
+
+        # A repeat that can neither be satisfied nor expire never stops.
+        if every is not None and check is None and expires_at is None:
+            await self._reject(
+                interaction,
+                "A repeating reminder needs `until` (an expiry) or `check` "
+                "(a condition that ends it) — otherwise it nags forever.",
+            )
+            return
+
+        if check is None:
+            await self._schedule_plain(interaction, fire_at, what, every, expires_at)
+        else:
+            await self._schedule_conditional(
+                interaction, fire_at, what, check, interval, every, expires_at
+            )
+
+    async def _schedule_plain(
+        self,
+        interaction: discord.Interaction,
+        fire_at: datetime,
+        what: str,
+        every: str | None,
+        expires_at: datetime | None,
+    ) -> None:
+        """Store an unconditional reminder as a notification (no agent run)."""
+        if every is not None:
+            await self._reject(
+                interaction,
+                "Repeating plain reminders are not supported — add `check` so the "
+                "reminder can tell when it is done, or schedule single reminders.",
+            )
+            return
+        try:
+            message = build_plain_reminder_text(what)
+        except ValueError as exc:
+            await self._reject(interaction, str(exc))
+            return
+
+        await self.notification_repo.create(
+            message=message,
+            scheduled_at=fire_at.strftime(_TIME_FORMAT),
+            source="slash_command",
+            channel_id=interaction.channel_id,
+        )
+        await interaction.response.send_message(
+            embed=self._confirmation(fire_at, what, conditional=False, every=None, until=expires_at)
+        )
+
+    async def _schedule_conditional(
+        self,
+        interaction: discord.Interaction,
+        fire_at: datetime,
+        what: str,
+        check: str,
+        interval: int,
+        every: str | None,
+        expires_at: datetime | None,
+    ) -> None:
+        """Register a scheduled task that verifies before it speaks."""
+        if self.task_repo is None:
+            await self._reject(
+                interaction,
+                "Conditional reminders need the scheduler, which is disabled in "
+                "this deployment. A plain reminder (without `check`) still works.",
+            )
+            return
+
+        channel = interaction.channel
+        parent_id = getattr(channel, "parent_id", None)
+        in_thread = parent_id is not None
+        thread_id = interaction.channel_id if in_thread else None
+        channel_id = parent_id if in_thread else interaction.channel_id
+        if channel_id is None:
+            await self._reject(interaction, "Cannot schedule a reminder outside a channel.")
+            return
+
+        # Unique per invocation: the same reminder may legitimately be set twice.
+        name = f"remind-{interaction.channel_id}-{int(time.time() * 1000)}"
+        try:
+            prompt = build_conditional_prompt(what=what, check=check, task_name=name)
+        except ValueError as exc:
+            await self._reject(interaction, str(exc))
+            return
+
+        await self.task_repo.create(
+            name=name,
+            prompt=prompt,
+            interval_seconds=interval,
+            channel_id=int(channel_id),
+            thread_id=thread_id,
+            one_shot=every is None,
+            run_at=fire_at.timestamp(),
+            until=expires_at.timestamp() if expires_at else None,
+        )
+        await interaction.response.send_message(
+            embed=self._confirmation(
+                fire_at, what, conditional=True, every=every, until=expires_at, check=check
+            )
+        )
+
+    @app_commands.command(name="reminders", description="List pending reminders")
+    async def reminders(self, interaction: discord.Interaction) -> None:
+        """Show every reminder that has not fired yet."""
+        lines: list[str] = []
+        for notification in (await self.notification_repo.get_pending())[:_MAX_LISTED]:
+            lines.append(
+                f"⏰ `{notification['scheduled_at']}` — {notification['message']}"
+                f" (id `{notification['id']}`)"
+            )
+        if self.task_repo is not None:
+            for task in await self.task_repo.get_all():
+                if not task["enabled"] or not task["name"].startswith("remind-"):
+                    continue
+                fires = datetime.fromtimestamp(task["next_run_at"]).strftime("%m/%d %H:%M")
+                subject = extract_reminder_what(task["prompt"]) or task["name"]
+                lines.append(f"🔍 `{fires}` — {subject} (`{task['name']}`)")
+
+        if not lines:
+            await interaction.response.send_message("No pending reminders.", ephemeral=True)
+            return
+        await interaction.response.send_message(
+            embed=discord.Embed(
+                title="⏰ Pending reminders",
+                description="\n".join(lines),
+                color=_REMINDER_COLOR,
+            ),
+            ephemeral=True,
+        )
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    async def _reject(interaction: discord.Interaction, message: str) -> None:
+        """Tell the user why nothing was scheduled. Never fail silently."""
+        await interaction.response.send_message(message, ephemeral=True)
+
+    @staticmethod
+    def _confirmation(
+        fire_at: datetime,
+        what: str,
+        *,
+        conditional: bool,
+        every: str | None,
+        until: datetime | None,
+        check: str | None = None,
+    ) -> discord.Embed:
+        detail = [f"**{fire_at.strftime('%m/%d %H:%M')}** — {what}"]
+        if conditional:
+            detail.append(f"Only if not done yet: {check}")
+        if every:
+            detail.append(f"Repeats: {every}")
+        if until:
+            detail.append(f"Stops after: {until.strftime('%m/%d %H:%M')}")
+        return discord.Embed(
+            title="✅ Reminder set",
+            description="\n".join(detail),
+            color=_REMINDER_COLOR,
+        )

--- a/claude_discord/cogs/scheduler.py
+++ b/claude_discord/cogs/scheduler.py
@@ -80,6 +80,11 @@ class SchedulerCog(commands.Cog):
     @tasks.loop(seconds=MASTER_LOOP_INTERVAL_SECONDS)
     async def _master_loop(self) -> None:
         """Wake up every 30 s, find due tasks, and spawn them concurrently."""
+        # Retire tasks that outlived their deadline before looking for work.
+        # get_due() already ignores them; this is what makes them *visibly*
+        # finished instead of silently skipped forever.
+        await self.repo.expire_overdue()
+
         due = await self.repo.get_due()
         if not due:
             return

--- a/claude_discord/database/task_repo.py
+++ b/claude_discord/database/task_repo.py
@@ -44,6 +44,12 @@ ALTER TABLE scheduled_tasks ADD COLUMN thread_id INTEGER;
 ALTER TABLE scheduled_tasks ADD COLUMN one_shot INTEGER DEFAULT 0;
 """
 
+# Migration: add expiry. NULL means "no expiry", which is what every task
+# created before this column existed meant implicitly.
+_MIGRATION_UNTIL = """
+ALTER TABLE scheduled_tasks ADD COLUMN until REAL;
+"""
+
 
 class TaskRepository:
     """Async CRUD for scheduled_tasks table."""
@@ -70,6 +76,12 @@ class TaskRepository:
                     if stmt:
                         await db.execute(stmt)
                 logger.info("Migrated scheduled_tasks: added thread_id, one_shot")
+            if "until" not in columns:
+                for stmt in _MIGRATION_UNTIL.strip().split(";"):
+                    stmt = stmt.strip()
+                    if stmt:
+                        await db.execute(stmt)
+                logger.info("Migrated scheduled_tasks: added until")
             await db.commit()
         logger.info("Task DB initialized at %s", self.db_path)
 
@@ -131,15 +143,21 @@ class TaskRepository:
         return result
 
     async def get_due(self, now: float | None = None) -> list[dict]:
-        """Return enabled tasks whose next_run_at is in the past."""
+        """Return enabled tasks whose next_run_at is in the past and not expired.
+
+        A task past its ``until`` is never returned, even when overdue: an
+        expired reminder firing late is exactly the nagging that ``until``
+        exists to prevent.  :meth:`expire_overdue` disables such rows.
+        """
         ts = now if now is not None else time.time()
         async with aiosqlite.connect(self.db_path) as db:
             db.row_factory = aiosqlite.Row
             cursor = await db.execute(
                 """SELECT * FROM scheduled_tasks
                    WHERE enabled = 1 AND next_run_at <= ?
+                     AND (until IS NULL OR until > ?)
                    ORDER BY next_run_at""",
-                (ts,),
+                (ts, ts),
             )
             rows = await cursor.fetchall()
         result = []
@@ -167,6 +185,8 @@ class TaskRepository:
         anchor_minute: int | None = None,
         thread_id: int | None = None,
         one_shot: bool = False,
+        run_at: float | None = None,
+        until: float | None = None,
     ) -> int:
         """Create a new scheduled task. Returns the created ID.
 
@@ -183,9 +203,16 @@ class TaskRepository:
                 the scheduler posts to this existing thread instead of
                 creating a new one (follow-up mode).
             one_shot: If True, the task auto-disables after a single execution.
+            run_at: Optional absolute epoch seconds for the first run. Wins
+                over run_immediately and anchor_hour — an explicit instant is
+                a stronger statement than either default.
+            until: Optional expiry (epoch seconds). After this the task stops
+                firing and is disabled by expire_overdue(). None = no expiry.
         """
         now = time.time()
-        if anchor_hour is not None and not run_immediately:
+        if run_at is not None:
+            next_run = run_at
+        elif anchor_hour is not None and not run_immediately:
             next_run = self._next_anchor(anchor_hour, anchor_minute or 0, interval_seconds)
         elif run_immediately:
             next_run = now
@@ -196,8 +223,8 @@ class TaskRepository:
                 """INSERT INTO scheduled_tasks
                    (name, prompt, interval_seconds, channel_id, working_dir,
                     enabled, next_run_at, created_at, anchor_hour, anchor_minute,
-                    thread_id, one_shot)
-                   VALUES (?, ?, ?, ?, ?, 1, ?, ?, ?, ?, ?, ?)""",
+                    thread_id, one_shot, until)
+                   VALUES (?, ?, ?, ?, ?, 1, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     name,
                     prompt,
@@ -210,6 +237,7 @@ class TaskRepository:
                     anchor_minute,
                     thread_id,
                     1 if one_shot else 0,
+                    until,
                 ),
             )
             await db.commit()
@@ -248,6 +276,33 @@ class TaskRepository:
                 (next_run, now, task_id),
             )
             await db.commit()
+
+    async def expire_overdue(self, now: float | None = None) -> list[str]:
+        """Disable tasks that are past their ``until``. Returns their names.
+
+        Disabled rather than deleted: a reminder that ran out of time is a
+        thing the user may want to see ("it never fired because the deadline
+        passed"), and a deleted row explains nothing.
+        """
+        ts = now if now is not None else time.time()
+        async with aiosqlite.connect(self.db_path) as db:
+            db.row_factory = aiosqlite.Row
+            cursor = await db.execute(
+                """SELECT name FROM scheduled_tasks
+                   WHERE enabled = 1 AND until IS NOT NULL AND until <= ?""",
+                (ts,),
+            )
+            names = [row["name"] for row in await cursor.fetchall()]
+            if names:
+                await db.execute(
+                    """UPDATE scheduled_tasks SET enabled = 0
+                       WHERE enabled = 1 AND until IS NOT NULL AND until <= ?""",
+                    (ts,),
+                )
+                await db.commit()
+        if names:
+            logger.info("Expired scheduled tasks disabled: %s", ", ".join(names))
+        return names
 
     async def delete_by_name(self, name: str) -> bool:
         """Delete a task by its unique name. Returns True if a row was deleted."""

--- a/claude_discord/ext/api_server.py
+++ b/claude_discord/ext/api_server.py
@@ -313,6 +313,8 @@ class ApiServer:
         # Scheduled task routes (requires task_repo)
         self.app.router.add_post("/api/tasks", self.create_task)
         self.app.router.add_get("/api/tasks", self.list_tasks)
+        # by-name comes first: a scheduled session knows its name, not its id.
+        self.app.router.add_delete("/api/tasks/by-name/{name}", self.delete_task_by_name)
         self.app.router.add_delete("/api/tasks/{id}", self.delete_task)
         self.app.router.add_patch("/api/tasks/{id}", self.patch_task)
         # AI Lounge routes (requires lounge_repo)
@@ -611,6 +613,24 @@ class ApiServer:
             raise ValueError(f"anchor_time must be HH:MM, got {raw!r}")
         return int(parts[0]), int(parts[1])
 
+    @staticmethod
+    def _parse_instant(raw: object, *, field: str, is_expiry: bool) -> float | None:
+        """Parse a reminder instant into epoch seconds, or None when absent.
+
+        Delegates to :mod:`claude_discord.reminders` so the REST API and the
+        ``/remind`` command accept exactly the same spellings.
+        """
+        if raw is None:
+            return None
+        from ..reminders import parse_until, parse_when
+
+        text = str(raw)
+        try:
+            parsed = parse_until(text) if is_expiry else parse_when(text)
+        except ValueError as exc:
+            raise ValueError(f"{field}: {exc}") from exc
+        return parsed.timestamp() if parsed is not None else None
+
     async def create_task(self, request: web.Request) -> web.Response:
         """POST /api/tasks — register a scheduled Claude Code task.
 
@@ -629,6 +649,12 @@ class ApiServer:
                 instead of creating a new one.
             one_shot: (optional, default false) If true, auto-disable after
                 a single execution.
+            run_at: (optional) Absolute first run — ISO 8601, a wall-clock
+                ``"HH:MM"`` (next occurrence), or an offset like ``"2h"``.
+                Overrides run_immediately and anchor_time.
+            until: (optional) Expiry — ISO 8601, a bare ``YYYY-MM-DD`` (which
+                covers that whole day), or an offset. After it the task stops
+                firing and is disabled.
         """
         if err := self._require_task_repo():
             return err
@@ -637,12 +663,21 @@ class ApiServer:
         except json.JSONDecodeError:
             return web.json_response({"error": "Invalid JSON"}, status=400)
 
-        for field in ("name", "prompt", "interval_seconds", "channel_id"):
+        for field in ("name", "prompt", "interval_seconds"):
             if not data.get(field):
                 return web.json_response({"error": f"{field} is required"}, status=400)
 
+        # A follow-up into an existing thread only needs channel_id as a
+        # fallback target, and a session knows its thread but not its parent.
+        if not data.get("channel_id"):
+            if not data.get("thread_id") or not self.default_channel_id:
+                return web.json_response({"error": "channel_id is required"}, status=400)
+            data["channel_id"] = self.default_channel_id
+
         try:
             anchor_hour, anchor_minute = self._parse_anchor_time(data.get("anchor_time"))
+            run_at = self._parse_instant(data.get("run_at"), field="run_at", is_expiry=False)
+            until = self._parse_instant(data.get("until"), field="until", is_expiry=True)
         except ValueError as exc:
             return web.json_response({"error": str(exc)}, status=400)
 
@@ -667,6 +702,8 @@ class ApiServer:
                 anchor_minute=anchor_minute,
                 thread_id=thread_id,
                 one_shot=one_shot,
+                run_at=run_at,
+                until=until,
             )
         except Exception as exc:
             # Most likely a UNIQUE constraint violation on name
@@ -694,6 +731,24 @@ class ApiServer:
 
         deleted = await self.task_repo.delete(task_id)  # type: ignore[union-attr]
         if deleted:
+            return web.json_response({"status": "deleted"})
+        return web.json_response({"error": "Task not found"}, status=404)
+
+    async def delete_task_by_name(self, request: web.Request) -> web.Response:
+        """DELETE /api/tasks/by-name/{name} — remove a scheduled task by name.
+
+        A scheduled session is told its own task name in its prompt but never
+        its row id, so this is how a satisfied reminder retires itself.
+        """
+        if err := self._require_task_repo():
+            return err
+        name = request.match_info.get("name", "")
+        if not name:
+            return web.json_response({"error": "name is required"}, status=400)
+
+        deleted = await self.task_repo.delete_by_name(name)  # type: ignore[union-attr]
+        if deleted:
+            logger.info("Task deleted by name via API: %s", _sanitize_log(name))
             return web.json_response({"status": "deleted"})
         return web.json_response({"error": "Task not found"}, status=404)
 

--- a/claude_discord/reminders.py
+++ b/claude_discord/reminders.py
@@ -1,0 +1,259 @@
+"""Reminder primitives — when to fire, and what to tell the session.
+
+Pure functions only: no Discord, no database, no I/O.  Two reasons.  First, the
+time arithmetic is where reminders actually break ("21:30" on a machine that is
+asleep, an expiry that has already passed), so it has to be testable without a
+bot.  Second, none of it may depend on the host OS — see ``docs`` on platform
+support: the scheduler runs on Linux, macOS and Windows alike.
+
+Two flavours of reminder exist, and the difference is not cosmetic:
+
+* **plain** — say this at that time.  Delivered as a notification; no agent
+  session is spawned, so it costs nothing but a Discord message.
+* **conditional** — say this at that time *unless it is already done*.  This
+  needs judgement, so a real session is spawned with
+  :func:`build_conditional_prompt` and decides whether to speak at all.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime, time, timedelta
+
+__all__ = [
+    "DEFAULT_CHECK_INTERVAL_SECONDS",
+    "build_conditional_prompt",
+    "build_plain_reminder_text",
+    "build_scheduling_notice",
+    "extract_reminder_what",
+    "parse_until",
+    "parse_when",
+    "repeat_interval_seconds",
+]
+
+# A one-shot reminder still has to store an interval (the column is NOT NULL).
+# A day is the least surprising value: if a one-shot were ever re-enabled by
+# hand it would fire at the same wall-clock time rather than immediately.
+DEFAULT_CHECK_INTERVAL_SECONDS = 86400
+
+_CLOCK_RE = re.compile(r"^(\d{1,2}):(\d{2})$")
+_OFFSET_RE = re.compile(r"^\+?(\d+)([smhd])$")
+_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+_UNIT_SECONDS = {"s": 1, "m": 60, "h": 3600, "d": 86400}
+
+_NAMED_INTERVALS = {
+    "hourly": 3600,
+    "daily": 86400,
+    "weekly": 604800,
+}
+
+_MAX_HOUR = 23
+_MAX_MINUTE = 59
+
+
+def _now_local(now: datetime | None) -> datetime:
+    """Return *now* as an aware datetime in the host's local timezone."""
+    return now if now is not None else datetime.now().astimezone()
+
+
+def _parse_offset(raw: str) -> timedelta | None:
+    """Parse ``"30m"`` / ``"+2h"`` into a positive timedelta, else None."""
+    match = _OFFSET_RE.match(raw)
+    if match is None:
+        return None
+    amount = int(match.group(1))
+    if amount == 0:
+        raise ValueError(f"Offset must be greater than zero: {raw!r}")
+    return timedelta(seconds=amount * _UNIT_SECONDS[match.group(2)])
+
+
+def _parse_iso(raw: str, reference: datetime) -> datetime | None:
+    """Parse an ISO 8601 datetime, assuming the local zone when none is given."""
+    try:
+        parsed = datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=reference.tzinfo)
+    return parsed
+
+
+def parse_when(raw: str, *, now: datetime | None = None) -> datetime:
+    """Resolve a human "when" into an absolute instant in the future.
+
+    Accepts a wall-clock time (``"21:30"`` — the next occurrence, so a time
+    that has already passed today means tomorrow), a relative offset
+    (``"30m"``, ``"+2h"``, ``"3d"``) or an ISO 8601 datetime.
+
+    Raises:
+        ValueError: If the input is unparseable or already in the past.
+    """
+    reference = _now_local(now)
+    text = (raw or "").strip()
+    if not text:
+        raise ValueError("A time is required (e.g. 21:30, 2h, 2026-08-08T09:00)")
+
+    if match := _CLOCK_RE.match(text):
+        hour, minute = int(match.group(1)), int(match.group(2))
+        if hour > _MAX_HOUR or minute > _MAX_MINUTE:
+            raise ValueError(f"Time out of range: {text!r} (use 00:00-23:59)")
+        candidate = datetime.combine(reference.date(), time(hour, minute), reference.tzinfo)
+        # "now" is never a useful reminder time, so treat it as tomorrow.
+        return candidate if candidate > reference else candidate + timedelta(days=1)
+
+    if (offset := _parse_offset(text)) is not None:
+        return reference + offset
+
+    if (parsed := _parse_iso(text, reference)) is not None:
+        if parsed <= reference:
+            raise ValueError(f"That moment is already in the past: {text!r}")
+        return parsed
+
+    raise ValueError(f"Cannot read {text!r} as a time (try 21:30, 2h, or 2026-08-08T09:00)")
+
+
+def parse_until(raw: str | None, *, now: datetime | None = None) -> datetime | None:
+    """Resolve an expiry. A bare date means the very end of that day.
+
+    ``None`` means "no expiry" — the reminder lives until it is satisfied or
+    cancelled.  A bare date is expanded to 23:59:59 because "until the 7th"
+    colloquially includes the 7th; expanding it to midnight would silently
+    drop the whole day.
+
+    Raises:
+        ValueError: If the input is unparseable or already in the past.
+    """
+    if raw is None:
+        return None
+    reference = _now_local(now)
+    text = raw.strip()
+    if not text:
+        return None
+
+    if _DATE_RE.match(text):
+        day = datetime.fromisoformat(text).date()
+        resolved = datetime.combine(day, time(23, 59, 59), reference.tzinfo)
+    elif (offset := _parse_offset(text)) is not None:
+        resolved = reference + offset
+    elif (parsed := _parse_iso(text, reference)) is not None:
+        resolved = parsed
+    else:
+        raise ValueError(f"Cannot read {text!r} as an expiry (try 2026-08-08 or 2d)")
+
+    if resolved <= reference:
+        raise ValueError(f"That expiry is already in the past: {text!r}")
+    return resolved
+
+
+def repeat_interval_seconds(every: str | None) -> int:
+    """Translate a repeat spec (``"daily"``, ``"6h"``, ``None``) into seconds."""
+    if every is None:
+        return DEFAULT_CHECK_INTERVAL_SECONDS
+    text = every.strip().lower()
+    if text in _NAMED_INTERVALS:
+        return _NAMED_INTERVALS[text]
+    if (offset := _parse_offset(text)) is not None:
+        return int(offset.total_seconds())
+    raise ValueError(f"Cannot read {every!r} as a repeat interval (try daily, 6h, 30m)")
+
+
+_CONDITIONAL_TEMPLATE = """\
+[SCHEDULED REMINDER — verify first, speak only if needed]
+
+You are a scheduled check, not a chat turn. The user asked to be reminded about
+this only if it is still outstanding.
+
+Verify whether it is already done:
+{check}
+
+Then act:
+- **Already done** → stay silent. Post nothing at all.
+- **Not done** → Remind the user in this thread, in their language. Be specific
+  and immediately actionable — restate the deadline and the next step, not just
+  "this is a reminder". What they wanted to be reminded of:
+  {what}
+
+Either way, finish by retiring this reminder so it cannot fire again:
+`curl -s -X DELETE "$CCDB_API_URL/api/tasks/by-name/{task_name}"`
+Skip the deletion only if this reminder is meant to repeat until satisfied and
+it is still outstanding.
+
+Use read-only checks. Do not change anything to make the condition true.
+
+{marker} {what}\
+"""
+
+# Trailing marker so ``/reminders`` can show what a scheduled task is *about*
+# without giving the generic scheduler table a reminder-specific column.
+_WHAT_MARKER = "[reminder:what]"
+
+
+def build_conditional_prompt(*, what: str, check: str, task_name: str) -> str:
+    """Build the session prompt for a reminder that must verify before nagging.
+
+    Raises:
+        ValueError: If *what* or *check* is blank — a conditional reminder with
+            nothing to check would nag unconditionally, which is worse than no
+            reminder at all.
+    """
+    what_text = (what or "").strip()
+    check_text = (check or "").strip()
+    if not what_text:
+        raise ValueError("A reminder needs something to remind about")
+    if not check_text:
+        raise ValueError("A conditional reminder needs a condition to check")
+    return _CONDITIONAL_TEMPLATE.format(
+        what=what_text, check=check_text, task_name=task_name, marker=_WHAT_MARKER
+    )
+
+
+def extract_reminder_what(prompt: str) -> str | None:
+    """Recover the human subject of a conditional reminder from its prompt.
+
+    Returns None for prompts that were not built by
+    :func:`build_conditional_prompt` (any other scheduled task).
+    """
+    for line in reversed((prompt or "").splitlines()):
+        stripped = line.strip()
+        if stripped.startswith(_WHAT_MARKER):
+            return stripped[len(_WHAT_MARKER) :].strip() or None
+    return None
+
+
+_SCHEDULING_NOTICE = """\
+## Scheduling Your Own Follow-Up
+You can wake yourself up later in this thread instead of asking the user to \
+remind you:
+```
+curl -s -X POST "$CCDB_API_URL/api/tasks" -H 'Content-Type: application/json' \\
+  -d '{{"name": "remind-{thread_id}-<slug>", "prompt": "<what to do then>", \
+"interval_seconds": 86400, "thread_id": {thread_id}, "run_at": "21:30", \
+"one_shot": true}}'
+```
+`run_at` takes `"21:30"` (next occurrence), `"2h"`, or ISO 8601. Add \
+`"until": "YYYY-MM-DD"` to a repeating task so it stops on its own, and \
+`DELETE $CCDB_API_URL/api/tasks/by-name/<name>` to retire one early.
+For a reminder that must stay quiet when the thing is already done, put the \
+check in the prompt: verify first, post nothing if satisfied, and delete the \
+task. Never claim you will follow up later without registering it — nothing \
+else will wake you.\
+"""
+
+
+def build_scheduling_notice(thread_id: int) -> str:
+    """Tell a session it can schedule its own future runs.
+
+    Injected into every session's system context.  The capability existed long
+    before this notice did, and sessions kept reinventing it with host cron or
+    external schedulers because nothing told them it was there.
+    """
+    return _SCHEDULING_NOTICE.format(thread_id=thread_id)
+
+
+def build_plain_reminder_text(what: str) -> str:
+    """Build the message body for an unconditional reminder."""
+    text = (what or "").strip()
+    if not text:
+        raise ValueError("A reminder needs something to remind about")
+    return f"⏰ {text}"

--- a/claude_discord/setup.py
+++ b/claude_discord/setup.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
     from .database.claims_repo import ClaimRepository
     from .database.ingest_repo import IngestResultRepository
     from .database.lounge_repo import LoungeRepository
+    from .database.notification_repo import NotificationRepository
     from .database.repository import SessionRepository
     from .database.resume_repo import PendingResumeRepository
     from .database.summary_repo import ThreadSummaryRepository
@@ -54,6 +55,7 @@ class BridgeComponents:
     resume_repo: PendingResumeRepository | None = None
     ingest_repo: IngestResultRepository | None = None
     summary_repo: ThreadSummaryRepository | None = None
+    notification_repo: NotificationRepository | None = None
     backend_factory: BackendFactory | None = None
     backend_settings: BackendSettings | None = None
 
@@ -78,6 +80,10 @@ class BridgeComponents:
             api_server.ingest_repo = self.ingest_repo
         if self.summary_repo is not None:
             api_server.summary_repo = self.summary_repo
+        if self.notification_repo is not None:
+            # Point the API at the same store the send loop drains. Two repos on
+            # two paths is how POST /api/schedule became a black hole.
+            api_server.repo = self.notification_repo
         api_server.session_repo = self.session_repo
 
 
@@ -449,6 +455,19 @@ async def setup_bridge(
         await bot.add_cog(scheduler_cog)
         logger.info("Registered SchedulerCog")
 
+    # --- ReminderCog -------------------------------------------------------
+    # Always registered: it owns the send loop for scheduled notifications, so
+    # without it POST /api/schedule would accept reminders that nothing ever
+    # delivers. Conditional reminders additionally need the scheduler.
+    from .cogs.reminder import ReminderCog
+    from .database.notification_repo import NotificationRepository as _NotificationRepo
+
+    os.makedirs(os.path.dirname(layout.notifications_db) or ".", exist_ok=True)
+    notification_repo = _NotificationRepo(layout.notifications_db)
+    await notification_repo.init_db()
+    await bot.add_cog(ReminderCog(bot, notification_repo=notification_repo, task_repo=task_repo))
+    logger.info("Registered ReminderCog (notifications=%s)", layout.notifications_db)
+
     # --- ContextLinksCog (optional — CONTEXT_LINKS_CONFIG or context_links.json) ---
     if context_links_config is None:
         context_links_config = os.getenv("CONTEXT_LINKS_CONFIG", "context_links.json")
@@ -483,6 +502,7 @@ async def setup_bridge(
         resume_repo=resume_repo,
         ingest_repo=ingest_repo,
         summary_repo=summary_repo,
+        notification_repo=notification_repo,
         backend_factory=backend_factory,
         backend_settings=backend_settings,
     )

--- a/claude_discord/worktree.py
+++ b/claude_discord/worktree.py
@@ -87,7 +87,7 @@ def _find_main_repo(worktree_path: str) -> str | None:
     if not git_file.is_file():
         return None
     try:
-        content = git_file.read_text().strip()
+        content = git_file.read_text(encoding="utf-8").strip()
     except OSError:
         return None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dev = [
     "aiohttp>=3.14.3",
     "pyright>=1.1.411",
     "pillow>=12.3.0",
+    "pytest-timeout>=2.4.0",
 ]
 
 [tool.pytest.ini_options]

--- a/tests/test_api_tasks_reminders.py
+++ b/tests/test_api_tasks_reminders.py
@@ -1,0 +1,238 @@
+"""Tests for the reminder-shaped parts of /api/tasks: run_at, until, delete-by-name.
+
+A scheduled session knows its own *name* (it is in its prompt) but not its
+numeric row id, so retiring itself has to be possible by name.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock
+
+import pytest
+from aiohttp.test_utils import TestClient, TestServer
+
+from claude_discord.database.notification_repo import NotificationRepository
+from claude_discord.database.task_repo import TaskRepository
+from claude_discord.ext.api_server import ApiServer
+
+
+@pytest.fixture
+async def notif_repo() -> NotificationRepository:
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    r = NotificationRepository(path)
+    await r.init_db()
+    yield r
+    os.unlink(path)
+
+
+@pytest.fixture
+async def task_repo() -> TaskRepository:
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    r = TaskRepository(path)
+    await r.init_db()
+    yield r
+    os.unlink(path)
+
+
+@pytest.fixture
+async def client(notif_repo, task_repo) -> TestClient:
+    api = ApiServer(
+        repo=notif_repo,
+        bot=MagicMock(),
+        task_repo=task_repo,
+        default_channel_id=12345,
+        host="127.0.0.1",
+        port=0,
+    )
+    server = TestServer(api.app)
+    c = TestClient(server)
+    await c.start_server()
+    yield c
+    await c.close()
+
+
+def _iso(**delta: float) -> str:
+    return (datetime.now().astimezone() + timedelta(**delta)).isoformat()
+
+
+class TestRunAt:
+    async def test_run_at_schedules_an_absolute_first_run(
+        self, client: TestClient, task_repo: TaskRepository
+    ) -> None:
+        target = datetime.now().astimezone() + timedelta(hours=3)
+        resp = await client.post(
+            "/api/tasks",
+            json={
+                "name": "one-shot",
+                "prompt": "p",
+                "interval_seconds": 86400,
+                "channel_id": 1,
+                "run_at": target.isoformat(),
+                "one_shot": True,
+            },
+        )
+        assert resp.status == 201
+        task = await task_repo.get((await resp.json())["id"])
+        assert task is not None
+        assert task["next_run_at"] == pytest.approx(target.timestamp(), abs=1)
+
+    async def test_run_at_in_the_past_is_rejected(self, client: TestClient) -> None:
+        resp = await client.post(
+            "/api/tasks",
+            json={
+                "name": "stale",
+                "prompt": "p",
+                "interval_seconds": 60,
+                "channel_id": 1,
+                "run_at": _iso(hours=-1),
+            },
+        )
+        assert resp.status == 400
+        assert "past" in (await resp.json())["error"].lower()
+
+    async def test_unparseable_run_at_is_rejected(self, client: TestClient) -> None:
+        resp = await client.post(
+            "/api/tasks",
+            json={
+                "name": "bad",
+                "prompt": "p",
+                "interval_seconds": 60,
+                "channel_id": 1,
+                "run_at": "tonight",
+            },
+        )
+        assert resp.status == 400
+
+
+class TestUntil:
+    async def test_until_is_stored(self, client: TestClient, task_repo: TaskRepository) -> None:
+        expiry = datetime.now().astimezone() + timedelta(days=1)
+        resp = await client.post(
+            "/api/tasks",
+            json={
+                "name": "expiring",
+                "prompt": "p",
+                "interval_seconds": 3600,
+                "channel_id": 1,
+                "until": expiry.isoformat(),
+            },
+        )
+        assert resp.status == 201
+        task = await task_repo.get((await resp.json())["id"])
+        assert task is not None
+        assert task["until"] == pytest.approx(expiry.timestamp(), abs=1)
+
+    async def test_bare_date_expiry_covers_the_whole_day(
+        self, client: TestClient, task_repo: TaskRepository
+    ) -> None:
+        """ "until tomorrow" must include tomorrow, not end at its midnight."""
+        tomorrow = (datetime.now().astimezone() + timedelta(days=1)).date().isoformat()
+        resp = await client.post(
+            "/api/tasks",
+            json={
+                "name": "expiring-date",
+                "prompt": "p",
+                "interval_seconds": 3600,
+                "channel_id": 1,
+                "until": tomorrow,
+            },
+        )
+        assert resp.status == 201
+        task = await task_repo.get((await resp.json())["id"])
+        assert task is not None
+        expiry = datetime.fromtimestamp(task["until"]).astimezone()
+        assert (expiry.hour, expiry.minute) == (23, 59)
+
+    async def test_until_in_the_past_is_rejected(self, client: TestClient) -> None:
+        resp = await client.post(
+            "/api/tasks",
+            json={
+                "name": "already-expired",
+                "prompt": "p",
+                "interval_seconds": 60,
+                "channel_id": 1,
+                "until": _iso(hours=-1),
+            },
+        )
+        assert resp.status == 400
+
+    async def test_list_exposes_until(self, client: TestClient) -> None:
+        await client.post(
+            "/api/tasks",
+            json={
+                "name": "expiring",
+                "prompt": "p",
+                "interval_seconds": 60,
+                "channel_id": 1,
+                "until": _iso(days=1),
+            },
+        )
+        tasks = (await (await client.get("/api/tasks")).json())["tasks"]
+        assert tasks[0]["until"] is not None
+
+
+class TestDeleteByName:
+    async def test_delete_by_name_removes_the_task(
+        self, client: TestClient, task_repo: TaskRepository
+    ) -> None:
+        await client.post(
+            "/api/tasks",
+            json={
+                "name": "remind-idr-42",
+                "prompt": "p",
+                "interval_seconds": 60,
+                "channel_id": 1,
+            },
+        )
+        resp = await client.delete("/api/tasks/by-name/remind-idr-42")
+        assert resp.status == 200
+        assert await task_repo.get_all() == []
+
+    async def test_delete_by_unknown_name_is_404(self, client: TestClient) -> None:
+        resp = await client.delete("/api/tasks/by-name/never-existed")
+        assert resp.status == 404
+
+    async def test_numeric_delete_still_works(self, client: TestClient) -> None:
+        """The by-name route must not shadow the existing id route."""
+        created = await client.post(
+            "/api/tasks",
+            json={"name": "byid", "prompt": "p", "interval_seconds": 60, "channel_id": 1},
+        )
+        task_id = (await created.json())["id"]
+        resp = await client.delete(f"/api/tasks/{task_id}")
+        assert resp.status == 200
+
+
+class TestChannelIdFallback:
+    async def test_thread_only_registration_uses_the_default_channel(
+        self, client: TestClient, task_repo: TaskRepository
+    ) -> None:
+        """A session knows its own thread, not its parent channel."""
+        resp = await client.post(
+            "/api/tasks",
+            json={
+                "name": "self-followup",
+                "prompt": "p",
+                "interval_seconds": 86400,
+                "thread_id": 777,
+                "run_at": "2h",
+                "one_shot": True,
+            },
+        )
+        assert resp.status == 201
+        task = await task_repo.get((await resp.json())["id"])
+        assert task is not None
+        assert (task["thread_id"], task["channel_id"]) == (777, 12345)
+
+    async def test_no_thread_and_no_channel_is_still_rejected(self, client: TestClient) -> None:
+        resp = await client.post(
+            "/api/tasks",
+            json={"name": "nowhere", "prompt": "p", "interval_seconds": 60},
+        )
+        assert resp.status == 400
+        assert "channel_id" in (await resp.json())["error"]

--- a/tests/test_api_teams_sync.py
+++ b/tests/test_api_teams_sync.py
@@ -494,7 +494,7 @@ async def test_plan_requests_a_message_with_obsolete_pending_metadata(
     meta["pending_attachments"] = [
         {"mid": ROOT, "name": "1.txt", "reason": "old client false positive", "url": ""}
     ]
-    meta_path.write_text(json.dumps(meta, ensure_ascii=False, indent=2) + "\n")
+    meta_path.write_text(json.dumps(meta, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
 
     plan = await client.post(
         "/api/teams/sync/plan",

--- a/tests/test_api_teams_sync.py
+++ b/tests/test_api_teams_sync.py
@@ -37,8 +37,12 @@ AUTH = {"Authorization": f"Bearer {TOKEN}"}
 
 @pytest.fixture
 def vault() -> Iterator[Path]:
+    # Resolved, because TeamsStore._contained returns realpaths and macOS hands
+    # out temp dirs under /var, a symlink to /private/var. Comparing a resolved
+    # result against an unresolved fixture fails there while the containment
+    # check itself is perfectly correct.
     with tempfile.TemporaryDirectory() as tmp:
-        yield Path(tmp)
+        yield Path(tmp).resolve()
 
 
 @pytest.fixture

--- a/tests/test_api_teams_sync.py
+++ b/tests/test_api_teams_sync.py
@@ -166,7 +166,7 @@ async def test_push_writes_one_file_per_message(client: TestClient, vault: Path)
 
     folder = Path(body["folder"])
     assert (folder / "messages" / f"{ROOT}.md").exists()
-    assert "返信です" in (folder / "messages" / "1784885000000.md").read_text()
+    assert "返信です" in (folder / "messages" / "1784885000000.md").read_text(encoding="utf-8")
     # mid is fixed width, so the filenames sort into chronological order.
     names = sorted(p.stem for p in (folder / "messages").glob("*.md"))
     assert names == [ROOT, "1784885000000"]
@@ -181,14 +181,17 @@ async def test_chain_records_order_and_prev(client: TestClient) -> None:
         ),
     )
     folder = Path((await resp.json())["folder"])
-    chain = [json.loads(line) for line in (folder / "chain.jsonl").read_text().splitlines()]
+    chain = [
+        json.loads(line)
+        for line in (folder / "chain.jsonl").read_text(encoding="utf-8").splitlines()
+    ]
     assert [c["mid"] for c in chain] == [ROOT, "1784885000000"]
     assert chain[0]["prev"] is None
     assert chain[1]["prev"] == ROOT
     # `next` is deliberately not stored anywhere: it would require rewriting an
     # existing file on every new reply.
     assert "next" not in chain[0]
-    front = (folder / "messages" / f"{ROOT}.md").read_text()
+    front = (folder / "messages" / f"{ROOT}.md").read_text(encoding="utf-8")
     assert "next:" not in front
 
 
@@ -201,7 +204,7 @@ async def test_pushing_twice_is_idempotent(client: TestClient) -> None:
     assert (await second.json())["folder"] == str(folder)
     assert len(list(Path(folder / "messages").glob("*.md"))) == 1
     assert sorted(p.name for p in folder.parent.iterdir()) == [folder.name]
-    meta = json.loads((folder / "thread.json").read_text())
+    meta = json.loads((folder / "thread.json").read_text(encoding="utf-8"))
     assert meta["message_count"] == 1
 
 
@@ -213,13 +216,16 @@ async def test_edit_archives_the_previous_version(client: TestClient) -> None:
         "/api/teams/sync/push", headers=AUTH, json=thread_body(messages=[msg(ROOT, "新本文", "h2")])
     )
     folder = Path((await resp.json())["folder"])
-    note = (folder / "messages" / f"{ROOT}.md").read_text()
+    note = (folder / "messages" / f"{ROOT}.md").read_text(encoding="utf-8")
     assert "新本文" in note
     assert "edited: true" in note
     archived = list((folder / "_history").glob(f"{ROOT}.*.md"))
     assert len(archived) == 1
-    assert "旧本文" in archived[0].read_text()
-    chain = [json.loads(line) for line in (folder / "chain.jsonl").read_text().splitlines()]
+    assert "旧本文" in archived[0].read_text(encoding="utf-8")
+    chain = [
+        json.loads(line)
+        for line in (folder / "chain.jsonl").read_text(encoding="utf-8").splitlines()
+    ]
     assert [c["rev"] for c in chain] == [1, 2]
 
 
@@ -235,7 +241,7 @@ async def test_deleted_message_keeps_its_file(client: TestClient) -> None:
         ),
     )
     folder = Path((await resp.json())["folder"])
-    note = (folder / "messages" / f"{ROOT}.md").read_text()
+    note = (folder / "messages" / f"{ROOT}.md").read_text(encoding="utf-8")
     assert "deleted: true" in note
     assert list((folder / "_history").glob("*.md"))
 
@@ -297,8 +303,8 @@ async def test_unfetched_attachment_is_reported_and_asked_for_again(
     ]
 
     folder = Path(body["folder"])
-    assert "admin.evtx" in (folder / "README.md").read_text()
-    assert "⚠️ 添付未取得" in (folder / "messages" / f"{ROOT}.md").read_text()
+    assert "admin.evtx" in (folder / "README.md").read_text(encoding="utf-8")
+    assert "⚠️ 添付未取得" in (folder / "messages" / f"{ROOT}.md").read_text(encoding="utf-8")
 
     # And the next plan asks for it again — a gap that stays visible is a gap
     # that can be closed by pressing the button once more.
@@ -390,7 +396,7 @@ async def test_obsolete_pending_clears_when_the_message_inventory_changes(
     )
     body = await resp.json()
     assert body["pending"] == []
-    meta = json.loads((Path(body["folder"]) / "thread.json").read_text())
+    meta = json.loads((Path(body["folder"]) / "thread.json").read_text(encoding="utf-8"))
     assert meta["pending_attachments"] == []
 
 
@@ -484,7 +490,7 @@ async def test_plan_requests_a_message_with_obsolete_pending_metadata(
     )
     folder = Path((await push.json())["folder"])
     meta_path = folder / "thread.json"
-    meta = json.loads(meta_path.read_text())
+    meta = json.loads(meta_path.read_text(encoding="utf-8"))
     meta["pending_attachments"] = [
         {"mid": ROOT, "name": "1.txt", "reason": "old client false positive", "url": ""}
     ]
@@ -659,7 +665,7 @@ async def test_thread_lands_in_its_company_folder(client: TestClient, vault: Pat
     )
     folder = Path((await resp.json())["folder"])
     assert folder.parent == vault / "日本工営"
-    assert json.loads((folder / "thread.json").read_text())["org"] == "日本工営"
+    assert json.loads((folder / "thread.json").read_text(encoding="utf-8"))["org"] == "日本工営"
 
 
 async def test_unlabelled_thread_stays_at_the_root(client: TestClient, vault: Path) -> None:
@@ -762,7 +768,9 @@ async def test_a_new_company_label_is_remembered_for_the_team(
             messages=[msg(ROOT, "本文", "h1")],
         ),
     )
-    assert json.loads((vault / "orgs.json").read_text())["teams"][TEAM] == "日本工営"
+    assert (
+        json.loads((vault / "orgs.json").read_text(encoding="utf-8"))["teams"][TEAM] == "日本工営"
+    )
 
     other = await client.post(
         "/api/teams/sync/push",
@@ -809,5 +817,5 @@ async def test_readme_names_the_company(client: TestClient) -> None:
             messages=[msg(ROOT, "本文", "h1")],
         ),
     )
-    readme = (Path((await resp.json())["folder"]) / "README.md").read_text()
+    readme = (Path((await resp.json())["folder"]) / "README.md").read_text(encoding="utf-8")
     assert "- 会社: 日本工営" in readme

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -147,7 +147,7 @@ class TestWriteEnv:
             working_dir="/home/user/project",
             model="sonnet",
         )
-        content = env_file.read_text()
+        content = env_file.read_text(encoding="utf-8")
         assert "DISCORD_BOT_TOKEN=mytoken" in content
         assert "DISCORD_CHANNEL_ID=123" in content
         assert "DISCORD_OWNER_ID=456" in content
@@ -166,7 +166,7 @@ class TestWriteEnv:
             working_dir="",
             model="sonnet",
         )
-        content = env_file.read_text()
+        content = env_file.read_text(encoding="utf-8")
         # owner_id line should still exist but be empty
         assert "DISCORD_OWNER_ID=" in content
 
@@ -174,7 +174,7 @@ class TestWriteEnv:
         from claude_discord.cli import write_env
 
         env_file = tmp_path / ".env"
-        env_file.write_text("DISCORD_BOT_TOKEN=original\n")
+        env_file.write_text("DISCORD_BOT_TOKEN=original\n", encoding="utf-8")
         with pytest.raises(FileExistsError):
             write_env(
                 path=env_file,
@@ -184,13 +184,13 @@ class TestWriteEnv:
                 working_dir="",
                 model="sonnet",
             )
-        assert "original" in env_file.read_text()
+        assert "original" in env_file.read_text(encoding="utf-8")
 
     def test_overwrites_with_flag(self, tmp_path: Path) -> None:
         from claude_discord.cli import write_env
 
         env_file = tmp_path / ".env"
-        env_file.write_text("DISCORD_BOT_TOKEN=original\n")
+        env_file.write_text("DISCORD_BOT_TOKEN=original\n", encoding="utf-8")
         write_env(
             path=env_file,
             token="new",
@@ -200,8 +200,8 @@ class TestWriteEnv:
             model="sonnet",
             overwrite=True,
         )
-        assert "new" in env_file.read_text()
-        assert "original" not in env_file.read_text()
+        assert "new" in env_file.read_text(encoding="utf-8")
+        assert "original" not in env_file.read_text(encoding="utf-8")
 
 
 # ---------------------------------------------------------------------------
@@ -306,7 +306,9 @@ class TestRunStartEnvLoading:
     async def test_run_start_loads_dotenv_from_explicit_path(self, tmp_path: Path) -> None:
         """_run_start must call load_dotenv(env_path) so vars are available to main."""
         env_file = tmp_path / ".env"
-        env_file.write_text("DISCORD_BOT_TOKEN=test-token-123\nDISCORD_CHANNEL_ID=999\n")
+        env_file.write_text(
+            "DISCORD_BOT_TOKEN=test-token-123\nDISCORD_CHANNEL_ID=999\n", encoding="utf-8"
+        )
 
         with (
             patch("dotenv.load_dotenv") as mock_load_dotenv,

--- a/tests/test_codex_runner.py
+++ b/tests/test_codex_runner.py
@@ -76,6 +76,16 @@ class _InterruptibleProcess(_FakeProcess):
         return self.returncode
 
     def send_signal(self, _signum: int) -> None:
+        self._stop()
+
+    def terminate(self) -> None:
+        # CodexRunner.interrupt() sends SIGINT on POSIX and calls terminate()
+        # on Windows. A double that only models the POSIX half leaves wait()
+        # blocked forever there, which reads as a hung test suite rather than
+        # as "the double is incomplete".
+        self._stop()
+
+    def _stop(self) -> None:
         self.returncode = 1
         self.interrupted.set()
 

--- a/tests/test_cog_loader.py
+++ b/tests/test_cog_loader.py
@@ -68,8 +68,12 @@ async def test_skip_underscore_prefix(
     cogs_dir: Path, mock_bot: MagicMock, mock_components: MagicMock
 ) -> None:
     """Files starting with _ should be skipped."""
-    (cogs_dir / "_helper.py").write_text("async def setup(bot, runner, components): pass")
-    (cogs_dir / "good.py").write_text("async def setup(bot, runner, components): pass")
+    (cogs_dir / "_helper.py").write_text(
+        "async def setup(bot, runner, components): pass", encoding="utf-8"
+    )
+    (cogs_dir / "good.py").write_text(
+        "async def setup(bot, runner, components): pass", encoding="utf-8"
+    )
 
     result = await load_custom_cogs(cogs_dir, mock_bot, None, mock_components)
     assert result == 1  # only good.py
@@ -79,8 +83,8 @@ async def test_skip_non_py_files(
     cogs_dir: Path, mock_bot: MagicMock, mock_components: MagicMock
 ) -> None:
     """Non-.py files should be ignored."""
-    (cogs_dir / "readme.txt").write_text("not a cog")
-    (cogs_dir / "config.json").write_text("{}")
+    (cogs_dir / "readme.txt").write_text("not a cog", encoding="utf-8")
+    (cogs_dir / "config.json").write_text("{}", encoding="utf-8")
 
     result = await load_custom_cogs(cogs_dir, mock_bot, None, mock_components)
     assert result == 0
@@ -90,7 +94,7 @@ async def test_skip_no_setup_function(
     cogs_dir: Path, mock_bot: MagicMock, mock_components: MagicMock
 ) -> None:
     """A .py file without setup() should be skipped with a warning."""
-    (cogs_dir / "no_setup.py").write_text("x = 42")
+    (cogs_dir / "no_setup.py").write_text("x = 42", encoding="utf-8")
 
     result = await load_custom_cogs(cogs_dir, mock_bot, None, mock_components)
     assert result == 0
@@ -163,7 +167,9 @@ async def test_syntax_error_in_cog(
     cogs_dir: Path, mock_bot: MagicMock, mock_components: MagicMock
 ) -> None:
     """A file with syntax errors should be skipped gracefully."""
-    (cogs_dir / "bad_syntax.py").write_text("def setup(bot, runner, components) oops")
+    (cogs_dir / "bad_syntax.py").write_text(
+        "def setup(bot, runner, components) oops", encoding="utf-8"
+    )
 
     result = await load_custom_cogs(cogs_dir, mock_bot, None, mock_components)
     assert result == 0

--- a/tests/test_context_links.py
+++ b/tests/test_context_links.py
@@ -102,7 +102,7 @@ class TestLoadConfig:
 
     def test_invalid_json_returns_none(self, tmp_path: Path) -> None:
         config_file = tmp_path / "bad.json"
-        config_file.write_text("not valid json {{{")
+        config_file.write_text("not valid json {{{", encoding="utf-8")
         result = load_config(str(config_file))
         assert result is None
 

--- a/tests/test_context_links.py
+++ b/tests/test_context_links.py
@@ -90,7 +90,7 @@ class TestLoadConfig:
                 }
             ],
         }
-        config_file.write_text(json.dumps(config_data))
+        config_file.write_text(json.dumps(config_data), encoding="utf-8")
         result = load_config(str(config_file))
         assert result is not None
         assert result["obsidian_vault"] == "obsidian"
@@ -108,13 +108,13 @@ class TestLoadConfig:
 
     def test_missing_projects_key_returns_none(self, tmp_path: Path) -> None:
         config_file = tmp_path / "empty.json"
-        config_file.write_text(json.dumps({"obsidian_vault": "test"}))
+        config_file.write_text(json.dumps({"obsidian_vault": "test"}), encoding="utf-8")
         result = load_config(str(config_file))
         assert result is None
 
     def test_empty_projects_returns_none(self, tmp_path: Path) -> None:
         config_file = tmp_path / "empty_projects.json"
-        config_file.write_text(json.dumps({"projects": []}))
+        config_file.write_text(json.dumps({"projects": []}), encoding="utf-8")
         result = load_config(str(config_file))
         assert result is None
 
@@ -404,7 +404,7 @@ class TestContextLinksCog:
             ],
         }
         config_file = tmp_path / "context_links.json"
-        config_file.write_text(json.dumps(config_data))
+        config_file.write_text(json.dumps(config_data), encoding="utf-8")
         return str(config_file)
 
     @pytest.fixture()

--- a/tests/test_describe_api.py
+++ b/tests/test_describe_api.py
@@ -58,7 +58,8 @@ class TestClaudeDescribeApi:
         saved = _clear()
         overlay = tmp_path / "overlay.env"
         overlay.write_text(
-            "CLAUDE_CODE_USE_FOUNDRY=1\nANTHROPIC_FOUNDRY_RESOURCE=jbs-llm-platform\n"
+            "CLAUDE_CODE_USE_FOUNDRY=1\nANTHROPIC_FOUNDRY_RESOURCE=jbs-llm-platform\n",
+            encoding="utf-8",
         )
         os.environ["CCDB_CLI_ENV_FILE"] = str(overlay)
         try:

--- a/tests/test_reminder_cog.py
+++ b/tests/test_reminder_cog.py
@@ -1,0 +1,277 @@
+"""Tests for ReminderCog — /remind, /reminders, and the notification drain loop.
+
+The drain loop is the part worth guarding: before it existed in the framework,
+``POST /api/schedule`` happily accepted notifications that nothing ever sent.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from claude_discord.cogs.reminder import ReminderCog
+from claude_discord.database.notification_repo import NotificationRepository
+from claude_discord.database.task_repo import TaskRepository
+
+
+@pytest.fixture
+async def notif_repo(tmp_path) -> NotificationRepository:
+    r = NotificationRepository(str(tmp_path / "notifications.db"))
+    await r.init_db()
+    return r
+
+
+@pytest.fixture
+async def task_repo(tmp_path) -> TaskRepository:
+    r = TaskRepository(str(tmp_path / "tasks.db"))
+    await r.init_db()
+    return r
+
+
+@pytest.fixture
+def channel() -> MagicMock:
+    ch = MagicMock()
+    ch.send = AsyncMock()
+    return ch
+
+
+@pytest.fixture
+def bot(channel: MagicMock) -> MagicMock:
+    b = MagicMock()
+    b.get_channel = MagicMock(return_value=channel)
+    b.fetch_channel = AsyncMock(return_value=channel)
+    b.default_channel_id = 999
+    return b
+
+
+@pytest.fixture
+def cog(bot: MagicMock, notif_repo, task_repo) -> ReminderCog:
+    return ReminderCog(bot, notification_repo=notif_repo, task_repo=task_repo)
+
+
+def _interaction(*, in_thread: bool = True) -> MagicMock:
+    interaction = MagicMock()
+    interaction.response.send_message = AsyncMock()
+    interaction.channel_id = 555
+    interaction.channel = MagicMock()
+    interaction.channel.id = 555
+    interaction.channel.parent_id = 111 if in_thread else None
+    return interaction
+
+
+def _past(**delta: float) -> str:
+    return (datetime.now() - timedelta(**delta)).strftime("%Y-%m-%dT%H:%M:%S")
+
+
+class TestDrainLoop:
+    async def test_sends_due_notification_and_marks_it_sent(
+        self, cog: ReminderCog, notif_repo: NotificationRepository, channel: MagicMock
+    ) -> None:
+        await notif_repo.create(message="買い物", scheduled_at=_past(minutes=1), channel_id=555)
+
+        await cog.drain_notifications()
+
+        channel.send.assert_awaited_once()
+        assert await notif_repo.get_pending() == []
+
+    async def test_future_notification_is_left_alone(
+        self, cog: ReminderCog, notif_repo: NotificationRepository, channel: MagicMock
+    ) -> None:
+        future = (datetime.now() + timedelta(hours=1)).strftime("%Y-%m-%dT%H:%M:%S")
+        await notif_repo.create(message="later", scheduled_at=future, channel_id=555)
+
+        await cog.drain_notifications()
+
+        channel.send.assert_not_awaited()
+        assert len(await notif_repo.get_pending()) == 1
+
+    async def test_falls_back_to_the_default_channel(
+        self, cog: ReminderCog, notif_repo: NotificationRepository, bot: MagicMock
+    ) -> None:
+        await notif_repo.create(message="no channel", scheduled_at=_past(minutes=1))
+
+        await cog.drain_notifications()
+
+        bot.get_channel.assert_called_with(999)
+
+    async def test_send_failure_marks_failed_and_does_not_retry_forever(
+        self, cog: ReminderCog, notif_repo: NotificationRepository, channel: MagicMock
+    ) -> None:
+        channel.send.side_effect = RuntimeError("discord is down")
+        await notif_repo.create(message="doomed", scheduled_at=_past(minutes=1), channel_id=555)
+
+        await cog.drain_notifications()
+
+        assert await notif_repo.get_pending() == []
+
+    async def test_one_bad_notification_does_not_block_the_next(
+        self, cog: ReminderCog, notif_repo: NotificationRepository, channel: MagicMock
+    ) -> None:
+        channel.send.side_effect = [RuntimeError("boom"), None]
+        await notif_repo.create(message="first", scheduled_at=_past(minutes=2), channel_id=555)
+        await notif_repo.create(message="second", scheduled_at=_past(minutes=1), channel_id=555)
+
+        await cog.drain_notifications()
+
+        assert channel.send.await_count == 2
+
+
+class TestRemindPlain:
+    async def test_schedules_a_notification(
+        self, cog: ReminderCog, notif_repo: NotificationRepository
+    ) -> None:
+        interaction = _interaction()
+
+        await cog.remind.callback(cog, interaction, when="2h", what="ゴミ出し")
+
+        pending = await notif_repo.get_pending()
+        assert len(pending) == 1
+        assert "ゴミ出し" in pending[0]["message"]
+        assert pending[0]["channel_id"] == 555
+
+    async def test_does_not_spawn_a_session(
+        self, cog: ReminderCog, task_repo: TaskRepository
+    ) -> None:
+        """A plain reminder is a message, not an agent run — no task row."""
+        await cog.remind.callback(cog, _interaction(), when="2h", what="ゴミ出し")
+
+        assert await task_repo.get_all() == []
+
+    async def test_confirms_to_the_user(self, cog: ReminderCog) -> None:
+        interaction = _interaction()
+        await cog.remind.callback(cog, interaction, when="21:30", what="x")
+        interaction.response.send_message.assert_awaited_once()
+
+    async def test_bad_time_is_rejected_without_scheduling(
+        self, cog: ReminderCog, notif_repo: NotificationRepository
+    ) -> None:
+        interaction = _interaction()
+
+        await cog.remind.callback(cog, interaction, when="tonight", what="x")
+
+        assert await notif_repo.get_pending() == []
+        kwargs = interaction.response.send_message.await_args.kwargs
+        assert kwargs.get("ephemeral") is True
+
+    async def test_blank_message_is_rejected(
+        self, cog: ReminderCog, notif_repo: NotificationRepository
+    ) -> None:
+        await cog.remind.callback(cog, _interaction(), when="2h", what="   ")
+        assert await notif_repo.get_pending() == []
+
+
+class TestRemindConditional:
+    async def test_registers_a_scheduled_task_with_the_condition(
+        self, cog: ReminderCog, task_repo: TaskRepository
+    ) -> None:
+        await cog.remind.callback(
+            cog,
+            _interaction(),
+            when="21:30",
+            what="IDR のアンケートを出す",
+            check="Gmail の in:sent to:idr.co に返信があるか",
+        )
+
+        tasks = await task_repo.get_all()
+        assert len(tasks) == 1
+        assert "in:sent to:idr.co" in tasks[0]["prompt"]
+        assert "IDR のアンケートを出す" in tasks[0]["prompt"]
+
+    async def test_posts_into_the_current_thread(
+        self, cog: ReminderCog, task_repo: TaskRepository
+    ) -> None:
+        await cog.remind.callback(
+            cog, _interaction(in_thread=True), when="21:30", what="x", check="y"
+        )
+
+        task = (await task_repo.get_all())[0]
+        assert task["thread_id"] == 555
+        assert task["channel_id"] == 111
+
+    async def test_outside_a_thread_it_uses_the_channel(
+        self, cog: ReminderCog, task_repo: TaskRepository
+    ) -> None:
+        await cog.remind.callback(
+            cog, _interaction(in_thread=False), when="21:30", what="x", check="y"
+        )
+
+        task = (await task_repo.get_all())[0]
+        assert task["thread_id"] is None
+        assert task["channel_id"] == 555
+
+    async def test_one_shot_unless_it_repeats(
+        self, cog: ReminderCog, task_repo: TaskRepository
+    ) -> None:
+        await cog.remind.callback(cog, _interaction(), when="21:30", what="x", check="y")
+        assert (await task_repo.get_all())[0]["one_shot"] is True
+
+    async def test_repeating_reminder_is_not_one_shot(
+        self, cog: ReminderCog, task_repo: TaskRepository
+    ) -> None:
+        await cog.remind.callback(
+            cog, _interaction(), when="21:30", what="x", check="y", every="daily"
+        )
+        task = (await task_repo.get_all())[0]
+        assert task["one_shot"] is False
+        assert task["interval_seconds"] == 86400
+
+    async def test_until_is_stored(self, cog: ReminderCog, task_repo: TaskRepository) -> None:
+        tomorrow = (datetime.now() + timedelta(days=1)).date().isoformat()
+        await cog.remind.callback(
+            cog, _interaction(), when="21:30", what="x", check="y", every="daily", until=tomorrow
+        )
+        assert (await task_repo.get_all())[0]["until"] is not None
+
+    async def test_repeating_without_until_is_rejected(
+        self, cog: ReminderCog, task_repo: TaskRepository
+    ) -> None:
+        """A repeat with no expiry and no condition to satisfy nags forever."""
+        interaction = _interaction()
+
+        await cog.remind.callback(cog, interaction, when="21:30", what="x", every="daily")
+
+        assert await task_repo.get_all() == []
+        assert interaction.response.send_message.await_args.kwargs.get("ephemeral") is True
+
+    async def test_task_name_is_unique_per_invocation(
+        self, cog: ReminderCog, task_repo: TaskRepository
+    ) -> None:
+        await cog.remind.callback(cog, _interaction(), when="21:30", what="x", check="y")
+        await cog.remind.callback(cog, _interaction(), when="22:30", what="x", check="y")
+
+        names = {t["name"] for t in await task_repo.get_all()}
+        assert len(names) == 2
+
+    async def test_scheduler_disabled_is_reported_not_ignored(
+        self, bot: MagicMock, notif_repo: NotificationRepository
+    ) -> None:
+        cog = ReminderCog(bot, notification_repo=notif_repo, task_repo=None)
+        interaction = _interaction()
+
+        await cog.remind.callback(cog, interaction, when="21:30", what="x", check="y")
+
+        assert interaction.response.send_message.await_args.kwargs.get("ephemeral") is True
+
+
+class TestRemindersList:
+    async def test_lists_both_kinds(
+        self, cog: ReminderCog, notif_repo: NotificationRepository
+    ) -> None:
+        await cog.remind.callback(cog, _interaction(), when="2h", what="plain one")
+        await cog.remind.callback(
+            cog, _interaction(), when="21:30", what="conditional one", check="cond"
+        )
+
+        interaction = _interaction()
+        await cog.reminders.callback(cog, interaction)
+
+        embed = interaction.response.send_message.await_args.kwargs["embed"]
+        assert "plain one" in embed.description
+        assert "conditional one" in embed.description
+
+    async def test_says_so_when_empty(self, cog: ReminderCog) -> None:
+        interaction = _interaction()
+        await cog.reminders.callback(cog, interaction)
+        assert interaction.response.send_message.await_args is not None

--- a/tests/test_reminders.py
+++ b/tests/test_reminders.py
@@ -1,0 +1,169 @@
+"""Tests for claude_discord.reminders — pure time parsing and prompt building."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from claude_discord.reminders import (
+    DEFAULT_CHECK_INTERVAL_SECONDS,
+    build_conditional_prompt,
+    build_plain_reminder_text,
+    parse_until,
+    parse_when,
+    repeat_interval_seconds,
+)
+
+JST = timezone(timedelta(hours=9))
+NOW = datetime(2026, 8, 7, 14, 0, 0, tzinfo=JST)
+
+
+class TestParseWhen:
+    def test_clock_time_later_today(self) -> None:
+        assert parse_when("21:30", now=NOW) == datetime(2026, 8, 7, 21, 30, tzinfo=JST)
+
+    def test_clock_time_already_passed_rolls_to_tomorrow(self) -> None:
+        assert parse_when("09:00", now=NOW) == datetime(2026, 8, 8, 9, 0, tzinfo=JST)
+
+    def test_clock_time_equal_to_now_rolls_to_tomorrow(self) -> None:
+        """A reminder for "right now" is never useful — it means tomorrow."""
+        assert parse_when("14:00", now=NOW) == datetime(2026, 8, 8, 14, 0, tzinfo=JST)
+
+    def test_single_digit_hour(self) -> None:
+        assert parse_when("9:05", now=NOW) == datetime(2026, 8, 8, 9, 5, tzinfo=JST)
+
+    @pytest.mark.parametrize(
+        ("raw", "expected_delta"),
+        [
+            ("30m", timedelta(minutes=30)),
+            ("+30m", timedelta(minutes=30)),
+            ("2h", timedelta(hours=2)),
+            ("3d", timedelta(days=3)),
+            ("90s", timedelta(seconds=90)),
+        ],
+    )
+    def test_relative_offsets(self, raw: str, expected_delta: timedelta) -> None:
+        assert parse_when(raw, now=NOW) == NOW + expected_delta
+
+    def test_iso_datetime_with_offset(self) -> None:
+        assert parse_when("2026-08-08T09:30:00+09:00", now=NOW) == datetime(
+            2026, 8, 8, 9, 30, tzinfo=JST
+        )
+
+    def test_iso_datetime_without_offset_assumes_local(self) -> None:
+        parsed = parse_when("2026-08-08T09:30", now=NOW)
+        assert parsed.utcoffset() == NOW.utcoffset()
+        assert (parsed.year, parsed.month, parsed.day, parsed.hour) == (2026, 8, 8, 9)
+
+    @pytest.mark.parametrize("raw", ["", "   ", "tonight", "25:00", "12:60", "0m", "-2h", "abc"])
+    def test_rejects_garbage(self, raw: str) -> None:
+        with pytest.raises(ValueError):
+            parse_when(raw, now=NOW)
+
+    def test_rejects_past_iso_datetime(self) -> None:
+        with pytest.raises(ValueError, match="past"):
+            parse_when("2026-08-06T09:00:00+09:00", now=NOW)
+
+
+class TestParseUntil:
+    def test_date_expands_to_end_of_day(self) -> None:
+        assert parse_until("2026-08-07", now=NOW) == datetime(2026, 8, 7, 23, 59, 59, tzinfo=JST)
+
+    def test_datetime_is_kept(self) -> None:
+        assert parse_until("2026-08-08T06:00:00+09:00", now=NOW) == datetime(
+            2026, 8, 8, 6, 0, tzinfo=JST
+        )
+
+    def test_relative_offset(self) -> None:
+        assert parse_until("2d", now=NOW) == NOW + timedelta(days=2)
+
+    def test_none_means_no_expiry(self) -> None:
+        assert parse_until(None, now=NOW) is None
+
+    def test_rejects_expiry_in_the_past(self) -> None:
+        with pytest.raises(ValueError, match="past"):
+            parse_until("2026-08-06", now=NOW)
+
+
+class TestRepeatIntervalSeconds:
+    def test_once_uses_the_default_check_interval(self) -> None:
+        """A one-shot still needs a nominal interval — the row requires one."""
+        assert repeat_interval_seconds(None) == DEFAULT_CHECK_INTERVAL_SECONDS
+
+    @pytest.mark.parametrize(
+        ("every", "expected"),
+        [("hourly", 3600), ("daily", 86400), ("weekly", 604800), ("30m", 1800), ("6h", 21600)],
+    )
+    def test_named_and_relative_intervals(self, every: str, expected: int) -> None:
+        assert repeat_interval_seconds(every) == expected
+
+    def test_rejects_garbage(self) -> None:
+        with pytest.raises(ValueError):
+            repeat_interval_seconds("sometimes")
+
+
+class TestBuildConditionalPrompt:
+    def _prompt(self, **kwargs: object) -> str:
+        defaults = {
+            "what": "IDR のアンケートを出す",
+            "check": "Gmail の in:sent to:idr.co after:2026/08/07 が 1 件以上あるか",
+            "task_name": "remind-idr-1234",
+        }
+        defaults.update(kwargs)
+        return build_conditional_prompt(**defaults)  # type: ignore[arg-type]
+
+    def test_includes_the_condition_and_the_reminder(self) -> None:
+        prompt = self._prompt()
+        assert "in:sent to:idr.co" in prompt
+        assert "IDR のアンケートを出す" in prompt
+
+    def test_tells_the_session_to_stay_silent_when_already_done(self) -> None:
+        prompt = self._prompt()
+        assert "silent" in prompt.lower()
+
+    def test_carries_the_self_delete_instruction_with_the_task_name(self) -> None:
+        """Without self-deletion a satisfied reminder would keep firing."""
+        prompt = self._prompt()
+        assert "remind-idr-1234" in prompt
+        assert "/api/tasks" in prompt
+
+    def test_verification_precedes_notification(self) -> None:
+        """Order matters: check first, only then decide to speak."""
+        prompt = self._prompt()
+        assert prompt.index("Verify") < prompt.index("Remind")
+
+    def test_rejects_empty_inputs(self) -> None:
+        with pytest.raises(ValueError):
+            self._prompt(what="  ")
+        with pytest.raises(ValueError):
+            self._prompt(check="")
+
+
+class TestBuildPlainReminderText:
+    def test_prefixes_with_a_clock_and_keeps_the_message(self) -> None:
+        assert "買い物" in build_plain_reminder_text("買い物")
+
+    def test_rejects_empty(self) -> None:
+        with pytest.raises(ValueError):
+            build_plain_reminder_text("   ")
+
+
+class TestExtractReminderWhat:
+    def test_round_trips_the_subject(self) -> None:
+        from claude_discord.reminders import extract_reminder_what
+
+        prompt = build_conditional_prompt(
+            what="IDR のアンケートを出す", check="Gmail を見る", task_name="remind-1"
+        )
+        assert extract_reminder_what(prompt) == "IDR のアンケートを出す"
+
+    def test_returns_none_for_an_unrelated_task_prompt(self) -> None:
+        from claude_discord.reminders import extract_reminder_what
+
+        assert extract_reminder_what("Check the CI build and report") is None
+
+    def test_returns_none_for_empty_input(self) -> None:
+        from claude_discord.reminders import extract_reminder_what
+
+        assert extract_reminder_what("") is None

--- a/tests/test_rewind_jsonl.py
+++ b/tests/test_rewind_jsonl.py
@@ -223,7 +223,7 @@ def test_truncate_jsonl_removes_selected_and_after(tmp_path: Path) -> None:
         '{"type":"user","message":{"content":"turn 1"}}\n',
         '{"type":"assistant","message":{"content":"resp 1"}}\n',
     ]
-    jsonl.write_text("".join(lines))
+    jsonl.write_text("".join(lines), encoding="utf-8")
 
     result = truncate_jsonl_at_line(jsonl, line_index=2)
 
@@ -236,7 +236,7 @@ def test_truncate_jsonl_removes_selected_and_after(tmp_path: Path) -> None:
 
 def test_truncate_jsonl_at_zero_empties_file(tmp_path: Path) -> None:
     jsonl = tmp_path / "sess.jsonl"
-    jsonl.write_text('{"type":"user","message":{"content":"only"}}\n')
+    jsonl.write_text('{"type":"user","message":{"content":"only"}}\n', encoding="utf-8")
 
     result = truncate_jsonl_at_line(jsonl, line_index=0)
 
@@ -254,7 +254,7 @@ def test_truncate_jsonl_beyond_end_keeps_all(tmp_path: Path) -> None:
     """Truncating beyond the last line keeps the file intact."""
     jsonl = tmp_path / "sess.jsonl"
     content = '{"type":"user","message":{"content":"only"}}\n'
-    jsonl.write_text(content)
+    jsonl.write_text(content, encoding="utf-8")
 
     result = truncate_jsonl_at_line(jsonl, line_index=999)
 

--- a/tests/test_rewind_jsonl.py
+++ b/tests/test_rewind_jsonl.py
@@ -166,7 +166,7 @@ def test_parse_user_turns_respects_max_turns(tmp_path: Path) -> None:
 
 def test_parse_user_turns_empty_file(tmp_path: Path) -> None:
     jsonl = tmp_path / "empty.jsonl"
-    jsonl.write_text("")
+    jsonl.write_text("", encoding="utf-8")
     turns = parse_user_turns(jsonl)
     assert turns == []
 
@@ -228,7 +228,7 @@ def test_truncate_jsonl_removes_selected_and_after(tmp_path: Path) -> None:
     result = truncate_jsonl_at_line(jsonl, line_index=2)
 
     assert result is True
-    remaining = jsonl.read_text().splitlines()
+    remaining = jsonl.read_text(encoding="utf-8").splitlines()
     assert len(remaining) == 2
     assert "turn 0" in remaining[0]
     assert "resp 0" in remaining[1]
@@ -241,7 +241,7 @@ def test_truncate_jsonl_at_zero_empties_file(tmp_path: Path) -> None:
     result = truncate_jsonl_at_line(jsonl, line_index=0)
 
     assert result is True
-    assert jsonl.read_text() == ""
+    assert jsonl.read_text(encoding="utf-8") == ""
 
 
 def test_truncate_jsonl_returns_false_on_missing_file(tmp_path: Path) -> None:
@@ -259,7 +259,7 @@ def test_truncate_jsonl_beyond_end_keeps_all(tmp_path: Path) -> None:
     result = truncate_jsonl_at_line(jsonl, line_index=999)
 
     assert result is True
-    assert jsonl.read_text() == content
+    assert jsonl.read_text(encoding="utf-8") == content
 
 
 # ---------------------------------------------------------------------------
@@ -279,7 +279,7 @@ def test_find_session_jsonl_via_working_dir(tmp_path: Path, monkeypatch) -> None
     project_dir.mkdir()
     session_id = "abc123"
     jsonl = project_dir / f"{session_id}.jsonl"
-    jsonl.write_text("")
+    jsonl.write_text("", encoding="utf-8")
 
     result = find_session_jsonl(session_id, "/home/ebi/myrepo")
     assert result == jsonl
@@ -297,7 +297,7 @@ def test_find_session_jsonl_fallback_search(tmp_path: Path, monkeypatch) -> None
     other_dir.mkdir()
     session_id = "xyz789"
     jsonl = other_dir / f"{session_id}.jsonl"
-    jsonl.write_text("")
+    jsonl.write_text("", encoding="utf-8")
 
     # Pass working_dir that doesn't match
     result = find_session_jsonl(session_id, "/does/not/exist")

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -955,7 +955,7 @@ class TestResolveWindowsCmd:
         js_path.write_text("// cli entry\n", encoding="utf-8")
 
         cmd_path = tmp_path / "claude.cmd"
-        cmd_path.write_text(self._NPM_CMD_TEMPLATE.format(rel_path=rel_js))
+        cmd_path.write_text(self._NPM_CMD_TEMPLATE.format(rel_path=rel_js), encoding="utf-8")
         return cmd_path
 
     def test_parses_npm_wrapper_and_returns_node_js(self, tmp_path: Path) -> None:
@@ -991,7 +991,9 @@ class TestResolveWindowsCmd:
         """Both paths fail: .cmd wrapper points to a non-existent .js file."""
         cmd_path = tmp_path / "claude.cmd"
         # Regex will match but the resolved path won't exist
-        cmd_path.write_text(r'"%~dp0\node_modules\@anthropic-ai\claude-code\cli.js"' + "\r\n")
+        cmd_path.write_text(
+            r'"%~dp0\node_modules\@anthropic-ai\claude-code\cli.js"' + "\r\n", encoding="utf-8"
+        )
         # Do NOT create cli.js — both primary and fallback should fail
 
         result = _resolve_windows_cmd(cmd_path)

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -260,7 +260,7 @@ class TestBuildEnv:
 
     def test_reads_cli_env_overlay_file(self, tmp_path: Path) -> None:
         overlay = tmp_path / "overlay.env"
-        overlay.write_text("MY_CUSTOM_VAR=hello\nANOTHER_VAR=world\n")
+        overlay.write_text("MY_CUSTOM_VAR=hello\nANOTHER_VAR=world\n", encoding="utf-8")
         os.environ["CCDB_CLI_ENV_FILE"] = str(overlay)
         try:
             runner = ClaudeRunner()
@@ -272,7 +272,7 @@ class TestBuildEnv:
 
     def test_cli_env_overlay_skips_comments_and_blanks(self, tmp_path: Path) -> None:
         overlay = tmp_path / "overlay.env"
-        overlay.write_text("# comment\n\nVALID_KEY=value\n")
+        overlay.write_text("# comment\n\nVALID_KEY=value\n", encoding="utf-8")
         os.environ["CCDB_CLI_ENV_FILE"] = str(overlay)
         try:
             runner = ClaudeRunner()
@@ -308,7 +308,7 @@ class TestBuildEnv:
 
     def test_cli_env_overlay_overrides_process_env(self, tmp_path: Path) -> None:
         overlay = tmp_path / "overlay.env"
-        overlay.write_text("PATH=/custom/path\n")
+        overlay.write_text("PATH=/custom/path\n", encoding="utf-8")
         os.environ["CCDB_CLI_ENV_FILE"] = str(overlay)
         try:
             runner = ClaudeRunner()
@@ -952,7 +952,7 @@ class TestResolveWindowsCmd:
         """Write a minimal .cmd wrapper and the target .js file."""
         js_path = tmp_path / rel_js
         js_path.parent.mkdir(parents=True, exist_ok=True)
-        js_path.write_text("// cli entry\n")
+        js_path.write_text("// cli entry\n", encoding="utf-8")
 
         cmd_path = tmp_path / "claude.cmd"
         cmd_path.write_text(self._NPM_CMD_TEMPLATE.format(rel_path=rel_js))
@@ -974,12 +974,12 @@ class TestResolveWindowsCmd:
         """Fallback path: .cmd has no parseable JS ref, but node_modules exists."""
         # Write a .cmd file without the "%~dp0\..." pattern
         cmd_path = tmp_path / "claude.cmd"
-        cmd_path.write_text("@ECHO off\r\nREM non-standard wrapper\r\n")
+        cmd_path.write_text("@ECHO off\r\nREM non-standard wrapper\r\n", encoding="utf-8")
 
         # Create the fallback cli.js location
         cli_js = tmp_path / "node_modules" / "@anthropic-ai" / "claude-code" / "cli.js"
         cli_js.parent.mkdir(parents=True, exist_ok=True)
-        cli_js.write_text("// cli entry\n")
+        cli_js.write_text("// cli entry\n", encoding="utf-8")
 
         with patch("claude_code_core.runner.shutil.which", return_value="node"):
             result = _resolve_windows_cmd(cmd_path)
@@ -1035,7 +1035,7 @@ class TestResolveWindowsCmd:
     def test_build_args_unchanged_on_linux(self, tmp_path: Path) -> None:
         """_build_args does not touch the command on non-Windows platforms."""
         cmd_path = tmp_path / "claude.cmd"
-        cmd_path.write_text("#!/bin/sh\n")
+        cmd_path.write_text("#!/bin/sh\n", encoding="utf-8")
 
         runner = ClaudeRunner(command=str(cmd_path), model="sonnet")
 

--- a/tests/test_skill_command.py
+++ b/tests/test_skill_command.py
@@ -96,7 +96,7 @@ class TestParseSkillMeta:
         skill_dir = tmp_path / "my-skill"
         skill_dir.mkdir()
         (skill_dir / "SKILL.md").write_text(
-            "---\nname: my-skill\ndescription: A cool skill\n---\n\nBody here."
+            "---\nname: my-skill\ndescription: A cool skill\n---\n\nBody here.", encoding="utf-8"
         )
         result = _parse_skill_meta(skill_dir)
         assert result == {"name": "my-skill", "description": "A cool skill"}
@@ -641,7 +641,7 @@ class TestGetPluginSkillDirs:
 
         plugins_json = tmp_path / "plugins" / "installed_plugins.json"
         plugins_json.parent.mkdir(parents=True, exist_ok=True)
-        plugins_json.write_text(json.dumps({"version": 2, "plugins": entries}))
+        plugins_json.write_text(json.dumps({"version": 2, "plugins": entries}), encoding="utf-8")
 
         result = _get_plugin_skill_dirs(claude_dir=tmp_path)
         assert set(result) == set(dirs)
@@ -659,14 +659,14 @@ class TestCollectSkills:
         primary.mkdir()
         (primary / "local-skill").mkdir()
         (primary / "local-skill" / "SKILL.md").write_text(
-            "---\nname: local-skill\ndescription: Local\n---\n"
+            "---\nname: local-skill\ndescription: Local\n---\n", encoding="utf-8"
         )
 
         extra = tmp_path / "plugin-skills"
         extra.mkdir()
         (extra / "plugin-skill").mkdir()
         (extra / "plugin-skill" / "SKILL.md").write_text(
-            "---\nname: plugin-skill\ndescription: Plugin\n---\n"
+            "---\nname: plugin-skill\ndescription: Plugin\n---\n", encoding="utf-8"
         )
 
         result = _collect_skills(primary, [extra])
@@ -680,14 +680,14 @@ class TestCollectSkills:
         primary.mkdir()
         (primary / "shared").mkdir()
         (primary / "shared" / "SKILL.md").write_text(
-            "---\nname: shared\ndescription: My custom version\n---\n"
+            "---\nname: shared\ndescription: My custom version\n---\n", encoding="utf-8"
         )
 
         extra = tmp_path / "plugin"
         extra.mkdir()
         (extra / "shared").mkdir()
         (extra / "shared" / "SKILL.md").write_text(
-            "---\nname: shared\ndescription: Plugin version\n---\n"
+            "---\nname: shared\ndescription: Plugin version\n---\n", encoding="utf-8"
         )
 
         result = _collect_skills(primary, [extra])
@@ -712,7 +712,7 @@ class TestCollectSkills:
         for name in ["zebra", "apple", "mango"]:
             (primary / name).mkdir()
             (primary / name / "SKILL.md").write_text(
-                f"---\nname: {name}\ndescription: {name}\n---\n"
+                f"---\nname: {name}\ndescription: {name}\n---\n", encoding="utf-8"
             )
         result = _collect_skills(primary, [])
         assert [s["name"] for s in result] == ["apple", "mango", "zebra"]
@@ -732,7 +732,7 @@ class TestCogPluginIntegration:
         plugin_skills.mkdir(parents=True)
         (plugin_skills / "plan").mkdir()
         (plugin_skills / "plan" / "SKILL.md").write_text(
-            "---\nname: plan\ndescription: Plan a feature\n---\n"
+            "---\nname: plan\ndescription: Plan a feature\n---\n", encoding="utf-8"
         )
 
         plugins_json = tmp_path / "plugins" / "installed_plugins.json"
@@ -768,7 +768,7 @@ class TestCogPluginIntegration:
         plugin_skills.mkdir(parents=True)
         (plugin_skills / "todoist").mkdir()
         (plugin_skills / "todoist" / "SKILL.md").write_text(
-            "---\nname: todoist\ndescription: Plugin version\n---\n"
+            "---\nname: todoist\ndescription: Plugin version\n---\n", encoding="utf-8"
         )
 
         plugins_json = tmp_path / "plugins" / "installed_plugins.json"
@@ -782,7 +782,7 @@ class TestCogPluginIntegration:
         primary_dir.mkdir()
         (primary_dir / "todoist").mkdir()
         (primary_dir / "todoist" / "SKILL.md").write_text(
-            "---\nname: todoist\ndescription: My custom version\n---\n"
+            "---\nname: todoist\ndescription: My custom version\n---\n", encoding="utf-8"
         )
 
         bot = MagicMock()

--- a/tests/test_skill_command.py
+++ b/tests/test_skill_command.py
@@ -104,7 +104,7 @@ class TestParseSkillMeta:
     def test_name_defaults_to_dir_name(self, tmp_path: Path) -> None:
         skill_dir = tmp_path / "fallback-name"
         skill_dir.mkdir()
-        (skill_dir / "SKILL.md").write_text("---\ndescription: Only desc\n---\n")
+        (skill_dir / "SKILL.md").write_text("---\ndescription: Only desc\n---\n", encoding="utf-8")
         result = _parse_skill_meta(skill_dir)
         assert result is not None
         assert result["name"] == "fallback-name"
@@ -118,13 +118,15 @@ class TestParseSkillMeta:
     def test_no_frontmatter(self, tmp_path: Path) -> None:
         skill_dir = tmp_path / "no-front"
         skill_dir.mkdir()
-        (skill_dir / "SKILL.md").write_text("# Just a heading\nNo frontmatter here.")
+        (skill_dir / "SKILL.md").write_text(
+            "# Just a heading\nNo frontmatter here.", encoding="utf-8"
+        )
         assert _parse_skill_meta(skill_dir) is None
 
     def test_empty_frontmatter(self, tmp_path: Path) -> None:
         skill_dir = tmp_path / "empty-front"
         skill_dir.mkdir()
-        (skill_dir / "SKILL.md").write_text("---\n---\nBody.")
+        (skill_dir / "SKILL.md").write_text("---\n---\nBody.", encoding="utf-8")
         # No name/desc fields → name defaults to dir name, desc is ""
         result = _parse_skill_meta(skill_dir)
         assert result is not None
@@ -135,7 +137,7 @@ class TestParseSkillMeta:
         skill_dir = tmp_path / "broken"
         skill_dir.mkdir()
         skill_md = skill_dir / "SKILL.md"
-        skill_md.write_text("---\nname: x\n---\n")
+        skill_md.write_text("---\nname: x\n---\n", encoding="utf-8")
         # Make unreadable
         skill_md.chmod(0o000)
         try:
@@ -156,9 +158,11 @@ class TestLoadSkills:
         for name in ["alpha", "beta", "gamma"]:
             d = tmp_path / name
             d.mkdir()
-            (d / "SKILL.md").write_text(f"---\nname: {name}\ndescription: Skill {name}\n---\n")
+            (d / "SKILL.md").write_text(
+                f"---\nname: {name}\ndescription: Skill {name}\n---\n", encoding="utf-8"
+            )
         # Add a file (not dir) — should be skipped
-        (tmp_path / "not-a-dir.txt").write_text("skip me")
+        (tmp_path / "not-a-dir.txt").write_text("skip me", encoding="utf-8")
         skills = _load_skills(tmp_path)
         assert len(skills) == 3
         assert [s["name"] for s in skills] == ["alpha", "beta", "gamma"]
@@ -167,7 +171,7 @@ class TestLoadSkills:
         # Valid
         d1 = tmp_path / "valid"
         d1.mkdir()
-        (d1 / "SKILL.md").write_text("---\nname: valid\ndescription: OK\n---\n")
+        (d1 / "SKILL.md").write_text("---\nname: valid\ndescription: OK\n---\n", encoding="utf-8")
         # Invalid (no SKILL.md)
         (tmp_path / "invalid").mkdir()
         skills = _load_skills(tmp_path)
@@ -620,7 +624,7 @@ class TestGetPluginSkillDirs:
         """Returns empty list when plugins.json is malformed JSON."""
         plugins_json = tmp_path / "plugins" / "installed_plugins.json"
         plugins_json.parent.mkdir(parents=True, exist_ok=True)
-        plugins_json.write_text("{invalid json}")
+        plugins_json.write_text("{invalid json}", encoding="utf-8")
         result = _get_plugin_skill_dirs(claude_dir=tmp_path)
         assert result == []
 
@@ -695,7 +699,9 @@ class TestCollectSkills:
         primary = tmp_path / "primary"
         primary.mkdir()
         (primary / "skill-a").mkdir()
-        (primary / "skill-a" / "SKILL.md").write_text("---\nname: skill-a\ndescription: A\n---\n")
+        (primary / "skill-a" / "SKILL.md").write_text(
+            "---\nname: skill-a\ndescription: A\n---\n", encoding="utf-8"
+        )
         result = _collect_skills(primary, [])
         assert len(result) == 1
 

--- a/tests/test_statusline.py
+++ b/tests/test_statusline.py
@@ -149,7 +149,7 @@ class TestReadStatuslineCommand:
 
     def test_returns_none_on_invalid_json(self, tmp_path: Path) -> None:
         settings = tmp_path / "settings.json"
-        settings.write_text("{not valid json}")
+        settings.write_text("{not valid json}", encoding="utf-8")
         assert read_statusline_command(str(settings)) is None
 
     def test_accepts_lowercase_statusline_key(self, tmp_path: Path) -> None:

--- a/tests/test_statusline.py
+++ b/tests/test_statusline.py
@@ -130,7 +130,8 @@ class TestReadStatuslineCommand:
     def test_reads_command_type(self, tmp_path: Path) -> None:
         settings = tmp_path / "settings.json"
         settings.write_text(
-            json.dumps({"statusLine": {"type": "command", "command": "bash ~/my-statusline.sh"}})
+            json.dumps({"statusLine": {"type": "command", "command": "bash ~/my-statusline.sh"}}),
+            encoding="utf-8",
         )
         assert read_statusline_command(str(settings)) == "bash ~/my-statusline.sh"
 
@@ -139,12 +140,14 @@ class TestReadStatuslineCommand:
 
     def test_returns_none_when_type_not_command(self, tmp_path: Path) -> None:
         settings = tmp_path / "settings.json"
-        settings.write_text(json.dumps({"statusLine": {"type": "text", "value": "hi"}}))
+        settings.write_text(
+            json.dumps({"statusLine": {"type": "text", "value": "hi"}}), encoding="utf-8"
+        )
         assert read_statusline_command(str(settings)) is None
 
     def test_returns_none_when_no_statusline_key(self, tmp_path: Path) -> None:
         settings = tmp_path / "settings.json"
-        settings.write_text(json.dumps({"model": "sonnet"}))
+        settings.write_text(json.dumps({"model": "sonnet"}), encoding="utf-8")
         assert read_statusline_command(str(settings)) is None
 
     def test_returns_none_on_invalid_json(self, tmp_path: Path) -> None:
@@ -154,7 +157,9 @@ class TestReadStatuslineCommand:
 
     def test_accepts_lowercase_statusline_key(self, tmp_path: Path) -> None:
         settings = tmp_path / "settings.json"
-        settings.write_text(json.dumps({"statusline": {"type": "command", "command": "echo hi"}}))
+        settings.write_text(
+            json.dumps({"statusline": {"type": "command", "command": "echo hi"}}), encoding="utf-8"
+        )
         assert read_statusline_command(str(settings)) == "echo hi"
 
 

--- a/tests/test_task_repo_expiry.py
+++ b/tests/test_task_repo_expiry.py
@@ -1,0 +1,161 @@
+"""Tests for absolute one-shot scheduling (``run_at``) and expiry (``until``).
+
+Both exist for the same failure mode: a reminder that outlives its own purpose.
+Before ``until``, a repeating task could only be stopped by the session that it
+spawned — so a session that crashed left the task nagging forever.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from claude_discord.database.task_repo import TaskRepository
+
+HOUR = 3600
+
+
+@pytest.fixture
+async def repo(tmp_path) -> TaskRepository:
+    r = TaskRepository(str(tmp_path / "tasks.db"))
+    await r.init_db()
+    return r
+
+
+class TestRunAt:
+    async def test_run_at_sets_next_run_exactly(self, repo: TaskRepository) -> None:
+        target = time.time() + HOUR
+        task_id = await repo.create(
+            name="one-shot",
+            prompt="p",
+            interval_seconds=86400,
+            channel_id=1,
+            run_at=target,
+            one_shot=True,
+        )
+        task = await repo.get(task_id)
+        assert task is not None
+        assert task["next_run_at"] == pytest.approx(target, abs=0.01)
+
+    async def test_run_at_beats_run_immediately(self, repo: TaskRepository) -> None:
+        """An explicit instant is a stronger statement than the default."""
+        target = time.time() + HOUR
+        task_id = await repo.create(
+            name="one-shot",
+            prompt="p",
+            interval_seconds=86400,
+            channel_id=1,
+            run_at=target,
+            run_immediately=True,
+        )
+        task = await repo.get(task_id)
+        assert task is not None
+        assert task["next_run_at"] == pytest.approx(target, abs=0.01)
+
+    async def test_run_at_task_is_not_due_yet(self, repo: TaskRepository) -> None:
+        await repo.create(
+            name="one-shot",
+            prompt="p",
+            interval_seconds=86400,
+            channel_id=1,
+            run_at=time.time() + HOUR,
+        )
+        assert await repo.get_due() == []
+
+
+class TestUntil:
+    async def test_until_is_stored(self, repo: TaskRepository) -> None:
+        expiry = time.time() + HOUR
+        task_id = await repo.create(
+            name="expiring", prompt="p", interval_seconds=60, channel_id=1, until=expiry
+        )
+        task = await repo.get(task_id)
+        assert task is not None
+        assert task["until"] == pytest.approx(expiry, abs=0.01)
+
+    async def test_until_defaults_to_none(self, repo: TaskRepository) -> None:
+        task_id = await repo.create(name="forever", prompt="p", interval_seconds=60, channel_id=1)
+        task = await repo.get(task_id)
+        assert task is not None
+        assert task["until"] is None
+
+    async def test_due_task_past_its_expiry_is_not_returned(self, repo: TaskRepository) -> None:
+        await repo.create(
+            name="stale",
+            prompt="p",
+            interval_seconds=60,
+            channel_id=1,
+            until=time.time() - 1,
+        )
+        assert await repo.get_due() == []
+
+    async def test_due_task_within_its_expiry_still_runs(self, repo: TaskRepository) -> None:
+        await repo.create(
+            name="fresh",
+            prompt="p",
+            interval_seconds=60,
+            channel_id=1,
+            until=time.time() + HOUR,
+        )
+        due = await repo.get_due()
+        assert [t["name"] for t in due] == ["fresh"]
+
+    async def test_expire_overdue_disables_and_reports_names(self, repo: TaskRepository) -> None:
+        """Expired tasks are disabled, not deleted — the record explains itself."""
+        await repo.create(
+            name="stale", prompt="p", interval_seconds=60, channel_id=1, until=time.time() - 1
+        )
+        await repo.create(
+            name="fresh", prompt="p", interval_seconds=60, channel_id=1, until=time.time() + HOUR
+        )
+        await repo.create(name="forever", prompt="p", interval_seconds=60, channel_id=1)
+
+        expired = await repo.expire_overdue()
+
+        assert expired == ["stale"]
+        remaining = {t["name"]: t["enabled"] for t in await repo.get_all()}
+        assert remaining == {"stale": False, "fresh": True, "forever": True}
+
+    async def test_expire_overdue_is_idempotent(self, repo: TaskRepository) -> None:
+        await repo.create(
+            name="stale", prompt="p", interval_seconds=60, channel_id=1, until=time.time() - 1
+        )
+        assert await repo.expire_overdue() == ["stale"]
+        assert await repo.expire_overdue() == []
+
+
+class TestMigrationCompatibility:
+    async def test_until_column_added_to_a_pre_existing_table(self, tmp_path) -> None:
+        """A database created before ``until`` existed must keep working."""
+        import aiosqlite
+
+        db_path = str(tmp_path / "legacy.db")
+        async with aiosqlite.connect(db_path) as db:
+            await db.execute(
+                """CREATE TABLE scheduled_tasks (
+                       id INTEGER PRIMARY KEY AUTOINCREMENT,
+                       name TEXT NOT NULL UNIQUE,
+                       prompt TEXT NOT NULL,
+                       interval_seconds INTEGER NOT NULL,
+                       channel_id INTEGER NOT NULL,
+                       working_dir TEXT,
+                       enabled INTEGER NOT NULL DEFAULT 1,
+                       next_run_at REAL NOT NULL,
+                       last_run_at REAL,
+                       created_at REAL NOT NULL)"""
+            )
+            await db.execute(
+                """INSERT INTO scheduled_tasks
+                   (name, prompt, interval_seconds, channel_id, enabled, next_run_at, created_at)
+                   VALUES ('legacy', 'p', 60, 1, 1, ?, ?)""",
+                (time.time() - 1, time.time()),
+            )
+            await db.commit()
+
+        repo = TaskRepository(db_path)
+        await repo.init_db()
+
+        due = await repo.get_due()
+        assert [t["name"] for t in due] == ["legacy"]
+        assert due[0]["until"] is None

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -77,7 +77,7 @@ class TestFindMainRepo:
         main_git.mkdir(parents=True)
 
         git_file = worktree_dir / ".git"
-        git_file.write_text(f"gitdir: {main_git}\n")
+        git_file.write_text(f"gitdir: {main_git}\n", encoding="utf-8")
 
         result = _find_main_repo(str(worktree_dir))
         assert result == str(tmp_path / "main-repo")
@@ -90,7 +90,7 @@ class TestFindMainRepo:
     def test_non_gitdir_content_returns_none(self, tmp_path: Path) -> None:
         d = tmp_path / "weird"
         d.mkdir()
-        (d / ".git").write_text("not a gitdir line\n")
+        (d / ".git").write_text("not a gitdir line\n", encoding="utf-8")
         assert _find_main_repo(str(d)) is None
 
 
@@ -133,12 +133,16 @@ class TestFindSessionWorktrees:
         # Create a fake session worktree directory
         session_wt = tmp_path / "wt-12345"
         session_wt.mkdir()
-        (session_wt / ".git").write_text("gitdir: /fake/repo/.git/worktrees/wt-12345\n")
+        (session_wt / ".git").write_text(
+            "gitdir: /fake/repo/.git/worktrees/wt-12345\n", encoding="utf-8"
+        )
 
         # Non-session worktree (feature branch) — should be excluded
         feature_wt = tmp_path / "wt-feat"
         feature_wt.mkdir()
-        (feature_wt / ".git").write_text("gitdir: /fake/repo/.git/worktrees/wt-feat\n")
+        (feature_wt / ".git").write_text(
+            "gitdir: /fake/repo/.git/worktrees/wt-feat\n", encoding="utf-8"
+        )
 
         # Not a worktree (no .git file)
         plain_dir = tmp_path / "wt-notgit"
@@ -178,7 +182,7 @@ class TestCleanupForThread:
     def test_removes_clean_worktree(self, tmp_path: Path) -> None:
         wt_path = tmp_path / "wt-999"
         wt_path.mkdir()
-        (wt_path / ".git").write_text("gitdir: /repo/.git/worktrees/wt-999\n")
+        (wt_path / ".git").write_text("gitdir: /repo/.git/worktrees/wt-999\n", encoding="utf-8")
 
         with (
             patch("claude_discord.worktree._is_clean", return_value=True),
@@ -195,7 +199,7 @@ class TestCleanupForThread:
     def test_skips_dirty_worktree(self, tmp_path: Path) -> None:
         wt_path = tmp_path / "wt-999"
         wt_path.mkdir()
-        (wt_path / ".git").write_text("gitdir: /repo/.git/worktrees/wt-999\n")
+        (wt_path / ".git").write_text("gitdir: /repo/.git/worktrees/wt-999\n", encoding="utf-8")
 
         with patch("claude_discord.worktree._is_clean", return_value=False):
             wm = WorktreeManager(base_dir=str(tmp_path))
@@ -213,7 +217,7 @@ class TestCleanupForThread:
     def test_handles_git_remove_failure(self, tmp_path: Path) -> None:
         wt_path = tmp_path / "wt-123"
         wt_path.mkdir()
-        (wt_path / ".git").write_text("gitdir: /repo/.git/worktrees/wt-123\n")
+        (wt_path / ".git").write_text("gitdir: /repo/.git/worktrees/wt-123\n", encoding="utf-8")
 
         with (
             patch("claude_discord.worktree._is_clean", return_value=True),
@@ -237,7 +241,7 @@ class TestCleanupOrphaned:
     def test_skips_active_sessions(self, tmp_path: Path) -> None:
         wt_path = tmp_path / "wt-555"
         wt_path.mkdir()
-        (wt_path / ".git").write_text("gitdir: /repo/.git/worktrees/wt-555\n")
+        (wt_path / ".git").write_text("gitdir: /repo/.git/worktrees/wt-555\n", encoding="utf-8")
 
         with (
             patch("claude_discord.worktree._get_branch", return_value="session/555"),
@@ -254,7 +258,7 @@ class TestCleanupOrphaned:
     def test_removes_orphaned_clean_worktree(self, tmp_path: Path) -> None:
         wt_path = tmp_path / "wt-777"
         wt_path.mkdir()
-        (wt_path / ".git").write_text("gitdir: /repo/.git/worktrees/wt-777\n")
+        (wt_path / ".git").write_text("gitdir: /repo/.git/worktrees/wt-777\n", encoding="utf-8")
 
         with (
             patch("claude_discord.worktree._get_branch", return_value="session/777"),

--- a/uv.lock
+++ b/uv.lock
@@ -171,6 +171,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
+    { name = "pytest-timeout" },
     { name = "ruff" },
 ]
 
@@ -192,6 +193,7 @@ dev = [
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "pytest-asyncio", specifier = ">=1.4.0" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
+    { name = "pytest-timeout", specifier = ">=2.4.0" },
     { name = "ruff", specifier = ">=0.16.1" },
 ]
 
@@ -582,6 +584,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "pytest-timeout"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -147,7 +147,7 @@ wheels = [
 
 [[package]]
 name = "claude-code-discord-bridge"
-version = "3.3.12"
+version = "3.3.18"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Why

Two problems, one root cause: scheduling existed but was neither discoverable nor complete.

1. **`POST /api/schedule` was a black hole.** The framework stores scheduled notifications but nothing in the framework ever sent them — the only send loop lived in `examples/ebibot/cogs/reminder.py`, against a *different* database (`data/bot.db` vs the deployment's `notifications.db`). On this deployment that left 5 pending notifications, oldest from 18 Jul, that were never going to be delivered.
2. **Sessions did not know they could schedule themselves.** `/api/tasks` has supported `thread_id` follow-ups and `one_shot` for a while, documented only in the README. A session asked to "remind me tonight if I haven't replied" built it with an external host scheduler instead, because nothing in its context said the capability was there.

## What

**Reminders as a framework feature** (`cogs/reminder.py`, `reminders.py`)

- `/remind when what [check] [every] [until]` and `/reminders`
- Without `check` → a notification row. One Discord message, no agent run.
- With `check` → a scheduled task whose prompt verifies the condition first and **stays silent when the thing is already done**, then retires itself.
- `ReminderCog` owns the notification send loop, so `POST /api/schedule` delivers in every deployment. `apply_to_api_server` now points the API at the same store the loop drains, which is how the two-databases split happened in the first place.
- A repeating reminder with neither `check` nor `until` is refused rather than accepted and left to nag forever.

**Scheduler primitives** (`database/task_repo.py`, `ext/api_server.py`)

- `run_at` — absolute first run (`"21:30"`, `"2h"`, ISO 8601), overriding `run_immediately`/`anchor_time`
- `until` — the task stops on its own; expired tasks are **disabled, not deleted**, so the record still explains why it never fired
- `DELETE /api/tasks/by-name/{name}` — a scheduled session knows its name, never its row id
- `channel_id` optional when `thread_id` is given
- Both new columns are nullable migrations; a pre-`until` database keeps working (covered by a test)

**Discoverability** — every session's system context now includes a short block showing how to register its own follow-up, with the rule "never claim you will follow up later without registering it".

**Cross-platform CI** — the README claimed macOS and Windows "pass CI" while all 8 workflows ran `[self-hosted, linux, x64]`. Adds a `cross-platform` job (macOS + Windows hosted runners, free for a public repo) and corrects the wording. The package ships `sys.platform` branches (signal handling, `.cmd`/`.bat` resolution) that no Linux run exercises.

## Test plan

- [x] `uv run pytest tests/ -q` — 2112 passed
- [x] `ruff check` / `ruff format --check` / `pyright` clean
- [x] Coverage gate (75%) holds — 81.8%
- [x] New tests: time parsing and prompt building (pure), `run_at`/`until`/`expire_overdue` incl. legacy-schema migration, API validation and by-name delete, ReminderCog drain loop and both `/remind` paths
- [ ] macOS + Windows CI — first run is on this PR; that is the point of the job
- [ ] Live check on Discord via `make dev-on` (deferred: three sessions had turns in flight, and `dev-on` restarts the bot — announced in the AI Lounge, will run once they drain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)