### PR TITLE
Ship the relay receiver as a container, and keep the core package importable without a database driver

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git
+.venv
+tests
+docs
+examples
+scripts
+*.md

--- a/claude_code_core/__init__.py
+++ b/claude_code_core/__init__.py
@@ -62,9 +62,7 @@ from .frontend import (
     ThreadKey,
     derive_thread_key,
 )
-from .lounge_repo import LoungeMessage, LoungeRepository
 from .memory_surface import MemorySurface
-from .models import init_db
 
 # Parser
 from .parser import parse_line
@@ -77,7 +75,6 @@ from .rewind import TurnEntry, find_session_jsonl, parse_user_turns, truncate_js
 
 # Runner
 from .runner import ClaudeRunner
-from .session_repo import SessionRecord, SessionRepository, UsageStatsRepository
 
 # Types (all frontend-agnostic types)
 from .types import (
@@ -164,3 +161,41 @@ __all__ = [
     "parse_user_turns",
     "truncate_jsonl_at_line",
 ]
+
+
+# ---------------------------------------------------------------------------
+# Lazily imported members
+# ---------------------------------------------------------------------------
+#
+# The database-backed repositories need ``aiosqlite``. Importing them here
+# meant that ``claude_code_core.frontend`` — a module of protocols and value
+# objects with no storage in it — could not be imported without a database
+# driver installed. That is not a theoretical tidiness point: the Teams relay
+# receiver runs on a public machine deliberately built with nothing but an HTTP
+# server and a JWT library, and it fell over on `import aiosqlite` at startup.
+#
+# PEP 562: these resolve on first attribute access, so
+# ``from claude_code_core import SessionRepository`` still works exactly as
+# before, and ``from claude_code_core.frontend import ...`` no longer drags a
+# storage layer in behind it.
+_LAZY: dict[str, str] = {
+    "LoungeMessage": ".lounge_repo",
+    "LoungeRepository": ".lounge_repo",
+    "init_db": ".models",
+    "SessionRecord": ".session_repo",
+    "SessionRepository": ".session_repo",
+    "UsageStatsRepository": ".session_repo",
+}
+
+
+def __getattr__(name: str):  # noqa: ANN202 — module-level PEP 562 hook
+    module_name = _LAZY.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    from importlib import import_module
+
+    return getattr(import_module(module_name, __name__), name)
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals()) | set(_LAZY))

--- a/deploy/teams-relay/Dockerfile
+++ b/deploy/teams-relay/Dockerfile
@@ -1,0 +1,39 @@
+# The public receiver, and deliberately nothing else.
+#
+# This image is copied to the machine that faces the internet, so what it does
+# *not* contain is as much of the design as what it does. There is no
+# discord.py, no session machinery, no database driver, and no client secret —
+# not because they are unused, but because a process that cannot import them
+# cannot be made to run them.
+#
+# Hence installing dependencies directly rather than the package: `pip install
+# .[teams]` would drag in the base dependencies (discord.py, aiosqlite) that
+# every other deployment needs and this one must not have.
+
+FROM python:3.13-slim
+
+# aiohttp for the endpoint, pyjwt+cryptography to verify the inbound token,
+# defusedxml for the queue's XML. Nothing else is needed to verify and enqueue.
+RUN pip install --no-cache-dir \
+        "aiohttp>=3.14.3" \
+        "pyjwt[crypto]>=2.9,<3.0" \
+        "defusedxml>=0.7,<1.0"
+
+WORKDIR /app
+COPY claude_code_core ./claude_code_core
+COPY claude_teams ./claude_teams
+
+# Run as a non-root user. The container holds a queue-write credential and a
+# public app id; root adds nothing it needs and everything an escape wants.
+RUN useradd --create-home --uid 10001 relay && chown -R relay:relay /app
+USER relay
+
+ENV PYTHONPATH=/app \
+    PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1
+
+EXPOSE 8080
+
+# 0.0.0.0 is correct here and only here: this is the container's own interface,
+# and the ingress in front of it decides who may reach the port at all.
+CMD ["python", "-m", "claude_teams", "relay", "--host", "0.0.0.0", "--port", "8080"]

--- a/docs/teams-relay.md
+++ b/docs/teams-relay.md
@@ -91,6 +91,40 @@ The queue SAS URL is a credential in a URL: it never appears in a log line, an
 exception, or a `repr`. The failures raised here name the operation and the
 status code and nothing else.
 
