### PR TITLE
Adopt the Ebi Agent Chat Relay brand (rename phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `elicitation_view.py` are removed; they had no callers left and no public exports.
   AskUserQuestion is untouched and still uses its own persisted view.
 
+- **The project is now called Ebi Agent Chat Relay** — phase 1 of the rename in
+  [ADR-0001](docs/adr/0001-adopt-ebi-agent-chat-relay.md), covering brand text only. The
+  README and the distribution description carry the new name with a "formerly" note; the
+  repository, the `claude-code-discord-bridge` distribution, the `ccdb` command, every
+  `CCDB_*` variable, all REST routes, persisted data paths and Python import names are
+  **unchanged**, and none of them may change without a separate accepted ADR and a major
+  release. Existing installations keep starting exactly as before, and `ccdb` stays the
+  short name used throughout the documentation. Translated READMEs are refreshed by the
+  existing translation workflow on the next release.
+
 ### Fixed
 
 - Report persisted sessions without an in-flight turn as `history` instead of `idle`,

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# Claude & Codex Discord Bridge
+# Ebi Agent Chat Relay
 
-*Package name: `claude-code-discord-bridge` (kebab-case)*
+*Formerly Claude Code Discord Bridge, then Claude & Codex Discord Bridge. Every existing
+identifier still works: the package is `claude-code-discord-bridge` (kebab-case), the
+command is `ccdb`, and `ccdb` remains the short name used throughout this document.*
 
 [![CI](https://github.com/ebibibi/claude-code-discord-bridge/actions/workflows/ci.yml/badge.svg)](https://github.com/ebibibi/claude-code-discord-bridge/actions/workflows/ci.yml)
 [![CodeQL](https://github.com/ebibibi/claude-code-discord-bridge/actions/workflows/codeql.yml/badge.svg)](https://github.com/ebibibi/claude-code-discord-bridge/actions/workflows/codeql.yml)
@@ -9,7 +11,9 @@
 
 **Use Claude Code _or_ OpenAI Codex on your phone. Multiple threads. All at once. Real development included.**
 
-Open Claude Code or OpenAI Codex from your smartphone's Discord app, spin up multiple threads, and run parallel development sessions — all without touching a keyboard. Each Discord thread becomes a fully isolated AI session. Work on a feature in one thread, review a PR in another, and run a background task in a third — simultaneously, even mixing backends per thread. The bridge handles all the coordination so sessions never clobber each other.
+Open Claude Code or OpenAI Codex from your smartphone's Discord app, spin up multiple threads, and run parallel development sessions — all without touching a keyboard. Each Discord thread becomes a fully isolated AI session. Work on a feature in one thread, review a PR in another, and run a background task in a third — simultaneously, even mixing backends per thread. The relay handles all the coordination so sessions never clobber each other.
+
+**Why the name changed.** This started as a bridge between one AI and one chat app, and the old name said exactly that. It is now a relay: several agent backends (Claude Code, OpenAI Codex) reachable from a chat surface, with the surface itself becoming pluggable — Discord today, Microsoft Teams next. Three of the four words in the old name had stopped being true. See [ADR-0001](docs/adr/0001-adopt-ebi-agent-chat-relay.md) for the decision and [the rename plan](docs/RENAME_PLAN.md) for how the change is being made without breaking a single existing install.
 
 **Use your existing subscriptions. No API key wrangling.** ccdb runs on top of the official CLIs — Claude Code (included with your [Claude Pro/Max subscription](https://claude.ai/pricing)) and OpenAI Codex (included with [ChatGPT Plus/Pro/Business](https://chatgpt.com)). Switch backends with `/backend` or set a per-thread override — your team gets both AIs through Discord at predictable cost.
 
@@ -23,7 +27,7 @@ Open Claude Code or OpenAI Codex from your smartphone's Discord app, spin up mul
 
 ## The Big Idea: Parallel Sessions Without Fear
 
-When you send tasks to Claude Code or OpenAI Codex in separate Discord threads, the bridge does four things automatically — regardless of which backend you picked:
+When you send tasks to Claude Code or OpenAI Codex in separate Discord threads, the relay does four things automatically — regardless of which backend you picked:
 
 1. **Concurrency notice injection** — Every session's system prompt includes mandatory instructions: create a git worktree, work only inside it, never touch the main working directory directly.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "claude-code-discord-bridge"
 version = "3.3.21"
-description = "Claude & Codex Discord Bridge — drive both Claude Code and OpenAI Codex from Discord with interactive chat, parallel sessions, and CI/CD automation"
+description = "Ebi Agent Chat Relay (formerly Claude & Codex Discord Bridge) — drive both Claude Code and OpenAI Codex from Discord with interactive chat, parallel sessions, and CI/CD automation"
 readme = "README.md"
 license = {text = "MIT"}
 requires-python = ">=3.12,<3.14"


### PR DESCRIPTION
Phase 1 of [ADR-0001](docs/adr/0001-adopt-ebi-agent-chat-relay.md), following [RENAME_PLAN.md](docs/RENAME_PLAN.md). PR boundary #2: **brand documentation and assets, nothing else.**

## What changes

- README leads with **Ebi Agent Chat Relay**, and says in one paragraph why the name changed — three of the four words in the old one had stopped being true.
- The distribution description carries the new name with a "formerly" note.
- CHANGELOG records the phase and, more importantly, records what did *not* move.

## What deliberately does not change

The repository name, the `claude-code-discord-bridge` distribution, the `ccdb` command, every `CCDB_*` variable, all REST routes, persisted data paths, and Python import names. Per the plan, none of those may change without a separate accepted ADR and a major release.

`ccdb` also stays the short name used throughout the README prose. Replacing ~40 in-text mentions would have meant touching lines that sit next to real commands, and a README full of a new name beside identifiers that do not exist is worse than the old name. The header states the relationship once, plainly.

## Compatibility gate

Every occurrence of the old product name was classified before anything was edited:

| Occurrence | Classification | Action |
|---|---|---|
| `README.md` title | stale branding | changed |
| `pyproject.toml` description | stale branding | changed, with "formerly" |
| `docs/adr/0001-*.md` | the recorded decision | kept |
| `docs/RENAME_PLAN.md` | the plan's own text | kept |
| `CHANGELOG.md` (3.0 entry) | history | kept |
| `docs/{ja,zh-CN,ko,es,pt-BR,fr}/README.md` | translation | left to the translation workflow, which runs on release publish |

Installation and command examples still use identifiers that exist — that is the gate this phase has to pass, and it does: no example in the README refers to anything that is not currently installable or runnable.

## Verification

- 2,027 tests pass (no code touched)
- Documentation links resolve, including the two new links into `docs/adr/` and `docs/RENAME_PLAN.md`

## Not in this PR

- Renaming the repository or publishing an `ebi-agent-chat-relay` distribution — that is Phase 2, and it needs redirect verification first
- The **GitHub repository description**, which is a one-click owner action rather than something to change from a PR
- Any CLI or configuration alias — Phase 3

Left as a draft: it is independent of the Teams abstraction work, but there is no reason to land a brand change ahead of the release that will regenerate the translations.