### PR TITLE
feat: local anonymization gateway for outbound prompts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -105,3 +105,12 @@ SESSION_TIMEOUT_SECONDS=300
 # version. Because this file is loaded via EnvironmentFile=, setting PATH here
 # fixes it for the service and every session it spawns.
 # PATH=/home/you/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
+
+# Anonymization gateway (optional, off until a rules file exists)
+# Replaces the terms that identify your organisation before the prompt reaches
+# the external CLI, and restores them in the answer. A local model checks for
+# replacement misses. See docs/anonymization.md.
+# CCDB_ANONYMIZE_RULES=/home/you/.ccdb/anonymize-rules.json
+# CCDB_ANONYMIZE_POLICY=block
+# CCDB_ANONYMIZE_INSPECTOR_URL=http://127.0.0.1:11434
+# CCDB_ANONYMIZE_INSPECTOR_MODEL=qwen3:4b

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,8 @@ Discord frontend for Claude Code CLI. **This is a framework (OSS library), not a
 10. **CLI env overlay** (`CCDB_CLI_ENV_FILE`): Optional `KEY=VALUE` file read on every CLI spawn to inject env vars into the subprocess. Enables live configuration changes (e.g., switching to Azure Foundry) without restarting the bot. The file is read by `_build_env()` in `runner.py`.
 11. **Model suggestions are discovered, not hardcoded** (`model_catalog.py`): the `/model` autocomplete asks `GET /v1/models` (reusing the CLI's own credentials) instead of shipping a constant that goes stale on every model launch. This is the *only* sanctioned direct Anthropic API call, and it is strictly non-essential: no credentials, no network, a 3P provider, or `CCDB_MODEL_DISCOVERY=0` all degrade to the static `SUGGESTED_MODELS` fallback. Never let it raise into a command path, and never log the token.
 
+12. **Anonymization replaces by rule, inspects by model** (`claude_code_core/privacy/`): an optional gateway wraps any `SessionBackend` and swaps organisation-identifying terms for stable aliases before the prompt reaches the CLI, restoring them in the answer. The substitution is a rule table — never a model — because a model produces a different alias every run and an alias that changes cannot be restored. The local LLM's only job is to *report* proper nouns the rules missed. Reversing those two roles breaks the feature. Off until a rules file exists; a malformed rules file raises rather than silently degrading to "send the real names". See `docs/anonymization.md`.
+
 ### Why REST API over stdout markers for Claude→ccdb communication
 
 Alternative considered: Claude embeds `<!-- ccdb:schedule {...} -->` in response text; ccdb parses stdout.
@@ -263,6 +265,20 @@ examples/
 pyproject.toml           # Package metadata + dependencies
 uv.lock                  # Dependency lock file
 CONTRIBUTING.md          # Contribution guidelines
+```
+
+`claude_code_core/privacy/` — the anonymization gateway (surface-agnostic, so a
+Teams or CLI frontend gets it for free):
+
+```
+  rules.py               # Rule table loader (literals, regexes, builtin detectors)
+  mapping.py             # 対応表 — persistent, local, bidirectional alias store
+  engine.py              # Deterministic replace + restore. Calls no model, ever
+  inspector.py           # Local Ollama-compatible leftover check. Reports only
+  config.py              # Env-driven config; absent rules file = feature off
+  audit.py               # JSONL trail of what actually left the machine
+  gateway.py             # Policy (block/warn/off) + process-wide accessor
+  backend.py             # AnonymizingBackend — SessionBackend decorator
 ```
 
 ### Adding a New Cog

--- a/README.md
+++ b/README.md
@@ -466,6 +466,7 @@ Behind the scenes:
 - **Secret isolation** — Bot token stripped from subprocess environment
 - **User authorization** — `allowed_user_ids` restricts who can invoke Claude
 - **Log injection prevention** — User-provided API values are sanitized (newlines stripped) before writing to logs
+- **Anonymization gateway** (optional) — Replaces organisation-identifying terms with stable aliases before the prompt reaches Claude or Codex, and restores them in the answer. A local model checks the result for replacement misses and, by default, blocks the send when it finds one. Off until you write a rules file — see [docs/anonymization.md](docs/anonymization.md)
 
 ---
 

--- a/claude_code_core/backend.py
+++ b/claude_code_core/backend.py
@@ -64,11 +64,31 @@ def create_backend(
     if backend == "claude":
         from .runner import ClaudeRunner
 
-        return ClaudeRunner(model=model, **kwargs)  # type: ignore[arg-type]
-
-    if backend == "codex":
+        runner: SessionBackend = ClaudeRunner(model=model, **kwargs)  # type: ignore[arg-type]
+    elif backend == "codex":
         from .codex_runner import CodexRunner
 
-        return CodexRunner(model=model, **kwargs)  # type: ignore[arg-type]
+        runner = CodexRunner(model=model, **kwargs)  # type: ignore[arg-type]
+    else:
+        raise ValueError(f"Unknown backend: {backend!r}")
 
-    raise ValueError(f"Unknown backend: {backend!r}")
+    return _apply_privacy_gateway(runner, backend=backend, thread_id=kwargs.get("thread_id"))
+
+
+def _apply_privacy_gateway(
+    runner: SessionBackend,
+    *,
+    backend: str,
+    thread_id: object = None,
+) -> SessionBackend:
+    """Wrap ``runner`` with the anonymization gateway when one is configured.
+
+    Auto-discovery keeps this zero-config: with no rules file the gateway is
+    ``None`` and the runner is returned untouched.
+    """
+    from .privacy import AnonymizingBackend, get_gateway
+
+    gateway = get_gateway()
+    if gateway is None:
+        return runner
+    return AnonymizingBackend(runner, gateway, backend=backend, thread_id=thread_id)

--- a/claude_code_core/privacy/__init__.py
+++ b/claude_code_core/privacy/__init__.py
@@ -1,0 +1,48 @@
+"""Anonymization gateway: local, deterministic, reversible.
+
+Rule-based replacement happens on this machine, a local model checks for
+leftovers, and only then does the text reach an external CLI (Claude Code,
+Codex, ...). Answers are restored on the way back.
+
+Design rules, in order of importance:
+
+1. **Rules replace, models inspect.** A model that rewrites text produces a
+   different result every run, and a different result cannot be restored.
+2. **The mapping table never leaves the machine.** It is the only thing that
+   can undo the replacement.
+3. **Absent rules mean the feature is off**, and a *broken* rules file is an
+   error — never a silent downgrade to sending real names.
+"""
+
+from __future__ import annotations
+
+from .audit import AuditLog
+from .backend import AnonymizingBackend
+from .config import InspectionPolicy, PrivacyConfig
+from .engine import AnonymizationResult, Anonymizer, Replacement
+from .gateway import GuardOutcome, PrivacyGateway, get_gateway, reset_gateway_cache
+from .inspector import InspectionResult, LocalLlmInspector, Suspect
+from .mapping import MappingStore
+from .rules import AnonymizationRules, Category, Matcher, RulesError
+
+__all__ = [
+    "AnonymizationResult",
+    "AnonymizationRules",
+    "Anonymizer",
+    "AnonymizingBackend",
+    "AuditLog",
+    "Category",
+    "GuardOutcome",
+    "InspectionPolicy",
+    "InspectionResult",
+    "LocalLlmInspector",
+    "MappingStore",
+    "Matcher",
+    "PrivacyConfig",
+    "PrivacyGateway",
+    "Replacement",
+    "RulesError",
+    "Suspect",
+    "get_gateway",
+    "reset_gateway_cache",
+]

--- a/claude_code_core/privacy/audit.py
+++ b/claude_code_core/privacy/audit.py
@@ -1,0 +1,61 @@
+"""Append-only audit trail for everything that crossed the boundary.
+
+"いつ・誰が・何を送ったか" — without this the gateway would just be a filter,
+and the operator would still be unable to answer an auditor's question.
+
+What is recorded: the anonymized text (what actually left the machine), the
+aliases used, the inspector verdict, and the decision. What is NOT recorded:
+the original text. The originals live only in the mapping table.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["AuditLog"]
+
+
+class AuditLog:
+    """JSON Lines writer. Never raises into the request path."""
+
+    def __init__(self, path: str | Path | None, *, include_text: bool = True) -> None:
+        self._path = Path(path) if path is not None else None
+        self._include_text = include_text
+        self._lock = threading.Lock()
+
+    @property
+    def path(self) -> Path | None:
+        return self._path
+
+    def record(self, event: str, **fields: Any) -> None:
+        """Append one record. Disabled (path=None) means silently skip."""
+        if self._path is None:
+            return
+        payload: dict[str, Any] = {
+            "ts": datetime.now(UTC).isoformat(timespec="seconds"),
+            "event": event,
+        }
+        if not self._include_text:
+            fields.pop("text", None)
+        payload.update({k: v for k, v in fields.items() if v is not None})
+        line = json.dumps(payload, ensure_ascii=False) + "\n"
+        try:
+            with self._lock:
+                self._path.parent.mkdir(parents=True, exist_ok=True)
+                existed = self._path.exists()
+                with self._path.open("a", encoding="utf-8") as handle:
+                    handle.write(line)
+                if not existed:
+                    os.chmod(self._path, 0o600)
+        except OSError:
+            # An unwritable audit log is a real problem, but failing the user's
+            # message over it would be worse. Log loudly instead of silently.
+            logger.exception("Failed to append to audit log %s", self._path)

--- a/claude_code_core/privacy/backend.py
+++ b/claude_code_core/privacy/backend.py
@@ -1,0 +1,158 @@
+"""SessionBackend decorator that anonymizes on the way out and restores on the
+way back.
+
+Wrapping the backend — rather than editing ClaudeRunner and CodexRunner — means
+both CLIs are covered by one implementation, and a backend added tomorrow is
+covered for free.
+
+Attribute access is delegated in *both* directions: several Cogs mutate the
+runner in place (``runner.images = ...``, ``runner.working_dir = ...``), and
+those writes must land on the real runner, not on this shell.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+from collections.abc import AsyncGenerator
+from typing import TYPE_CHECKING, Any
+
+from ..types import ImageData, MessageType, StreamEvent
+
+if TYPE_CHECKING:
+    from ..backend import SessionBackend
+    from .gateway import PrivacyGateway
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["AnonymizingBackend"]
+
+_PASSTHROUGH = ("_inner", "_gateway", "_context")
+
+
+class AnonymizingBackend:
+    """Wraps a SessionBackend with the anonymization gateway."""
+
+    # Declared, never assigned: reads and writes are forwarded to the inner
+    # backend by ``__getattr__`` / ``__setattr__``. The annotations exist so the
+    # wrapper still satisfies the SessionBackend protocol for a type checker.
+    command: str
+    model: str
+    working_dir: str | None
+    permission_mode: str
+    images: list[ImageData] | None
+    api_port: int | None
+    timeout_seconds: int
+    dangerously_skip_permissions: bool
+    allowed_tools: list[str] | None
+
+    def __init__(
+        self,
+        inner: SessionBackend,
+        gateway: PrivacyGateway,
+        **context: Any,
+    ) -> None:
+        object.__setattr__(self, "_inner", inner)
+        object.__setattr__(self, "_gateway", gateway)
+        object.__setattr__(self, "_context", context)
+
+    # ------------------------------------------------------------ delegation
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(object.__getattribute__(self, "_inner"), name)
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        if name in _PASSTHROUGH:
+            object.__setattr__(self, name, value)
+        else:
+            setattr(object.__getattribute__(self, "_inner"), name, value)
+
+    @property
+    def inner(self) -> SessionBackend:
+        return object.__getattribute__(self, "_inner")
+
+    # ------------------------------------------------------------------ run
+
+    async def run(
+        self,
+        prompt: str,
+        session_id: str | None = None,
+    ) -> AsyncGenerator[StreamEvent, None]:
+        gateway: PrivacyGateway = object.__getattribute__(self, "_gateway")
+        context: dict[str, Any] = dict(object.__getattribute__(self, "_context"))
+        context.setdefault("session_id", session_id)
+        context.setdefault("backend", getattr(self.inner, "command", ""))
+
+        outcome = await gateway.guard(prompt, **context)
+        if not outcome.allowed:
+            yield StreamEvent(
+                raw={},
+                message_type=MessageType.RESULT,
+                is_complete=True,
+                error=outcome.reason,
+            )
+            return
+
+        if outcome.warning:
+            yield StreamEvent(
+                raw={},
+                message_type=MessageType.SYSTEM,
+                text=f"⚠️ {outcome.warning}",
+            )
+
+        async for event in self.inner.run(outcome.text, session_id):
+            yield _restore_event(event, gateway)
+
+    # ------------------------------------------------- explicit delegations
+    # ``__getattr__`` already forwards these at runtime; spelling them out
+    # keeps the protocol satisfied for the type checker.
+
+    async def interrupt(self) -> None:
+        await self.inner.interrupt()
+
+    async def kill(self) -> None:
+        await self.inner.kill()
+
+    async def inject_tool_result(self, request_id: str, data: dict) -> None:
+        await self.inner.inject_tool_result(request_id, data)
+
+    def _build_env(self) -> dict[str, str]:
+        return self.inner._build_env()
+
+    def describe_api(self) -> str:
+        return self.inner.describe_api()
+
+    def clone(self, **kwargs: object) -> AnonymizingBackend:
+        """Clone the inner backend and re-wrap it — the guard must survive."""
+        gateway: PrivacyGateway = object.__getattribute__(self, "_gateway")
+        context: dict[str, Any] = object.__getattribute__(self, "_context")
+        return AnonymizingBackend(self.inner.clone(**kwargs), gateway, **context)
+
+
+def _restore_event(event: StreamEvent, gateway: PrivacyGateway) -> StreamEvent:
+    """Return a copy of ``event`` with aliases turned back into real names.
+
+    Only fields that reach a human are rewritten. ``raw`` is left untouched:
+    it is the transport record of what the external model actually said, and
+    rewriting it would make the audit trail lie.
+    """
+    changes: dict[str, Any] = {}
+    for attr in ("text", "thinking", "tool_result_content", "error"):
+        value = getattr(event, attr, None)
+        if isinstance(value, str) and value:
+            restored = gateway.restore(value)
+            if restored != value:
+                changes[attr] = restored
+
+    tool_use = event.tool_use
+    if tool_use is not None and tool_use.tool_input:
+        restored_input = {
+            key: (gateway.restore(val) if isinstance(val, str) else val)
+            for key, val in tool_use.tool_input.items()
+        }
+        if restored_input != tool_use.tool_input:
+            changes["tool_use"] = dataclasses.replace(tool_use, tool_input=restored_input)
+
+    if not changes:
+        return event
+    return dataclasses.replace(event, **changes)

--- a/claude_code_core/privacy/config.py
+++ b/claude_code_core/privacy/config.py
@@ -1,0 +1,122 @@
+"""Environment-driven configuration for the anonymization gateway.
+
+Zero-config rule: the feature turns itself on when a rules file exists and off
+when it does not. There is nothing to wire up in a consumer's code.
+
+Empty environment variables are treated as *unset*. ``os.environ.get(k, d)``
+returns ``""`` when the key exists but is blank, which silently kills defaults;
+every read here goes through ``_env`` to avoid that.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["PrivacyConfig", "InspectionPolicy"]
+
+DEFAULT_DIR = Path.home() / ".ccdb"
+DEFAULT_RULES_NAME = "anonymize-rules.json"
+DEFAULT_MAPPING_NAME = "anonymize-mapping.json"
+DEFAULT_AUDIT_NAME = "anonymize-audit.jsonl"
+DEFAULT_INSPECTOR_URL = "http://127.0.0.1:11434"
+DEFAULT_INSPECTOR_MODEL = "qwen3:4b"
+DEFAULT_INSPECTOR_TIMEOUT = 30.0
+
+
+class InspectionPolicy:
+    """What to do when the local inspector finds — or cannot look for — leftovers."""
+
+    BLOCK = "block"  # refuse to send; show the operator what was found
+    WARN = "warn"  # send anyway, but log and surface the finding
+    OFF = "off"  # do not inspect at all (rule-based replacement still runs)
+
+    ALL = (BLOCK, WARN, OFF)
+
+
+def _env(name: str) -> str | None:
+    """Read an env var, treating blank as unset."""
+    value = os.environ.get(name)
+    if value is None:
+        return None
+    value = value.strip()
+    return value or None
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    raw = _env(name)
+    if raw is None:
+        return default
+    return raw.lower() not in ("0", "false", "no", "off")
+
+
+@dataclass(frozen=True)
+class PrivacyConfig:
+    """Resolved gateway settings."""
+
+    rules_path: Path
+    mapping_path: Path
+    audit_path: Path | None
+    inspector_url: str = DEFAULT_INSPECTOR_URL
+    inspector_model: str = DEFAULT_INSPECTOR_MODEL
+    inspector_timeout: float = DEFAULT_INSPECTOR_TIMEOUT
+    policy: str = InspectionPolicy.BLOCK
+    audit_includes_text: bool = True
+    explicitly_disabled: bool = False
+
+    @property
+    def rules_exist(self) -> bool:
+        return self.rules_path.is_file()
+
+    @property
+    def active(self) -> bool:
+        """The gateway runs only when it has rules and was not switched off."""
+        return not self.explicitly_disabled and self.rules_exist
+
+    @classmethod
+    def from_env(cls) -> PrivacyConfig:
+        rules_path = Path(_env("CCDB_ANONYMIZE_RULES") or DEFAULT_DIR / DEFAULT_RULES_NAME)
+        base_dir = rules_path.parent
+
+        mapping_raw = _env("CCDB_ANONYMIZE_MAPPING")
+        mapping_path = Path(mapping_raw) if mapping_raw else base_dir / DEFAULT_MAPPING_NAME
+
+        if _env_bool("CCDB_ANONYMIZE_AUDIT_ENABLED", True):
+            audit_raw = _env("CCDB_ANONYMIZE_AUDIT")
+            audit_path: Path | None = (
+                Path(audit_raw) if audit_raw else base_dir / DEFAULT_AUDIT_NAME
+            )
+        else:
+            audit_path = None
+
+        policy = (_env("CCDB_ANONYMIZE_POLICY") or InspectionPolicy.BLOCK).lower()
+        if policy not in InspectionPolicy.ALL:
+            logger.warning(
+                "Unknown CCDB_ANONYMIZE_POLICY=%r; falling back to %r",
+                policy,
+                InspectionPolicy.BLOCK,
+            )
+            policy = InspectionPolicy.BLOCK
+
+        timeout_raw = _env("CCDB_ANONYMIZE_INSPECTOR_TIMEOUT")
+        try:
+            timeout = float(timeout_raw) if timeout_raw else DEFAULT_INSPECTOR_TIMEOUT
+        except ValueError:
+            logger.warning("Invalid CCDB_ANONYMIZE_INSPECTOR_TIMEOUT=%r", timeout_raw)
+            timeout = DEFAULT_INSPECTOR_TIMEOUT
+
+        return cls(
+            rules_path=rules_path,
+            mapping_path=mapping_path,
+            audit_path=audit_path,
+            inspector_url=_env("CCDB_ANONYMIZE_INSPECTOR_URL") or DEFAULT_INSPECTOR_URL,
+            inspector_model=_env("CCDB_ANONYMIZE_INSPECTOR_MODEL") or DEFAULT_INSPECTOR_MODEL,
+            inspector_timeout=timeout,
+            policy=policy,
+            audit_includes_text=_env_bool("CCDB_ANONYMIZE_AUDIT_TEXT", True),
+            explicitly_disabled=not _env_bool("CCDB_ANONYMIZE", True),
+        )

--- a/claude_code_core/privacy/engine.py
+++ b/claude_code_core/privacy/engine.py
@@ -1,0 +1,170 @@
+"""Deterministic, reversible replacement engine.
+
+The whole design rests on one property: replacement is a *pure function of the
+rules and the mapping table*. Run it a thousand times and ``srv-example-dc01``
+becomes the same alias every time — which is the only reason the answer can be
+put back together afterwards.
+
+Nothing here calls a model. See ``inspector.py`` for the local-LLM half, whose
+job is to *report* leftovers, never to rewrite text.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+
+from .mapping import MappingStore
+from .rules import AnonymizationRules
+
+__all__ = ["Anonymizer", "AnonymizationResult", "Replacement"]
+
+
+@dataclass(frozen=True)
+class Replacement:
+    """One original→alias substitution that actually fired."""
+
+    original: str
+    alias: str
+    category: str
+    count: int
+
+
+@dataclass(frozen=True)
+class AnonymizationResult:
+    """Outcome of anonymizing one piece of text."""
+
+    text: str
+    replacements: tuple[Replacement, ...] = ()
+    original_length: int = 0
+
+    @property
+    def changed(self) -> bool:
+        return bool(self.replacements)
+
+    @property
+    def total_substitutions(self) -> int:
+        return sum(r.count for r in self.replacements)
+
+    def summary(self) -> str:
+        """Human-readable one-liner for logs and audit records."""
+        if not self.replacements:
+            return "no substitutions"
+        parts = [f"{r.original}→{r.alias}(x{r.count})" for r in self.replacements]
+        return ", ".join(parts)
+
+
+@dataclass
+class Anonymizer:
+    """Applies rules to text and restores aliases in the answer."""
+
+    rules: AnonymizationRules
+    store: MappingStore = field(default_factory=MappingStore)
+    _restore_pattern: re.Pattern[str] | None = field(default=None, init=False, repr=False)
+    _restore_size: int = field(default=-1, init=False, repr=False)
+
+    # ------------------------------------------------------------ anonymize
+
+    def anonymize(self, text: str) -> AnonymizationResult:
+        """Replace every rule hit with its stable alias."""
+        if not text or self.rules.is_empty:
+            return AnonymizationResult(text=text, original_length=len(text or ""))
+
+        spans = self._collect_spans(text)
+        if not spans:
+            return AnonymizationResult(text=text, original_length=len(text))
+
+        pieces: list[str] = []
+        counts: dict[tuple[str, str], int] = {}
+        aliases: dict[tuple[str, str], str] = {}
+        first_seen: dict[tuple[str, str], str] = {}
+        cursor = 0
+        for start, end, category in spans:
+            original = text[start:end]
+            alias = self.store.alias_for(category, original)
+            pieces.append(text[cursor:start])
+            pieces.append(alias)
+            cursor = end
+            key = (category, original.casefold())
+            counts[key] = counts.get(key, 0) + 1
+            aliases.setdefault(key, alias)
+            first_seen.setdefault(key, original)
+        pieces.append(text[cursor:])
+
+        replacements = tuple(
+            Replacement(
+                original=first_seen[key],
+                alias=aliases[key],
+                category=key[0],
+                count=count,
+            )
+            for key, count in counts.items()
+        )
+        self._invalidate_restore_cache()
+        return AnonymizationResult(
+            text="".join(pieces),
+            replacements=replacements,
+            original_length=len(text),
+        )
+
+    def _collect_spans(self, text: str) -> list[tuple[int, int, str]]:
+        """Find non-overlapping match spans, honouring rule priority.
+
+        Rules earlier in ``rules.matchers`` win ties; literals are already
+        sorted longest-first by the loader, so "Contoso Japan" beats "Contoso".
+        """
+        candidates: list[tuple[int, int, int]] = []  # (start, end, priority)
+        categories: dict[tuple[int, int, int], str] = {}
+        for priority, matcher in enumerate(self.rules.matchers):
+            for match in matcher.pattern.finditer(text):
+                start, end = match.span()
+                if end <= start:
+                    continue
+                key = (start, end, priority)
+                candidates.append(key)
+                categories[key] = matcher.category
+
+        # Longer match first at the same offset, then rule priority.
+        candidates.sort(key=lambda c: (c[0], -(c[1] - c[0]), c[2]))
+
+        accepted: list[tuple[int, int, str]] = []
+        last_end = 0
+        for start, end, priority in candidates:
+            if start < last_end:
+                continue
+            accepted.append((start, end, categories[(start, end, priority)]))
+            last_end = end
+        return accepted
+
+    # -------------------------------------------------------------- restore
+
+    def restore(self, text: str) -> str:
+        """Put the real names back. Case-insensitive: models rewrite case."""
+        if not text:
+            return text
+        pattern = self._get_restore_pattern()
+        if pattern is None:
+            return text
+
+        def _sub(match: re.Match[str]) -> str:
+            original = self.store.original_for(match.group(0))
+            return original if original is not None else match.group(0)
+
+        return pattern.sub(_sub, text)
+
+    def _get_restore_pattern(self) -> re.Pattern[str] | None:
+        if self._restore_size == len(self.store) and self._restore_pattern is not None:
+            return self._restore_pattern
+        aliases = self.store.aliases()
+        if not aliases:
+            self._restore_pattern = None
+            self._restore_size = len(self.store)
+            return None
+        # Longest first: "203.0.113.10" must not be eaten by "203.0.113.1".
+        aliases.sort(key=len, reverse=True)
+        self._restore_pattern = re.compile("|".join(re.escape(a) for a in aliases), re.IGNORECASE)
+        self._restore_size = len(self.store)
+        return self._restore_pattern
+
+    def _invalidate_restore_cache(self) -> None:
+        self._restore_size = -1

--- a/claude_code_core/privacy/gateway.py
+++ b/claude_code_core/privacy/gateway.py
@@ -1,0 +1,228 @@
+"""The gateway: rules → replacement → local inspection → decision → audit.
+
+One object owns the whole boundary crossing, so the policy lives in exactly one
+place and can be tested without a Discord bot or a CLI subprocess.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+import threading
+from dataclasses import dataclass, field
+from typing import Any
+
+from .audit import AuditLog
+from .config import InspectionPolicy, PrivacyConfig
+from .engine import AnonymizationResult, Anonymizer
+from .inspector import InspectionResult, LocalLlmInspector
+from .mapping import MappingStore
+from .rules import AnonymizationRules
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["PrivacyGateway", "GuardOutcome", "get_gateway", "reset_gateway_cache"]
+
+
+@dataclass(frozen=True)
+class GuardOutcome:
+    """Whether the text may leave, and in what form."""
+
+    allowed: bool
+    text: str
+    result: AnonymizationResult
+    inspection: InspectionResult | None = None
+    reason: str | None = None
+    warning: str | None = None
+
+
+@dataclass
+class PrivacyGateway:
+    """Anonymize outbound text, inspect it locally, restore inbound text."""
+
+    anonymizer: Anonymizer
+    inspector: LocalLlmInspector | None = None
+    policy: str = InspectionPolicy.BLOCK
+    audit: AuditLog = field(default_factory=lambda: AuditLog(None))
+    _lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
+
+    async def guard(self, text: str, **context: Any) -> GuardOutcome:
+        """Anonymize ``text`` and decide whether it may be sent."""
+        with self._lock:
+            result = self.anonymizer.anonymize(text)
+
+        inspection: InspectionResult | None = None
+        if self.policy != InspectionPolicy.OFF and self.inspector is not None:
+            inspection = self._drop_own_output(await self.inspector.inspect(result.text))
+
+        allowed, reason, warning = self._decide(inspection)
+        self.audit.record(
+            "outbound",
+            allowed=allowed,
+            reason=reason,
+            warning=warning,
+            policy=self.policy,
+            substitutions=[
+                {"alias": r.alias, "category": r.category, "count": r.count}
+                for r in result.replacements
+            ],
+            inspector=(inspection.summary() if inspection else "not run"),
+            text=result.text,
+            **context,
+        )
+        if not allowed:
+            logger.warning("Anonymization gateway blocked a message: %s", reason)
+        elif warning:
+            logger.warning("Anonymization gateway warning: %s", warning)
+
+        return GuardOutcome(
+            allowed=allowed,
+            text=result.text,
+            result=result,
+            inspection=inspection,
+            reason=reason,
+            warning=warning,
+        )
+
+    def _drop_own_output(self, inspection: InspectionResult) -> InspectionResult:
+        """Discard suspects that are the anonymizer's own placeholders.
+
+        Observed in practice: told in plain language to ignore placeholders, a
+        local model still reports ``person-001@example.invalid`` as a real
+        address — and under the block policy that false positive stops a
+        message that was already safe. Asking the model more nicely is not a
+        fix; checking against the mapping table is. If restoring a suspect
+        changes it, we minted it, so it cannot be a leak.
+        """
+        if not inspection.suspects:
+            return inspection
+        with self._lock:
+            kept = tuple(
+                s for s in inspection.suspects if self.anonymizer.restore(s.value) == s.value
+            )
+        dropped = len(inspection.suspects) - len(kept)
+        if dropped:
+            logger.debug("Dropped %d inspector suspect(s) that were our own aliases", dropped)
+        if dropped == 0:
+            return inspection
+        return dataclasses.replace(inspection, suspects=kept)
+
+    def _decide(self, inspection: InspectionResult | None) -> tuple[bool, str | None, str | None]:
+        if inspection is None:
+            return True, None, None
+
+        if not inspection.available:
+            detail = (
+                f"the local inspector ({inspection.model}) could not be reached: {inspection.error}"
+            )
+            if self.policy == InspectionPolicy.BLOCK:
+                return (
+                    False,
+                    (
+                        f"Blocked before sending: {detail}. Nothing was sent to the "
+                        "external model. Start the local model, or set "
+                        "CCDB_ANONYMIZE_POLICY=warn to send without inspection."
+                    ),
+                    None,
+                )
+            return True, None, f"Sent without inspection — {detail}"
+
+        if not inspection.suspects:
+            return True, None, None
+
+        listed = ", ".join(f"`{s.value}`" for s in inspection.suspects)
+        if self.policy == InspectionPolicy.BLOCK:
+            return (
+                False,
+                (
+                    "Blocked before sending: the local inspector still sees "
+                    f"identifying terms — {listed}. Nothing was sent to the external "
+                    "model. Add them to the replacement rules, or rephrase."
+                ),
+                None,
+            )
+        return True, None, f"Possible replacement misses sent anyway: {listed}"
+
+    def restore(self, text: str) -> str:
+        """Turn aliases back into the real names for display."""
+        with self._lock:
+            return self.anonymizer.restore(text)
+
+
+# --------------------------------------------------------------------------
+# Process-wide accessor. Rules are re-read when the file changes on disk, so
+# adding a term does not require restarting the bot.
+# --------------------------------------------------------------------------
+
+_cache_lock = threading.Lock()
+_cached_gateway: PrivacyGateway | None = None
+_cached_signature: tuple[Any, ...] | None = None
+
+
+def _signature(config: PrivacyConfig) -> tuple[Any, ...]:
+    try:
+        mtime = config.rules_path.stat().st_mtime_ns
+    except OSError:
+        mtime = 0
+    return (
+        str(config.rules_path),
+        mtime,
+        str(config.mapping_path),
+        config.policy,
+        config.inspector_url,
+        config.inspector_model,
+    )
+
+
+def get_gateway(config: PrivacyConfig | None = None) -> PrivacyGateway | None:
+    """Return the shared gateway, or ``None`` when the feature is not active.
+
+    A malformed rules file raises instead of degrading to "no anonymization":
+    silently sending real names because a comma was missing is the one failure
+    mode this feature exists to prevent.
+    """
+    config = config or PrivacyConfig.from_env()
+    if not config.active:
+        return None
+
+    signature = _signature(config)
+    global _cached_gateway, _cached_signature
+    with _cache_lock:
+        if _cached_gateway is not None and _cached_signature == signature:
+            return _cached_gateway
+
+        rules = AnonymizationRules.load(config.rules_path)
+        store = MappingStore(config.mapping_path)
+        inspector = (
+            None
+            if config.policy == InspectionPolicy.OFF
+            else LocalLlmInspector(
+                base_url=config.inspector_url,
+                model=config.inspector_model,
+                timeout_seconds=config.inspector_timeout,
+            )
+        )
+        gateway = PrivacyGateway(
+            anonymizer=Anonymizer(rules=rules, store=store),
+            inspector=inspector,
+            policy=config.policy,
+            audit=AuditLog(config.audit_path, include_text=config.audit_includes_text),
+        )
+        logger.info(
+            "Anonymization gateway active: %d rule(s) from %s, policy=%s, mapping=%s",
+            len(rules.matchers),
+            config.rules_path,
+            config.policy,
+            config.mapping_path,
+        )
+        _cached_gateway = gateway
+        _cached_signature = signature
+        return gateway
+
+
+def reset_gateway_cache() -> None:
+    """Drop the cached gateway (tests, and after rewriting the rules file)."""
+    global _cached_gateway, _cached_signature
+    with _cache_lock:
+        _cached_gateway = None
+        _cached_signature = None

--- a/claude_code_core/privacy/inspector.py
+++ b/claude_code_core/privacy/inspector.py
@@ -1,0 +1,168 @@
+"""Local-LLM leftover inspector.
+
+The model here has exactly one job: look at *already anonymized* text and point
+at proper nouns the rules did not cover. It never rewrites anything — if it
+did, the substitution would stop being deterministic and the answer could no
+longer be restored.
+
+Transport is plain ``urllib`` against an Ollama-compatible endpoint, run in a
+worker thread. No new dependency, and no network call that isn't the local one
+the operator configured.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["LocalLlmInspector", "InspectionResult", "Suspect"]
+
+_SYSTEM_PROMPT = (
+    "You are a privacy leak detector. You are given text that has ALREADY been "
+    "anonymized by a rule-based system. Your only job is to list identifiers "
+    "that still look like they belong to a REAL organization: company names, "
+    "person names, internal hostnames, domain names, project code names, "
+    "account names, license keys.\n"
+    "Placeholder tokens such as org-001, person-002, host-003, "
+    "example-001.invalid, 203.0.113.x are the anonymizer's own output — never "
+    "report those.\n"
+    "Generic technology names (Windows, Azure, Python, Kubernetes, GitHub) are "
+    "NOT identifiers — never report those.\n"
+    'Reply with JSON only: {"suspects": [{"value": "...", "kind": "...", '
+    '"reason": "..."}]}. Empty list if the text is clean.'
+)
+
+
+@dataclass(frozen=True)
+class Suspect:
+    """A term the local model thinks still identifies someone."""
+
+    value: str
+    kind: str = ""
+    reason: str = ""
+
+
+@dataclass(frozen=True)
+class InspectionResult:
+    """Outcome of one inspection pass."""
+
+    suspects: tuple[Suspect, ...] = ()
+    available: bool = True
+    error: str | None = None
+    model: str = ""
+
+    @property
+    def clean(self) -> bool:
+        """True only when the inspector ran *and* found nothing."""
+        return self.available and not self.suspects
+
+    def summary(self) -> str:
+        if not self.available:
+            return f"inspector unavailable: {self.error}"
+        if not self.suspects:
+            return "clean"
+        return ", ".join(f"{s.value} ({s.kind})" for s in self.suspects)
+
+
+class LocalLlmInspector:
+    """Calls a local Ollama-compatible model to find replacement misses."""
+
+    def __init__(
+        self,
+        *,
+        base_url: str = "http://127.0.0.1:11434",
+        model: str = "qwen3:4b",
+        timeout_seconds: float = 30.0,
+        max_chars: int = 12000,
+    ) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.model = model
+        self.timeout_seconds = timeout_seconds
+        self.max_chars = max_chars
+
+    async def inspect(self, text: str) -> InspectionResult:
+        """Inspect ``text``; never raises — failures come back as ``available=False``."""
+        if not text.strip():
+            return InspectionResult(model=self.model)
+        try:
+            raw = await asyncio.to_thread(self._request, text[: self.max_chars])
+        except (urllib.error.URLError, OSError, TimeoutError) as exc:
+            logger.warning("Local inspector unreachable at %s: %s", self.base_url, exc)
+            return InspectionResult(available=False, error=str(exc), model=self.model)
+        except Exception as exc:  # noqa: BLE001 - inspector must never break a run
+            logger.exception("Local inspector failed")
+            return InspectionResult(available=False, error=str(exc), model=self.model)
+
+        suspects = _parse_suspects(raw)
+        # Hallucination guard: a suspect that does not literally occur in the
+        # text is the model inventing work for a human. Drop it.
+        present = tuple(s for s in suspects if s.value and s.value in text)
+        dropped = len(suspects) - len(present)
+        if dropped:
+            logger.info("Inspector proposed %d suspect(s) absent from the text", dropped)
+        return InspectionResult(suspects=present, model=self.model)
+
+    def _request(self, text: str) -> str:
+        payload = {
+            "model": self.model,
+            "messages": [
+                {"role": "system", "content": _SYSTEM_PROMPT},
+                {"role": "user", "content": text},
+            ],
+            "stream": False,
+            "format": "json",
+            # Thinking models return an empty `content` unless this is off.
+            "think": False,
+            "options": {"temperature": 0},
+        }
+        request = urllib.request.Request(  # noqa: S310 - operator-configured local URL
+            f"{self.base_url}/api/chat",
+            data=json.dumps(payload).encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(request, timeout=self.timeout_seconds) as response:  # noqa: S310
+            body = response.read().decode("utf-8", errors="replace")
+        parsed = json.loads(body)
+        return str(parsed.get("message", {}).get("content", ""))
+
+
+def _parse_suspects(raw: str) -> tuple[Suspect, ...]:
+    """Parse the model's JSON reply, tolerating fenced or padded output."""
+    text = raw.strip()
+    if not text:
+        return ()
+    if text.startswith("```"):
+        text = text.strip("`")
+        _, _, text = text.partition("\n")
+    start, end = text.find("{"), text.rfind("}")
+    if start == -1 or end <= start:
+        logger.debug("Inspector reply was not JSON: %.120s", raw)
+        return ()
+    try:
+        data = json.loads(text[start : end + 1])
+    except json.JSONDecodeError:
+        logger.debug("Inspector reply was not valid JSON: %.120s", raw)
+        return ()
+    entries = data.get("suspects")
+    if not isinstance(entries, list):
+        return ()
+    suspects: list[Suspect] = []
+    for entry in entries:
+        if isinstance(entry, str):
+            suspects.append(Suspect(value=entry.strip()))
+        elif isinstance(entry, dict):
+            suspects.append(
+                Suspect(
+                    value=str(entry.get("value", "")).strip(),
+                    kind=str(entry.get("kind", "")).strip(),
+                    reason=str(entry.get("reason", "")).strip(),
+                )
+            )
+    return tuple(s for s in suspects if s.value)

--- a/claude_code_core/privacy/mapping.py
+++ b/claude_code_core/privacy/mapping.py
@@ -1,0 +1,170 @@
+"""The 対応表 (alias mapping table).
+
+This is the single most sensitive file the gateway owns: it is what makes the
+replacement reversible, and it is what must never leave the operator's machine.
+It is stored as JSON next to the rules file, written atomically.
+
+Determinism contract: for a given store, ``alias_for(category, value)`` returns
+the same alias forever. That is what lets an answer be restored, and what lets
+two sessions weeks apart talk about the same server.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+
+from .rules import Category
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["MappingStore"]
+
+# Alias templates. Values keep the *shape* of what they replace so the external
+# model still sees "a hostname" / "an address" and can reason structurally.
+_ALIAS_TEMPLATES: dict[str, str] = {
+    Category.ORG: "org-{n:03d}",
+    Category.PERSON: "person-{n:03d}",
+    Category.HOST: "host-{n:03d}",
+    Category.DOMAIN: "example-{n:03d}.invalid",
+    Category.EMAIL: "person-{n:03d}@example.invalid",
+    Category.PROJECT: "project-{n:03d}",
+    Category.TERM: "term-{n:03d}",
+}
+_FALLBACK_TEMPLATE = "{category}-{n:03d}"
+
+# RFC 5737 documentation ranges — safe to hand to an external model, and still
+# parseable as an address by whatever it suggests running.
+_IPV4_BLOCKS = ("203.0.113.{n}", "198.51.100.{n}", "192.0.2.{n}")
+_IPV4_PER_BLOCK = 254
+
+
+def _alias_for_index(category: str, index: int) -> str:
+    """Render the alias for the ``index``-th (1-based) value in ``category``."""
+    if category == Category.IPV4:
+        block, offset = divmod(index - 1, _IPV4_PER_BLOCK)
+        if block < len(_IPV4_BLOCKS):
+            return _IPV4_BLOCKS[block].format(n=offset + 1)
+        return f"ipv4-{index:03d}"  # ran out of documentation space; stay unique
+    template = _ALIAS_TEMPLATES.get(category, _FALLBACK_TEMPLATE)
+    return template.format(n=index, category=_safe_category(category))
+
+
+def _safe_category(category: str) -> str:
+    cleaned = "".join(ch if ch.isalnum() else "-" for ch in category.lower()).strip("-")
+    return cleaned or "term"
+
+
+@dataclass(frozen=True)
+class _Entry:
+    alias: str
+    original: str
+    category: str
+
+
+class MappingStore:
+    """Bidirectional, persistent alias table.
+
+    Not process-safe across multiple bots writing the same file; it is
+    thread-safe within one process, which is what ccdb needs (one bot, many
+    concurrent sessions).
+    """
+
+    def __init__(self, path: str | Path | None = None) -> None:
+        self._path = Path(path) if path is not None else None
+        self._lock = threading.RLock()
+        self._by_key: dict[str, _Entry] = {}  # "category\x00casefolded" -> entry
+        self._by_alias: dict[str, _Entry] = {}  # casefolded alias -> entry
+        self._counters: dict[str, int] = {}
+        self._dirty = False
+        if self._path is not None:
+            self._load()
+
+    # ---------------------------------------------------------------- lookup
+
+    @property
+    def path(self) -> Path | None:
+        return self._path
+
+    def __len__(self) -> int:
+        return len(self._by_alias)
+
+    def alias_for(self, category: str, value: str) -> str:
+        """Return the stable alias for ``value``, minting one on first sight."""
+        key = f"{category}\x00{value.casefold()}"
+        with self._lock:
+            existing = self._by_key.get(key)
+            if existing is not None:
+                return existing.alias
+            index = self._counters.get(category, 0) + 1
+            alias = _alias_for_index(category, index)
+            # Defensive: never hand out an alias that already maps elsewhere.
+            while alias.casefold() in self._by_alias:
+                index += 1
+                alias = _alias_for_index(category, index)
+            self._counters[category] = index
+            entry = _Entry(alias=alias, original=value, category=category)
+            self._by_key[key] = entry
+            self._by_alias[alias.casefold()] = entry
+            self._dirty = True
+            self.flush()
+            return alias
+
+    def original_for(self, alias: str) -> str | None:
+        """Reverse lookup. Case-insensitive: models rewrite case freely."""
+        entry = self._by_alias.get(alias.casefold())
+        return entry.original if entry else None
+
+    def aliases(self) -> list[str]:
+        with self._lock:
+            return [entry.alias for entry in self._by_alias.values()]
+
+    # ----------------------------------------------------------- persistence
+
+    def _load(self) -> None:
+        assert self._path is not None
+        if not self._path.exists():
+            return
+        try:
+            data = json.loads(self._path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            # A corrupt table would silently break restoration, which is worse
+            # than refusing to start the feature. Surface it loudly.
+            logger.exception("Mapping table %s is unreadable", self._path)
+            raise
+        for raw in data.get("entries", []):
+            entry = _Entry(
+                alias=str(raw["alias"]),
+                original=str(raw["original"]),
+                category=str(raw.get("category", Category.TERM)),
+            )
+            self._by_key[f"{entry.category}\x00{entry.original.casefold()}"] = entry
+            self._by_alias[entry.alias.casefold()] = entry
+        for category, count in (data.get("counters") or {}).items():
+            self._counters[str(category)] = int(count)
+
+    def flush(self) -> None:
+        """Write the table to disk atomically. No-op for in-memory stores."""
+        if self._path is None or not self._dirty:
+            return
+        payload = {
+            "version": 1,
+            "counters": dict(self._counters),
+            "entries": [
+                {"alias": e.alias, "original": e.original, "category": e.category}
+                for e in self._by_alias.values()
+            ],
+        }
+        tmp = self._path.with_suffix(self._path.suffix + ".tmp")
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        tmp.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+        os.replace(tmp, self._path)
+        try:
+            self._path.chmod(0o600)
+        except OSError:  # pragma: no cover - platform dependent
+            logger.debug("Could not tighten permissions on %s", self._path)
+        self._dirty = False

--- a/claude_code_core/privacy/rules.py
+++ b/claude_code_core/privacy/rules.py
@@ -1,0 +1,171 @@
+"""Replacement rule definitions for the anonymization gateway.
+
+Rules are *data*, not code: a JSON file lists the literal terms and regular
+expressions that identify the operator's organisation. The engine never asks a
+model what to replace — see ``docs/ja/anonymization.md`` for why.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+__all__ = ["Category", "Matcher", "AnonymizationRules", "RulesError"]
+
+
+class RulesError(ValueError):
+    """Raised when a rules file is malformed."""
+
+
+class Category:
+    """Well-known replacement categories.
+
+    Unknown categories are allowed; they fall back to the generic alias
+    template. These constants exist so the built-in detectors and the alias
+    templates agree on spelling.
+    """
+
+    ORG = "org"
+    PERSON = "person"
+    HOST = "host"
+    DOMAIN = "domain"
+    EMAIL = "email"
+    IPV4 = "ipv4"
+    PROJECT = "project"
+    TERM = "term"
+
+
+@dataclass(frozen=True)
+class Matcher:
+    """A compiled rule: what to find, and which category the alias comes from."""
+
+    pattern: re.Pattern[str]
+    category: str
+    literal: str | None = None  # set for literal terms, None for regex rules
+
+
+# Built-in detectors. Deliberately conservative: they only fire on shapes that
+# are unambiguous. Anything fuzzier belongs in the local-LLM inspector, which
+# reports rather than rewrites.
+_BUILTIN_PATTERNS: dict[str, str] = {
+    Category.EMAIL: r"\b[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}\b",
+    Category.IPV4: (
+        r"\b(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\.){3}"
+        r"(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\b"
+    ),
+}
+
+_DEFAULT_BUILTINS: tuple[str, ...] = (Category.EMAIL, Category.IPV4)
+
+
+@dataclass(frozen=True)
+class AnonymizationRules:
+    """An ordered set of matchers plus the categories they draw aliases from."""
+
+    matchers: tuple[Matcher, ...] = ()
+    source_path: Path | None = None
+
+    @property
+    def is_empty(self) -> bool:
+        return not self.matchers
+
+    @classmethod
+    def from_dict(
+        cls, data: dict[str, Any], *, source_path: Path | None = None
+    ) -> AnonymizationRules:
+        """Build rules from a parsed rules document.
+
+        Schema::
+
+            {
+              "terms": [{"value": "Contoso", "category": "org"}, "Fabrikam"],
+              "patterns": [{"regex": "srv-[a-z0-9]+", "category": "host"}],
+              "builtins": ["email", "ipv4"]
+            }
+
+        ``terms`` entries may be bare strings (category defaults to ``term``).
+        """
+        if not isinstance(data, dict):
+            raise RulesError("rules document must be a JSON object")
+
+        literals: list[tuple[str, str]] = []
+        for raw in data.get("terms", []) or []:
+            value, category = _parse_term(raw)
+            if value:
+                literals.append((value, category))
+
+        # Longest first so "Contoso Japan" wins over "Contoso". Regex alternation
+        # is leftmost-*first-alternative*, not leftmost-longest, so the ordering
+        # here is what makes nested terms replace correctly.
+        literals.sort(key=lambda pair: len(pair[0]), reverse=True)
+
+        matchers: list[Matcher] = [
+            Matcher(
+                pattern=re.compile(re.escape(value), re.IGNORECASE),
+                category=category,
+                literal=value,
+            )
+            for value, category in literals
+        ]
+
+        for raw in data.get("patterns", []) or []:
+            matchers.append(_parse_pattern(raw))
+
+        builtins = data.get("builtins")
+        if builtins is None:
+            builtins = list(_DEFAULT_BUILTINS)
+        for name in builtins:
+            if name not in _BUILTIN_PATTERNS:
+                raise RulesError(f"unknown builtin detector: {name!r}")
+            matchers.append(Matcher(pattern=re.compile(_BUILTIN_PATTERNS[name]), category=name))
+
+        return cls(matchers=tuple(matchers), source_path=source_path)
+
+    @classmethod
+    def load(cls, path: str | Path) -> AnonymizationRules:
+        """Load rules from a JSON file. Raises ``RulesError`` on bad input."""
+        p = Path(path)
+        try:
+            raw = p.read_text(encoding="utf-8")
+        except OSError as exc:
+            raise RulesError(f"cannot read rules file {p}: {exc}") from exc
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise RulesError(f"invalid JSON in rules file {p}: {exc}") from exc
+        return cls.from_dict(data, source_path=p)
+
+
+def _parse_term(raw: object) -> tuple[str, str]:
+    if isinstance(raw, str):
+        return raw.strip(), Category.TERM
+    if isinstance(raw, dict):
+        value = str(raw.get("value", "")).strip()
+        category = str(raw.get("category") or Category.TERM).strip() or Category.TERM
+        return value, category
+    raise RulesError(f"term entry must be a string or object, got {type(raw).__name__}")
+
+
+def _parse_pattern(raw: object) -> Matcher:
+    if not isinstance(raw, dict):
+        raise RulesError(f"pattern entry must be an object, got {type(raw).__name__}")
+    regex = str(raw.get("regex", "")).strip()
+    if not regex:
+        raise RulesError("pattern entry is missing 'regex'")
+    category = str(raw.get("category") or Category.TERM).strip() or Category.TERM
+    flags = re.IGNORECASE if raw.get("ignore_case", True) else 0
+    try:
+        compiled = re.compile(regex, flags)
+    except re.error as exc:
+        raise RulesError(f"invalid regex {regex!r}: {exc}") from exc
+    if compiled.match(""):
+        raise RulesError(f"regex {regex!r} matches the empty string")
+    return Matcher(pattern=compiled, category=category)
+
+
+# Kept module-private but exported for tests and documentation generation.
+BUILTIN_PATTERNS: dict[str, str] = dict(_BUILTIN_PATTERNS)
+DEFAULT_BUILTINS: tuple[str, ...] = _DEFAULT_BUILTINS

--- a/claude_discord/cogs/event_processor.py
+++ b/claude_discord/cogs/event_processor.py
@@ -337,6 +337,16 @@ class EventProcessor:
             await self._handle_hook_lifecycle(event)
             return
 
+        # Out-of-band notice carried by a SYSTEM event that has no session_id —
+        # currently the anonymization gateway reporting that it sent anyway.
+        # Without this branch the session_id guard below swallows the text, and
+        # a warning nobody sees is worse than no warning at all.
+        if event.text and not event.session_id:
+            await self._config.surface.send_notice(
+                Notice(level=NoticeLevel.WARNING, body=event.text)
+            )
+            return
+
         if not event.session_id:
             return
 

--- a/docs/adr/0003-anonymize-by-rule-inspect-by-model.md
+++ b/docs/adr/0003-anonymize-by-rule-inspect-by-model.md
@@ -1,0 +1,86 @@
+---
+type: adr
+id: ADR-0003
+title: Anonymize by rule, inspect by model
+decision: Organisation-identifying terms are replaced by a deterministic rule table before a prompt reaches an external CLI; a local model only reports replacement misses and never rewrites text.
+status: accepted
+date: 2026-08-08
+deciders: [Masahiko Ebi, Claude]
+scope: repository
+supersedes:
+superseded_by:
+---
+
+# ADR-0003: Anonymize by rule, inspect by model
+
+## Context
+
+The relay sends what a person types in a chat surface to an external CLI, which
+sends it to an external model. In consulting and internal-IT work the useful
+message is usually the one that names a customer, a server, and a person — the
+message that policy forbids sending. The observed outcome is not abstention: the
+strong external model gets used anyway, unreported, because the sanctioned
+internal model is not good enough for the question.
+
+Two mechanisms are available for removing the identifying parts before the text
+leaves the machine:
+
+1. ask a local model to rewrite the text so that identifiers are gone;
+2. apply a rule table that maps each known identifier to a fixed alias.
+
+A third component is also needed either way: something that notices identifiers
+nobody anticipated.
+
+## Decision
+
+**A rule table performs the replacement. A local model only inspects the
+already-replaced text and reports what it still sees. The roles are not
+interchangeable.**
+
+Concretely:
+
+- Replacement is a pure function of `(rules, mapping table)`. The same input
+  always produces the same alias, and the mapping table makes it reversible, so
+  the answer can be restored before it is shown.
+- The mapping table is stored locally with `0600` permissions and is never sent
+  anywhere. It is the only artefact that can undo the replacement.
+- The local model receives the anonymized text and returns a list of suspects.
+  Its output is advisory input to a policy, never a rewrite.
+- The policy defaults to fail-closed: an inspector that reports a leftover, or
+  an inspector that cannot be reached at all, stops the send.
+- The feature is inactive without a rules file, and a malformed rules file is an
+  error rather than a silent downgrade.
+
+## Consequences
+
+### Why not let the model rewrite
+
+- **Determinism.** A model produces a different alias per run, and an alias that
+  changes cannot be mapped back. Restoration would be impossible, which removes
+  the reason the feature is usable at all.
+- **Detail loss.** Rewriting drifts into summarising, and the detail is what the
+  question was about. A rule table preserves structure, configuration values and
+  error ordering exactly, which is what the external model actually reasons over.
+- **Auditability.** "These twelve strings were replaced by these twelve aliases"
+  is a statement that can be checked. "A model rewrote it" is not.
+
+### Accepted costs
+
+- Rule quality is the product. A term nobody listed is a term nobody replaced,
+  which is precisely why the inspector exists and why the default policy blocks.
+- The inspector produces false positives — including, in the first end-to-end
+  run against a real local model, the anonymizer's own placeholder
+  `person-001@example.invalid`. Prompt wording did not fix this reliably, so
+  suspects are filtered mechanically against the mapping table: if restoring a
+  suspect changes it, we minted it and it cannot be a leak.
+- The guarantee is bounded and must be stated as such. Only the message text is
+  covered; the CLI still reads local files and sends their contents to the API
+  on its own. The gateway sits on the chat path, not the API path. Extending the
+  same table to the API path is a separate decision.
+
+## Implementation
+
+`claude_code_core/privacy/`, wired in by `create_backend()` via
+`AnonymizingBackend`, a `SessionBackend` decorator — so Claude, Codex and any
+backend added later are covered by one implementation. See
+`docs/anonymization.md`.

--- a/docs/adr/_index.md
+++ b/docs/adr/_index.md
@@ -8,3 +8,4 @@ earlier ADR instead of rewriting its history.
 
 - [ADR-0001: Adopt Ebi Agent Chat Relay as the product name](0001-adopt-ebi-agent-chat-relay.md)
 - [ADR-0002: Gate session completion on owner PR lifecycle](0002-gate-session-completion-on-owner-prs.md)
+- [ADR-0003: Anonymize by rule, inspect by model](0003-anonymize-by-rule-inspect-by-model.md)

--- a/docs/anonymization.md
+++ b/docs/anonymization.md
@@ -1,0 +1,158 @@
+# Anonymization gateway
+
+Replace the parts of a message that identify *your* organisation, send the rest
+to the strongest external model you can reach, and put the real names back in
+the answer.
+
+The intent is narrow and worth stating plainly: the safe model your company
+provides is often not good enough, and the model people actually want to use
+becomes a policy violation the moment internal information is pasted into it.
+The result is that it gets used anyway, unreported. This feature exists to make
+the safe path the default path — not to claim the problem is solved.
+
+## What it does
+
+```
+Discord message
+   │
+   ▼
+[1] rule-based replacement ── deterministic, reversible, no model involved
+   │
+   ▼
+[2] local model inspection ── looks for proper nouns the rules missed
+   │                          (never rewrites; only reports)
+   ▼
+[3] policy decision ──────── block / warn / off
+   │
+   ▼
+   claude / codex CLI ──────► external API
+   │
+   ▼
+[4] restore aliases in the answer, then show it to the user
+```
+
+Everything except step 3's outbound call happens on your machine. The mapping
+table — the only thing that can undo the replacement — never leaves it.
+
+## Why the rules replace and the model only inspects
+
+Handing the replacement itself to a model is the obvious design and the wrong
+one:
+
+- **It is not deterministic.** The same hostname becomes a different alias on
+  each run, so the answer can no longer be mapped back.
+- **It summarises.** Detail disappears — and detail is the reason you asked an
+  AI in the first place.
+
+A rule table replaces the same string the same way forever, which is what makes
+restoration possible. The local model is good at something else: noticing a
+proper noun nobody wrote a rule for. So it reports, and a human decides.
+
+## Turning it on
+
+The feature is off until a rules file exists. Create one at
+`~/.ccdb/anonymize-rules.json` (see
+[`examples/anonymize-rules.example.json`](../examples/anonymize-rules.example.json)):
+
+```json
+{
+  "terms": [
+    { "value": "Contoso Japan", "category": "org" },
+    { "value": "Contoso", "category": "org" },
+    { "value": "Taro Yamada", "category": "person" }
+  ],
+  "patterns": [
+    { "regex": "srv-[a-z0-9\\-]+", "category": "host" },
+    { "regex": "[a-z0-9\\-]+\\.onmicrosoft\\.com", "category": "domain" }
+  ],
+  "builtins": ["email", "ipv4"]
+}
+```
+
+- `terms` — literal strings, matched case-insensitively. Longer terms win, so
+  `Contoso Japan` is replaced as a unit rather than as `org-001 Japan`.
+- `patterns` — regular expressions, for naming conventions.
+- `builtins` — `email` and `ipv4` are enabled by default; pass `[]` to disable.
+
+Categories decide the shape of the alias, so the external model still sees "a
+hostname" or "an address" and can reason structurally:
+
+| category | alias |
+|---|---|
+| `org`, `person`, `host`, `project`, `term` | `org-001`, `person-002`, … |
+| `domain` | `example-001.invalid` |
+| `email` | `person-001@example.invalid` |
+| `ipv4` | `203.0.113.1` (RFC 5737 documentation range) |
+
+Then restart the bot, or just save the file — the rules are re-read when the
+file's mtime changes.
+
+## The local inspector
+
+Any Ollama-compatible endpoint works. A small model is enough; the task is
+"does this still contain a proper noun", not reasoning.
+
+```bash
+CCDB_ANONYMIZE_INSPECTOR_URL=http://127.0.0.1:11434
+CCDB_ANONYMIZE_INSPECTOR_MODEL=qwen3:4b
+```
+
+Suspects it reports are filtered twice before a human sees them: anything that
+does not literally appear in the text is dropped (hallucination), and anything
+that turns out to be one of our own aliases is dropped too. That second filter
+is not paranoia — a local model does report `person-001@example.invalid` as a
+real address even when the prompt tells it not to, and under the block policy
+that false positive stops a message that was already safe.
+
+## Configuration
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `CCDB_ANONYMIZE` | `1` | Set to `0` to disable even with a rules file present |
+| `CCDB_ANONYMIZE_RULES` | `~/.ccdb/anonymize-rules.json` | Rules file; its absence disables the feature |
+| `CCDB_ANONYMIZE_MAPPING` | next to the rules file | The mapping table. **Back this up, never share it** |
+| `CCDB_ANONYMIZE_POLICY` | `block` | `block` / `warn` / `off` |
+| `CCDB_ANONYMIZE_INSPECTOR_URL` | `http://127.0.0.1:11434` | Ollama-compatible endpoint |
+| `CCDB_ANONYMIZE_INSPECTOR_MODEL` | `qwen3:4b` | Inspection model |
+| `CCDB_ANONYMIZE_INSPECTOR_TIMEOUT` | `30` | Seconds |
+| `CCDB_ANONYMIZE_AUDIT` | next to the rules file | JSONL audit trail |
+| `CCDB_ANONYMIZE_AUDIT_ENABLED` | `1` | Set to `0` to write no audit trail |
+| `CCDB_ANONYMIZE_AUDIT_TEXT` | `1` | Set to `0` to log metadata without the sent text |
+
+Policies:
+
+- **`block`** (default) — nothing is sent while the inspector reports a
+  leftover, and nothing is sent when the inspector cannot be reached. Fail
+  closed: an inspector that is down must not silently become "no inspection".
+- **`warn`** — send anyway, but say so in the thread and in the audit log.
+- **`off`** — skip inspection entirely. Rule-based replacement still runs.
+
+A malformed rules file raises instead of disabling the feature. Sending real
+names because of a missing comma is the exact failure this exists to prevent.
+
+## What it does not protect
+
+Say this part out loud to anyone who asks:
+
+- **Only the message text is anonymized.** Claude Code and Codex read files and
+  run commands on your machine, and what they read goes to the API directly.
+  This gateway sits on the chat path, not on the API path.
+- **Replacement misses are possible.** That is why the inspector and the block
+  policy exist, and why neither is a guarantee.
+- **The body still goes out.** Identifiers are removed; the sentences are not.
+  If the text itself is the secret, this is the wrong tool.
+- **It cannot stop copy-paste.** Someone pasting into a personal AI account in
+  a browser is outside this path entirely.
+
+What you get is not "safe". It is *describable*: you can say exactly what was
+sent, and show the log.
+
+## Files it owns
+
+| File | Contents | Sensitivity |
+|---|---|---|
+| `anonymize-rules.json` | What to replace | Names your organisation — keep it internal |
+| `anonymize-mapping.json` | alias ⇄ real name | **Highest.** Losing it makes old answers unreadable; leaking it undoes the anonymization |
+| `anonymize-audit.jsonl` | What was sent, when, by which thread | Contains anonymized text only |
+
+The mapping table and audit log are created with `0600` permissions.

--- a/examples/anonymize-rules.example.json
+++ b/examples/anonymize-rules.example.json
@@ -1,0 +1,16 @@
+{
+  "_comment": "Copy to ~/.ccdb/anonymize-rules.json and edit. See docs/anonymization.md.",
+  "terms": [
+    { "value": "Contoso Japan", "category": "org" },
+    { "value": "Contoso", "category": "org" },
+    { "value": "Fabrikam", "category": "org" },
+    { "value": "Taro Yamada", "category": "person" },
+    { "value": "Project Northwind", "category": "project" }
+  ],
+  "patterns": [
+    { "regex": "srv-[a-z0-9\\-]+", "category": "host" },
+    { "regex": "[a-z0-9\\-]+\\.onmicrosoft\\.com", "category": "domain" },
+    { "regex": "[a-z0-9\\-]+\\.contoso\\.local", "category": "host" }
+  ],
+  "builtins": ["email", "ipv4"]
+}

--- a/tests/test_event_processor_surface.py
+++ b/tests/test_event_processor_surface.py
@@ -85,3 +85,21 @@ async def test_attachment_marker_is_delivered_by_surface(tmp_path) -> None:
 
     assert surface.conformance_delivered_files == ["result.txt"]
     assert not marker.exists()
+
+
+async def test_system_event_with_text_and_no_session_id_becomes_a_warning() -> None:
+    """The anonymization gateway reports "sent anyway" through this path.
+
+    Before this branch existed the session_id guard dropped the text silently,
+    which is the worst possible outcome for a privacy warning.
+    """
+    surface = MemorySurface()
+    runner = MagicMock()
+    processor = EventProcessor(_config(surface, runner))
+
+    await processor.process(
+        StreamEvent(message_type=MessageType.SYSTEM, text="⚠️ possible replacement miss")
+    )
+
+    assert [notice.level for notice in surface.notices] == [NoticeLevel.WARNING]
+    assert "replacement miss" in surface.notices[0].body

--- a/tests/test_privacy_engine.py
+++ b/tests/test_privacy_engine.py
@@ -1,0 +1,171 @@
+"""Tests for the deterministic replacement engine and its mapping table."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from claude_code_core.privacy import (
+    AnonymizationRules,
+    Anonymizer,
+    Category,
+    MappingStore,
+    RulesError,
+)
+
+RULES = {
+    "terms": [
+        {"value": "Contoso Japan", "category": "org"},
+        {"value": "Contoso", "category": "org"},
+        {"value": "山田太郎", "category": "person"},
+    ],
+    "patterns": [{"regex": r"srv-[a-z0-9\-]+", "category": "host"}],
+}
+
+
+def make_anonymizer(tmp_path=None, rules_doc=None) -> Anonymizer:
+    rules = AnonymizationRules.from_dict(rules_doc or RULES)
+    store = MappingStore(tmp_path / "map.json" if tmp_path else None)
+    return Anonymizer(rules=rules, store=store)
+
+
+class TestAnonymize:
+    def test_replaces_literal_term(self):
+        anon = make_anonymizer()
+        result = anon.anonymize("Contoso のADが壊れた")
+        assert "Contoso" not in result.text
+        assert result.text.startswith("org-001")
+        assert result.total_substitutions == 1
+
+    def test_longest_term_wins(self):
+        anon = make_anonymizer()
+        result = anon.anonymize("Contoso Japan の話")
+        # "Contoso Japan" must not be replaced as "org-x Japan".
+        assert "Japan" not in result.text
+        assert len(result.replacements) == 1
+
+    def test_same_value_always_gets_same_alias(self):
+        anon = make_anonymizer()
+        first = anon.anonymize("srv-dc01 が落ちた")
+        second = anon.anonymize("あとで srv-dc01 を再起動")
+        alias = first.replacements[0].alias
+        assert alias in second.text
+
+    def test_distinct_values_get_distinct_aliases(self):
+        anon = make_anonymizer()
+        result = anon.anonymize("srv-dc01 と srv-dc02")
+        aliases = {r.alias for r in result.replacements}
+        assert len(aliases) == 2
+
+    def test_case_insensitive_match_keeps_one_alias(self):
+        anon = make_anonymizer()
+        result = anon.anonymize("CONTOSO and contoso")
+        assert len(result.replacements) == 1
+        assert result.replacements[0].count == 2
+
+    def test_builtin_email_and_ipv4(self):
+        anon = make_anonymizer(rules_doc={"terms": [], "builtins": ["email", "ipv4"]})
+        result = anon.anonymize("mail ebi@example.co.jp from 192.168.1.10")
+        assert "ebi@example.co.jp" not in result.text
+        assert "192.168.1.10" not in result.text
+        assert "203.0.113.1" in result.text  # documentation range, shape preserved
+
+    def test_no_rules_is_a_noop(self):
+        anon = Anonymizer(rules=AnonymizationRules.from_dict({"builtins": []}))
+        result = anon.anonymize("Contoso")
+        assert result.text == "Contoso"
+        assert not result.changed
+
+    def test_empty_text(self):
+        anon = make_anonymizer()
+        assert anon.anonymize("").text == ""
+
+    def test_summary_is_readable(self):
+        anon = make_anonymizer()
+        result = anon.anonymize("Contoso Contoso")
+        assert "x2" in result.summary()
+
+
+class TestRestore:
+    def test_round_trip(self):
+        anon = make_anonymizer()
+        original = "Contoso の srv-dc01 を 山田太郎 が見ている"
+        result = anon.anonymize(original)
+        assert anon.restore(result.text) == original
+
+    def test_restores_case_shifted_alias(self):
+        anon = make_anonymizer()
+        result = anon.anonymize("srv-dc01")
+        alias = result.replacements[0].alias
+        assert anon.restore(alias.upper()) == "srv-dc01"
+
+    def test_restore_without_mapping_is_identity(self):
+        anon = make_anonymizer()
+        assert anon.restore("nothing to do here") == "nothing to do here"
+
+    def test_longer_alias_wins_over_prefix(self):
+        anon = make_anonymizer(rules_doc={"terms": [], "builtins": ["ipv4"]})
+        # Allocate ten addresses so 203.0.113.1 and 203.0.113.10 coexist.
+        text = " ".join(f"10.0.0.{i}" for i in range(1, 11))
+        result = anon.anonymize(text)
+        assert anon.restore(result.text) == text
+
+
+class TestMappingStore:
+    def test_persists_across_instances(self, tmp_path):
+        path = tmp_path / "map.json"
+        first = MappingStore(path)
+        alias = first.alias_for(Category.HOST, "srv-dc01")
+        second = MappingStore(path)
+        assert second.alias_for(Category.HOST, "srv-dc01") == alias
+        assert second.original_for(alias) == "srv-dc01"
+
+    def test_alias_never_collides_across_categories(self, tmp_path):
+        store = MappingStore(tmp_path / "map.json")
+        a = store.alias_for("org", "Contoso")
+        b = store.alias_for("person", "Contoso")
+        assert a != b
+
+    def test_file_is_written_atomically_and_is_valid_json(self, tmp_path):
+        path = tmp_path / "nested" / "map.json"
+        store = MappingStore(path)
+        store.alias_for(Category.ORG, "Contoso")
+        data = json.loads(path.read_text(encoding="utf-8"))
+        assert data["entries"][0]["original"] == "Contoso"
+        assert not list(path.parent.glob("*.tmp"))
+
+    def test_corrupt_table_raises_instead_of_starting_empty(self, tmp_path):
+        path = tmp_path / "map.json"
+        path.write_text("{not json", encoding="utf-8")
+        with pytest.raises(json.JSONDecodeError):
+            MappingStore(path)
+
+
+class TestRulesLoading:
+    def test_bare_string_terms_default_to_term_category(self):
+        rules = AnonymizationRules.from_dict({"terms": ["Contoso"], "builtins": []})
+        assert rules.matchers[0].category == Category.TERM
+
+    def test_invalid_regex_is_rejected(self):
+        with pytest.raises(RulesError):
+            AnonymizationRules.from_dict({"patterns": [{"regex": "([a-z"}]})
+
+    def test_empty_matching_regex_is_rejected(self):
+        with pytest.raises(RulesError):
+            AnonymizationRules.from_dict({"patterns": [{"regex": "x*"}]})
+
+    def test_unknown_builtin_is_rejected(self):
+        with pytest.raises(RulesError):
+            AnonymizationRules.from_dict({"builtins": ["telepathy"]})
+
+    def test_load_from_file(self, tmp_path):
+        path = tmp_path / "rules.json"
+        path.write_text(json.dumps(RULES), encoding="utf-8")
+        rules = AnonymizationRules.load(path)
+        assert not rules.is_empty
+        assert rules.source_path == path
+
+    def test_missing_file_raises_rules_error(self, tmp_path):
+        with pytest.raises(RulesError):
+            AnonymizationRules.load(tmp_path / "nope.json")

--- a/tests/test_privacy_gateway.py
+++ b/tests/test_privacy_gateway.py
@@ -1,0 +1,335 @@
+"""Tests for the inspector, the policy decision, and the backend wrapper."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncGenerator
+
+import pytest
+
+from claude_code_core.privacy import (
+    AnonymizationRules,
+    Anonymizer,
+    AnonymizingBackend,
+    AuditLog,
+    InspectionPolicy,
+    InspectionResult,
+    LocalLlmInspector,
+    MappingStore,
+    PrivacyConfig,
+    PrivacyGateway,
+    RulesError,
+    Suspect,
+    get_gateway,
+    reset_gateway_cache,
+)
+from claude_code_core.privacy.inspector import _parse_suspects
+from claude_code_core.types import MessageType, StreamEvent, ToolCategory, ToolUseEvent
+
+RULES = {"terms": [{"value": "Contoso", "category": "org"}], "builtins": []}
+
+
+def make_gateway(policy: str, inspection: InspectionResult | None, audit_path=None):
+    class _FakeInspector:
+        model = "fake"
+
+        async def inspect(self, text: str) -> InspectionResult:
+            assert inspection is not None
+            return inspection
+
+    return PrivacyGateway(
+        anonymizer=Anonymizer(rules=AnonymizationRules.from_dict(RULES), store=MappingStore()),
+        inspector=_FakeInspector() if inspection is not None else None,  # type: ignore[arg-type]
+        policy=policy,
+        audit=AuditLog(audit_path),
+    )
+
+
+class TestPolicy:
+    async def test_clean_text_is_allowed_and_anonymized(self):
+        gateway = make_gateway(InspectionPolicy.BLOCK, InspectionResult())
+        outcome = await gateway.guard("Contoso が落ちた")
+        assert outcome.allowed
+        assert "Contoso" not in outcome.text
+
+    async def test_block_policy_stops_on_suspects(self):
+        gateway = make_gateway(
+            InspectionPolicy.BLOCK, InspectionResult(suspects=(Suspect(value="Fabrikam"),))
+        )
+        outcome = await gateway.guard("Fabrikam の件")
+        assert not outcome.allowed
+        assert "Fabrikam" in (outcome.reason or "")
+
+    async def test_warn_policy_sends_but_reports(self):
+        gateway = make_gateway(
+            InspectionPolicy.WARN, InspectionResult(suspects=(Suspect(value="Fabrikam"),))
+        )
+        outcome = await gateway.guard("Fabrikam の件")
+        assert outcome.allowed
+        assert "Fabrikam" in (outcome.warning or "")
+
+    async def test_block_policy_is_fail_closed_when_inspector_is_down(self):
+        gateway = make_gateway(
+            InspectionPolicy.BLOCK, InspectionResult(available=False, error="connection refused")
+        )
+        outcome = await gateway.guard("Contoso の件")
+        assert not outcome.allowed
+        assert "could not be reached" in (outcome.reason or "")
+
+    async def test_warn_policy_sends_when_inspector_is_down(self):
+        gateway = make_gateway(
+            InspectionPolicy.WARN, InspectionResult(available=False, error="connection refused")
+        )
+        outcome = await gateway.guard("Contoso の件")
+        assert outcome.allowed
+        assert "without inspection" in (outcome.warning or "")
+
+    async def test_own_placeholders_are_not_treated_as_leaks(self):
+        """Observed with a real local model: it reports our own alias as a leak.
+
+        Under the block policy that false positive stops an already-safe
+        message, so the alias check has to be mechanical, not prompt-based.
+        """
+        gateway = make_gateway(
+            InspectionPolicy.BLOCK,
+            InspectionResult(suspects=(Suspect(value="org-001", kind="org"),)),
+        )
+        await gateway.guard("Contoso")  # mints org-001
+        outcome = await gateway.guard("Contoso again")
+        assert outcome.allowed
+        assert outcome.inspection is not None
+        assert outcome.inspection.suspects == ()
+
+    async def test_off_policy_skips_inspection_but_still_replaces(self):
+        gateway = make_gateway(InspectionPolicy.OFF, None)
+        outcome = await gateway.guard("Contoso が落ちた")
+        assert outcome.allowed
+        assert outcome.inspection is None
+        assert "Contoso" not in outcome.text
+
+
+class TestAudit:
+    async def test_audit_records_anonymized_text_not_the_original(self, tmp_path):
+        path = tmp_path / "audit.jsonl"
+        gateway = make_gateway(InspectionPolicy.OFF, None, audit_path=path)
+        await gateway.guard("Contoso が落ちた", thread_id=42)
+        record = json.loads(path.read_text(encoding="utf-8").splitlines()[0])
+        assert record["thread_id"] == 42
+        assert record["allowed"] is True
+        assert "Contoso" not in record["text"]
+        assert record["substitutions"][0]["category"] == "org"
+
+    async def test_audit_can_omit_text(self, tmp_path):
+        path = tmp_path / "audit.jsonl"
+        gateway = PrivacyGateway(
+            anonymizer=Anonymizer(rules=AnonymizationRules.from_dict(RULES), store=MappingStore()),
+            inspector=None,
+            policy=InspectionPolicy.OFF,
+            audit=AuditLog(path, include_text=False),
+        )
+        await gateway.guard("Contoso")
+        record = json.loads(path.read_text(encoding="utf-8").splitlines()[0])
+        assert "text" not in record
+
+    async def test_disabled_audit_writes_nothing(self, tmp_path):
+        gateway = make_gateway(InspectionPolicy.OFF, None, audit_path=None)
+        await gateway.guard("Contoso")
+        assert not list(tmp_path.iterdir())
+
+
+class _FakeBackend:
+    """Minimal SessionBackend stand-in that echoes what it was given."""
+
+    command = "claude"
+    model = "sonnet"
+
+    def __init__(self) -> None:
+        self.received: list[str] = []
+        self.images = None
+
+    async def run(self, prompt: str, session_id: str | None = None) -> AsyncGenerator:
+        self.received.append(prompt)
+        yield StreamEvent(
+            raw={},
+            message_type=MessageType.ASSISTANT,
+            text=f"answer about {prompt}",
+        )
+        yield StreamEvent(raw={}, message_type=MessageType.RESULT, is_complete=True)
+
+    def clone(self, **kwargs: object) -> _FakeBackend:
+        return _FakeBackend()
+
+
+class TestAnonymizingBackend:
+    async def test_prompt_is_anonymized_and_answer_restored(self):
+        gateway = make_gateway(InspectionPolicy.OFF, None)
+        inner = _FakeBackend()
+        backend = AnonymizingBackend(inner, gateway)
+
+        events = [event async for event in backend.run("Contoso が落ちた")]
+
+        assert "Contoso" not in inner.received[0]
+        assert "Contoso" in (events[0].text or "")
+
+    async def test_blocked_prompt_never_reaches_the_inner_backend(self):
+        gateway = make_gateway(
+            InspectionPolicy.BLOCK, InspectionResult(suspects=(Suspect(value="Fabrikam"),))
+        )
+        inner = _FakeBackend()
+        backend = AnonymizingBackend(inner, gateway)
+
+        events = [event async for event in backend.run("Fabrikam の件")]
+
+        assert inner.received == []
+        assert len(events) == 1
+        assert events[0].is_complete
+        assert "Fabrikam" in (events[0].error or "")
+
+    async def test_warning_is_emitted_before_the_answer(self):
+        gateway = make_gateway(
+            InspectionPolicy.WARN, InspectionResult(suspects=(Suspect(value="Fabrikam"),))
+        )
+        backend = AnonymizingBackend(_FakeBackend(), gateway)
+
+        events = [event async for event in backend.run("Fabrikam の件")]
+
+        assert events[0].message_type is MessageType.SYSTEM
+        assert "Fabrikam" in (events[0].text or "")
+
+    async def test_tool_input_is_restored_for_display(self):
+        gateway = make_gateway(InspectionPolicy.OFF, None)
+        await gateway.guard("Contoso")  # mint the alias
+        alias = gateway.anonymizer.store.aliases()[0]
+
+        event = StreamEvent(
+            raw={},
+            message_type=MessageType.ASSISTANT,
+            tool_use=ToolUseEvent(
+                tool_id="t1",
+                tool_name="Bash",
+                tool_input={"command": f"grep {alias} log.txt", "timeout": 5},
+                category=ToolCategory.COMMAND,
+            ),
+        )
+        from claude_code_core.privacy.backend import _restore_event
+
+        restored = _restore_event(event, gateway)
+        assert restored.tool_use is not None
+        assert restored.tool_use.tool_input["command"] == "grep Contoso log.txt"
+        assert restored.tool_use.tool_input["timeout"] == 5
+
+    def test_attribute_writes_land_on_the_inner_backend(self):
+        gateway = make_gateway(InspectionPolicy.OFF, None)
+        inner = _FakeBackend()
+        backend = AnonymizingBackend(inner, gateway)
+
+        backend.images = ["x"]  # Cogs mutate the runner in place
+
+        assert inner.images == ["x"]
+        assert backend.model == "sonnet"
+
+    def test_clone_stays_wrapped(self):
+        gateway = make_gateway(InspectionPolicy.OFF, None)
+        clone = AnonymizingBackend(_FakeBackend(), gateway).clone()
+        assert isinstance(clone, AnonymizingBackend)
+
+
+class TestInspectorParsing:
+    def test_parses_plain_json(self):
+        suspects = _parse_suspects('{"suspects": [{"value": "Fabrikam", "kind": "org"}]}')
+        assert suspects[0].value == "Fabrikam"
+
+    def test_parses_fenced_json(self):
+        suspects = _parse_suspects('```json\n{"suspects": ["Fabrikam"]}\n```')
+        assert suspects[0].value == "Fabrikam"
+
+    def test_non_json_reply_yields_nothing(self):
+        assert _parse_suspects("I could not find anything, sorry!") == ()
+
+    def test_empty_suspect_values_are_dropped(self):
+        assert _parse_suspects('{"suspects": [{"value": "  "}]}') == ()
+
+    async def test_hallucinated_suspects_are_dropped(self, monkeypatch):
+        inspector = LocalLlmInspector(model="fake")
+        monkeypatch.setattr(
+            inspector,
+            "_request",
+            lambda text: '{"suspects": ["Fabrikam", "NotInTheText"]}',
+        )
+        result = await inspector.inspect("Fabrikam had an outage")
+        assert [s.value for s in result.suspects] == ["Fabrikam"]
+
+    async def test_unreachable_endpoint_is_reported_not_raised(self):
+        inspector = LocalLlmInspector(
+            base_url="http://127.0.0.1:1", model="fake", timeout_seconds=1
+        )
+        result = await inspector.inspect("anything")
+        assert not result.available
+        assert result.error
+
+
+class TestConfigAndDiscovery:
+    def test_inactive_without_a_rules_file(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CCDB_ANONYMIZE_RULES", str(tmp_path / "absent.json"))
+        reset_gateway_cache()
+        assert PrivacyConfig.from_env().active is False
+        assert get_gateway() is None
+
+    def test_active_when_the_rules_file_exists(self, tmp_path, monkeypatch):
+        rules = tmp_path / "rules.json"
+        rules.write_text(json.dumps(RULES), encoding="utf-8")
+        monkeypatch.setenv("CCDB_ANONYMIZE_RULES", str(rules))
+        monkeypatch.setenv("CCDB_ANONYMIZE_POLICY", "off")
+        reset_gateway_cache()
+        gateway = get_gateway()
+        assert gateway is not None
+        assert gateway.policy == InspectionPolicy.OFF
+        reset_gateway_cache()
+
+    def test_explicit_disable_wins(self, tmp_path, monkeypatch):
+        rules = tmp_path / "rules.json"
+        rules.write_text(json.dumps(RULES), encoding="utf-8")
+        monkeypatch.setenv("CCDB_ANONYMIZE_RULES", str(rules))
+        monkeypatch.setenv("CCDB_ANONYMIZE", "0")
+        reset_gateway_cache()
+        assert get_gateway() is None
+        reset_gateway_cache()
+
+    def test_blank_env_var_does_not_kill_the_default(self, monkeypatch):
+        monkeypatch.setenv("CCDB_ANONYMIZE_POLICY", "")
+        assert PrivacyConfig.from_env().policy == InspectionPolicy.BLOCK
+
+    def test_unknown_policy_falls_back_to_block(self, monkeypatch):
+        monkeypatch.setenv("CCDB_ANONYMIZE_POLICY", "yolo")
+        assert PrivacyConfig.from_env().policy == InspectionPolicy.BLOCK
+
+    def test_broken_rules_file_raises_rather_than_disabling(self, tmp_path, monkeypatch):
+        rules = tmp_path / "rules.json"
+        rules.write_text("{oops", encoding="utf-8")
+        monkeypatch.setenv("CCDB_ANONYMIZE_RULES", str(rules))
+        reset_gateway_cache()
+        with pytest.raises(RulesError):
+            get_gateway()
+        reset_gateway_cache()
+
+    def test_editing_the_rules_file_refreshes_the_gateway(self, tmp_path, monkeypatch):
+        rules = tmp_path / "rules.json"
+        rules.write_text(json.dumps(RULES), encoding="utf-8")
+        monkeypatch.setenv("CCDB_ANONYMIZE_RULES", str(rules))
+        monkeypatch.setenv("CCDB_ANONYMIZE_MAPPING", str(tmp_path / "map.json"))
+        monkeypatch.setenv("CCDB_ANONYMIZE_POLICY", "off")
+        reset_gateway_cache()
+        first = get_gateway()
+        assert first is not None
+        before = len(first.anonymizer.rules.matchers)
+
+        rules.write_text(
+            json.dumps({"terms": ["Contoso", "Fabrikam"], "builtins": []}), encoding="utf-8"
+        )
+        import os
+
+        os.utime(rules, (0, 0))  # force a different mtime
+        second = get_gateway()
+        assert second is not None
+        assert len(second.anonymizer.rules.matchers) != before
+        reset_gateway_cache()


### PR DESCRIPTION
## Summary

Adds an optional gateway that replaces organisation-identifying terms with stable aliases **before** a prompt reaches the Claude or Codex CLI, and restores them in the answer. A local Ollama-compatible model inspects the anonymized text for replacement misses and, by default, blocks the send when it finds one.

```
Discord message
  → [1] rule-based replacement (deterministic, reversible, no model)
  → [2] local model inspection  (reports leftovers, never rewrites)
  → [3] policy: block / warn / off
  → claude / codex CLI → external API
  → [4] restore aliases in the answer before the user sees it
```

Everything except the outbound call happens locally. The mapping table — the only thing that can undo the replacement — never leaves the machine.

## Why rules replace and the model only inspects

Handing the substitution itself to a model is the obvious design and the wrong one: it produces a different alias on every run, so the answer can no longer be mapped back, and it drifts into summarising away exactly the detail the question was about. A rule table replaces the same string the same way forever, which is what makes restoration possible. The local model is good at a different job — noticing a proper noun nobody wrote a rule for — so it reports and a human decides. ADR-0003 records this.

## What's in it

- `claude_code_core/privacy/` — `rules` (literals, regexes, builtin email/IPv4 detectors), `mapping` (persistent bidirectional alias store, `0600`), `engine` (replace + restore), `inspector` (local Ollama-compatible check over stdlib `urllib`, no new dependency), `audit` (JSONL of what actually left), `gateway` (policy + process-wide accessor), `backend` (`AnonymizingBackend`, a `SessionBackend` decorator)
- Wired in at `create_backend()`, so Claude, Codex and any future backend are covered by one implementation
- Zero-config: inactive until a rules file exists at `~/.ccdb/anonymize-rules.json`; rules are re-read when the file's mtime changes
- Fail-closed by default: a reported leftover blocks, and an unreachable inspector also blocks — an inspector that is down must not silently become "no inspection"
- A malformed rules file raises rather than degrading to "send the real names"

## Two things found while testing, not while designing

- **The inspector flags its own placeholders.** In the first end-to-end run against a real local model it reported `person-001@example.invalid` as a real address, blocking a message that was already safe. Prompt wording did not fix it reliably, so suspects are now filtered mechanically against the mapping table: if restoring a suspect changes it, we minted it and it cannot be a leak.
- **`SYSTEM` events carrying text but no `session_id` were dropped** by the `session_id` guard in `EventProcessor._on_system`. That is the channel the `warn` policy uses, so the warning would have been invisible. Now surfaced as a warning notice.

## Scope — stated plainly in the docs

Only the message text is anonymized. The CLI still reads local files and runs commands, and what it reads goes to the API directly; this gateway sits on the chat path, not the API path. Replacement misses are possible, the body of the message still goes out, and nothing here stops someone pasting into a browser. The result is not "safe" — it is *describable*, with a log to show.

## Test plan

- [x] `pytest tests/` — 2080 passed (52 new across `test_privacy_engine.py` / `test_privacy_gateway.py`)
- [x] `ruff check` + `ruff format --check` + `pyright` clean
- [x] End-to-end through the real `claude` CLI: the subprocess received `サーバー host-001 の担当者は person-001 です`, the user-visible answer came back with the original names, and the audit record matches
- [x] End-to-end against a real local Ollama endpoint (block policy, clean verdict after the alias filter)
- [ ] Live verification in a Discord instance with a rules file configured

## Docs

`docs/anonymization.md`, `docs/adr/0003-anonymize-by-rule-inspect-by-model.md`, `examples/anonymize-rules.example.json`, README + `.env.example` + CLAUDE.md design decision 12.