+## Measured, on a real deployment
+
+Azure Container Apps in `japaneast`, 0.25 vCPU / 0.5 GiB, receiver only. Times
+are from the Teams transcript — user message to bot reply, end to end through
+Teams, the Bot Connector, the receiver, the queue, the poller at home, and back
+out to the Bot Connector.
+
+| | latency |
+|---|---|
+| home endpoint behind a Cloudflare tunnel (no relay) | 1.8 s |
+| **through the relay**, first message (outbound token not yet cached) | 2.1 s |
+| **through the relay**, steady state | **0.8 s / 1.1 s** |
+
+The relay is *faster* than the tunnel it replaced. The queue hop costs less
+than the tunnel did, and the receiver sits in the same region as the tenant.
+
+The receiver's own share, measured from the internet: **68 ms median** to
+verify and answer (8 samples, warm).
+
+### Cold start, and why `min-replicas` is 1
+
+Scale-to-zero is the wrong default here, and not for cost reasons. Teams gives
+the messaging endpoint a short budget, and a **card press is answered from the
+HTTP response body within seconds** — a cold start lands squarely inside that
+window, so the first press after an idle period would show the user an error
+even though everything worked.
+
+Running one replica always-on removes the variable entirely. Container Apps
+bills a running-but-idle replica at a reduced rate, and for a container that
+verifies a JWT and writes to a queue, 0.25 vCPU is generous.
+
+If you do run at zero, the failure is not "slow" — it is "the first person to
+press a button after lunch sees an error".
+
 ## Why not the Azure SDK
 
 Four HTTP calls — put, get, delete, and a `visibilitytimeout` that does the

--- a/docs/teams-relay.md
+++ b/docs/teams-relay.md
@@ -112,18 +112,46 @@ verify and answer (8 samples, warm).
 
 ### Cold start, and why `min-replicas` is 1
 
-Scale-to-zero is the wrong default here, and not for cost reasons. Teams gives
-the messaging endpoint a short budget, and a **card press is answered from the
-HTTP response body within seconds** — a cold start lands squarely inside that
-window, so the first press after an idle period would show the user an error
-even though everything worked.
+Scale-to-zero is the wrong default here, and not for cost reasons. Measured on
+this deployment, after the app had scaled to zero:
 
-Running one replica always-on removes the variable entirely. Container Apps
-bills a running-but-idle replica at a reduced rate, and for a container that
-verifies a JWT and writes to a queue, 0.25 vCPU is generous.
+| | latency |
+|---|---|
+| first request after scale-to-zero | **20.9 s** |
+| the very next request | **0.069 s** |
 
-If you do run at zero, the failure is not "slow" — it is "the first person to
-press a button after lunch sees an error".
+20.9 s is not a slow reply. Teams gives the messaging endpoint a short budget,
+and a **card press is answered from the HTTP response body within seconds** —
+so the first press after an idle period shows the user an error even though
+everything downstream worked perfectly. The failure mode is not "slow", it is
+"the first person to press a button after lunch sees an error, and nobody can
+reproduce it".
+
+Running one replica always-on removes the variable, and the bill says it is not
+the expensive part of this deployment.
+
+### What it costs to leave one replica running
+
+Container Apps bills a replica that is *running but not serving a request* at an
+idle rate — for vCPU that is **1/8** of the active rate. At the `japaneast`
+retail price (2026-08), 0.25 vCPU and 0.5 GiB for a 730-hour month:
+
+| | monthly |
+|---|---|
+| Container App, `min-replicas=1`, idle | **$4.3 – $5.9** |
+| Container Registry, Basic — one image | **$5.1** |
+| Storage queue, Bot Service (F0), Container Apps environment | ~$0 |
+
+The range on the first line is whether the monthly free grant (180,000 vCPU-s,
+360,000 GiB-s) is credited against idle usage; the honest answer is "assume it
+is not".
+
+Note what that table says: **holding the image costs about as much as running
+it.** A registry is billed per day for existing, and the compute is billed at
+the idle rate for a container that spends its life asleep. If this bill needs to
+come down, the receiver is the wrong place to look — publish the image to a free
+public registry instead. Nothing in it is secret; that is the point of the
+Dockerfile.
 
 ## Why not the Azure SDK
 

--- a/tests/test_core_import_is_light.py
+++ b/tests/test_core_import_is_light.py
@@ -1,0 +1,62 @@
+"""Importing a protocol must not require a database driver.
+
+`claude_code_core.frontend` is protocols and value objects. It had no storage
+in it and could not be imported without `aiosqlite`, because the package's
+`__init__` eagerly imported the repositories. That is not a tidiness point: the
+Teams relay receiver runs on a public machine built with nothing but an HTTP
+server and a JWT library, and it crashed on startup with `ModuleNotFoundError:
+aiosqlite` — a dependency it has no reason to carry.
+
+Checked in a subprocess because import side effects cannot be undone in-process
+once another test has already imported the world.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def run(code: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+
+
+class TestTheProtocolImportsAlone:
+    def test_frontend_does_not_pull_in_the_database_layer(self) -> None:
+        result = run(
+            "import sys, claude_code_core.frontend;"
+            "assert 'aiosqlite' not in sys.modules, 'frontend dragged in aiosqlite';"
+            "assert 'claude_code_core.session_repo' not in sys.modules"
+        )
+        assert result.returncode == 0, result.stderr
+
+    def test_the_teams_package_does_not_either(self) -> None:
+        # This is the one that actually broke a deployment.
+        result = run(
+            "import sys, claude_teams;"
+            "assert 'aiosqlite' not in sys.modules, 'claude_teams dragged in aiosqlite';"
+            "assert 'discord' not in sys.modules, 'claude_teams dragged in discord.py'"
+        )
+        assert result.returncode == 0, result.stderr
+
+
+class TestTheLazyMembersStillWork:
+    def test_the_repositories_are_still_importable_from_the_package(self) -> None:
+        # PEP 562 must not change the public API, only when it resolves.
+        result = run(
+            "from claude_code_core import SessionRepository, LoungeRepository, init_db;"
+            "assert SessionRepository and LoungeRepository and init_db"
+        )
+        assert result.returncode == 0, result.stderr
+
+    def test_an_unknown_attribute_still_raises_attribute_error(self) -> None:
+        result = run(
+            "import claude_code_core\n"
+            "try:\n"
+            "    claude_code_core.NoSuchThing\n"
+            "except AttributeError:\n"
+            "    pass\n"
+            "else:\n"
+            "    raise SystemExit('expected AttributeError')\n"
+        )
+        assert result.returncode == 0, result.stderr

--- a/uv.lock
+++ b/uv.lock
@@ -184,7 +184,7 @@ wheels = [
 
 [[package]]
 name = "claude-code-discord-bridge"
-version = "3.3.29"
+version = "3.3.30"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/uv.lock
+++ b/uv.lock
@@ -184,7 +184,7 @@ wheels = [
 
 [[package]]
 name = "claude-code-discord-bridge"
-version = "3.3.28"
+version = "3.3.29"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Follow-up to #594, which built the relay but never ran one. This makes the public receiver deployable and records what a real deployment measured.

## What is here

- `deploy/teams-relay/Dockerfile` — an image that contains the receiver and deliberately nothing else. No discord.py, no session machinery, no database driver, no client secret: a process that cannot import them cannot be made to run them.
- `claude_code_core/__init__.py` — lazy (PEP 562) attribute imports. The package previously pulled in the DB layer at import time, so the receiver container crashed on `ModuleNotFoundError: aiosqlite` while doing nothing that needs a database.
- `tests/test_core_import_is_light.py` — subprocess assertions that `claude_code_core.frontend` and `claude_teams` import with neither `aiosqlite` nor `discord` installed. Without this the laziness regresses the first time someone adds a convenient top-level import.
- `docs/teams-relay.md` — measurements from the deployment, including the ones that changed a decision.

## Measured, not assumed

End-to-end through Teams, the Bot Connector, the receiver, the queue, and the poller:

| | latency |
|---|---|
| the previous tunnel-to-home arrangement | 1.8 s |
| through the relay, steady state | 0.8 s / 1.1 s |

The relay is faster than what it replaced. The receiver's own share is 68 ms median, measured from the internet.

Scale-to-zero was rejected on measurement rather than principle: the first request after the app scaled to zero took **20.9 s**, and the next one 0.069 s. A card press is answered from the HTTP response body within seconds, so that first press would show the user an error that nobody can reproduce afterwards.

The cost table in the doc is the part worth reading twice — at the idle rate, holding the image in a registry costs about as much as running the container.

## Test plan

- [x] full suite green (2,472 tests), ruff and pyright clean
- [x] receiver refuses from the open internet: no token 401, garbage token 401, non-JSON 400, GET 405
- [x] round trip through the deployed relay confirmed in a real Teams conversation
- [x] session host verified to hold **zero listening sockets** — outbound only
- [ ] wiring `claude_teams` into the bot process (`CCDB_FRONTENDS=discord,teams`) is not in this PR