### PR TITLE
feat: let a long chat sync before it has been scrolled to the beginning

### DIFF
--- a/claude_discord/ext/api_server.py
+++ b/claude_discord/ext/api_server.py
@@ -2220,6 +2220,12 @@ class ApiServer:
                 # it wrong costs one extra sync, not a hole in the history.
                 "newest_have_mid": plan.newest_have_mid,
                 "pending": meta.get("pending_attachments") or [],
+                # What this server supports, so a client can tell it apart from
+                # an older one. `conversation_scope` is the permission a client
+                # needs before it may upload a partially-scrolled chat: against
+                # a server without it, each partial scan reports a different
+                # root mid and lands in its own folder.
+                "capabilities": {"conversation_scope": True},
             }
         )
 

--- a/claude_discord/ext/teams_store.py
+++ b/claude_discord/ext/teams_store.py
@@ -164,15 +164,21 @@ class TeamsVaultStore:
         re-created empty and the entire history uploads again, silently, because
         every message looks new. There is deliberately no index file: an index
         would be a second ledger that can drift from the directory it describes.
+
+        A conversation-scoped ref matches on the team alone (see
+        ``ThreadRef.identity_scope``). That is only safe because such a team is
+        derived from one Teams conversation id and therefore never holds a second
+        thread — matching a real channel GUID this way would pull every thread of
+        that team into one folder. The scope is the client's claim, so the check
+        stays on the ref rather than on the shape of the GUID.
         """
         for entry in self._thread_dir_candidates():
             meta = self._read_json(entry / "thread.json")
             if not meta:
                 continue
-            if (
-                str(meta.get("team", "")).lower() == ref.team
-                and str(meta.get("root_mid", "")) == ref.root_mid
-            ):
+            if str(meta.get("team", "")).lower() != ref.team:
+                continue
+            if ref.conversation_scoped or str(meta.get("root_mid", "")) == ref.root_mid:
                 return entry
         return None
 
@@ -430,6 +436,25 @@ class TeamsVaultStore:
         with path.open("a", encoding="utf-8") as fh:
             fh.write(json.dumps(entry, ensure_ascii=False) + "\n")
 
+    @staticmethod
+    def _root_mid_for(ref: ThreadRef, previous: dict) -> str:
+        """The root a conversation-scoped chat keeps as chunks arrive out of order.
+
+        A client working backwards through a long chat reports a different
+        "oldest mid I have seen" on every flush, and a later chunk covering only
+        recent messages reports a *newer* one. Taking the last value would make
+        the root walk forward and backward with the scroll position; keeping the
+        oldest ever seen means it converges on the real beginning of the chat and
+        stays there. The folder name is left alone either way — renaming it would
+        break every wikilink pointing into the vault.
+        """
+        if not ref.conversation_scoped:
+            return ref.root_mid
+        stored = str(previous.get("root_mid") or "").strip()
+        if not stored.isdigit():
+            return ref.root_mid
+        return stored if int(stored) <= int(ref.root_mid) else ref.root_mid
+
     def write_meta(
         self,
         thread_dir: Path,
@@ -448,7 +473,7 @@ class TeamsVaultStore:
         meta = {
             "team": ref.team,
             "org": self.org_for(ref) or previous.get("org", ""),
-            "root_mid": ref.root_mid,
+            "root_mid": self._root_mid_for(ref, previous),
             "title": ref.title,
             "url": ref.url or previous.get("url", ""),
             "participants": sorted({a for a in authors if a}),

--- a/claude_discord/ext/teams_sync.py
+++ b/claude_discord/ext/teams_sync.py
@@ -61,6 +61,19 @@ class ThreadRef:
     ``org`` is the company the conversation belongs to. It is a *label*, not part
     of the identity: two threads of the same team are the same team whatever the
     folder says, so relabelling never re-uploads anything.
+
+    ``identity_scope`` says which part of the pair the client considers
+    authoritative:
+
+    - ``"oldest-mid"`` (default) — the pair is the key. A real channel team holds
+      many threads, so both halves are needed to tell them apart.
+    - ``"conversation"`` — the team alone is the key, and ``root_mid`` is allowed
+      to move. Only a chat may claim this: it has no real team GUID, so the
+      client derives one from Teams' conversation id, which makes the team
+      already unique per conversation. This exists so a client can upload the
+      newest part of a very long chat before it has scrolled to the beginning —
+      under the strict key a partial scan reports a different root and the server
+      opens a second folder for the same conversation.
     """
 
     team: str
@@ -68,10 +81,15 @@ class ThreadRef:
     title: str
     url: str = ""
     org: str = ""
+    identity_scope: str = "oldest-mid"
 
     @property
     def key(self) -> str:
         return f"{self.team}/{self.root_mid}"
+
+    @property
+    def conversation_scoped(self) -> bool:
+        return self.identity_scope == "conversation"
 
 
 @dataclass(frozen=True)
@@ -150,7 +168,16 @@ def parse_thread_ref(raw: object) -> ThreadRef:
     title = _clean_line(raw.get("title"), limit=300) or f"thread-{root_mid}"
     url = _clean_line(raw.get("url"), limit=2000)
     org = _clean_line(raw.get("org"), limit=200)
-    return ThreadRef(team=team, root_mid=root_mid, title=title, url=url, org=org)
+    # Anything this version does not recognise falls back to the strict key.
+    # Widening the match on an unknown value would merge conversations that a
+    # newer client meant to keep apart, and a merge cannot be undone by syncing
+    # again — the messages are already interleaved in one folder.
+    scope = str(raw.get("identity_scope") or "").strip().lower()
+    if scope != "conversation":
+        scope = "oldest-mid"
+    return ThreadRef(
+        team=team, root_mid=root_mid, title=title, url=url, org=org, identity_scope=scope
+    )
 
 
 def parse_messages(raw: object, *, require_body: bool) -> list[IncomingMessage]:

--- a/tests/test_api_teams_sync.py
+++ b/tests/test_api_teams_sync.py
@@ -807,3 +807,133 @@ async def test_readme_names_the_company(client: TestClient) -> None:
     )
     readme = (Path((await resp.json())["folder"]) / "README.md").read_text()
     assert "- 会社: 日本工営" in readme
+
+
+# ---------------------------------------------------------------------------
+# conversation-scoped identity (long chats that cannot be scrolled to the top)
+# ---------------------------------------------------------------------------
+#
+# A chat has no team GUID, so the extension derives one. It used to derive it
+# from the chat's *oldest* message id, which meant the identity only existed
+# once the whole history had been scrolled. On a long chat Teams becomes
+# unstable well before that, so the client threw the partial scan away rather
+# than fork the folder — and the longest conversations could never sync at all.
+#
+# `identity_scope: "conversation"` says the team alone is the identity, so the
+# root mid is free to move as the client works backwards through the history.
+
+
+def chat_body(root_mid: str, *, scope: str = "conversation", **over) -> dict:
+    body = thread_body()
+    body["thread"] = dict(body["thread"], root_mid=root_mid, identity_scope=scope)
+    body.update(over)
+    return body
+
+
+@pytest.mark.asyncio
+async def test_conversation_scope_keeps_one_folder_as_the_root_mid_moves(
+    client: TestClient, vault: Path
+) -> None:
+    """The newest chunk lands first; scrolling back must reuse the same folder."""
+    newest = await client.post(
+        "/api/teams/sync/push",
+        json=chat_body("1784800000000", messages=[msg("1784800000000", "new", "h1")]),
+        headers=AUTH,
+    )
+    assert newest.status == 200
+    # A later chunk reaches further back, so the oldest mid it can see is older.
+    older = await client.post(
+        "/api/teams/sync/push",
+        json=chat_body("1770000000000", messages=[msg("1770000000000", "old", "h2")]),
+        headers=AUTH,
+    )
+    assert older.status == 200
+
+    folders = [p for p in vault.rglob("thread.json")]
+    assert len(folders) == 1, f"a moving root mid forked the vault: {folders}"
+    stored = sorted(p.name for p in (folders[0].parent / "messages").glob("*.md"))
+    assert stored == ["1770000000000.md", "1784800000000.md"]
+
+
+@pytest.mark.asyncio
+async def test_conversation_scope_records_the_oldest_mid_seen_so_far(
+    client: TestClient, vault: Path
+) -> None:
+    await client.post(
+        "/api/teams/sync/push",
+        json=chat_body("1784800000000", messages=[msg("1784800000000", "new", "h1")]),
+        headers=AUTH,
+    )
+    await client.post(
+        "/api/teams/sync/push",
+        json=chat_body("1770000000000", messages=[msg("1770000000000", "old", "h2")]),
+        headers=AUTH,
+    )
+    meta = json.loads(next(vault.rglob("thread.json")).read_text(encoding="utf-8"))
+    assert meta["root_mid"] == "1770000000000", "the root must follow the history back"
+    # A newer chunk arriving later must not drag the root forward again.
+    await client.post(
+        "/api/teams/sync/push",
+        json=chat_body("1790000000000", messages=[msg("1790000000000", "newer", "h3")]),
+        headers=AUTH,
+    )
+    meta = json.loads(next(vault.rglob("thread.json")).read_text(encoding="utf-8"))
+    assert meta["root_mid"] == "1770000000000"
+
+
+@pytest.mark.asyncio
+async def test_a_plan_finds_the_folder_by_conversation_alone(client: TestClient) -> None:
+    await client.post(
+        "/api/teams/sync/push",
+        json=chat_body("1784800000000", messages=[msg("1784800000000", "new", "h1")]),
+        headers=AUTH,
+    )
+    plan = await client.post("/api/teams/sync/plan", json=chat_body("1770000000000"), headers=AUTH)
+    body = await plan.json()
+    assert body["exists"] is True, "a different root mid must still find the chat"
+    assert body["have"] == 1, "the stored message is already accounted for"
+
+
+@pytest.mark.asyncio
+async def test_without_the_scope_a_different_root_is_still_a_different_thread(
+    client: TestClient, vault: Path
+) -> None:
+    """Channels and pre-upgrade clients keep the old {team}/{root_mid} key.
+
+    A real team GUID holds many threads, so team-only matching there would merge
+    unrelated conversations into one folder.
+    """
+    for root in ("1784800000000", "1770000000000"):
+        res = await client.post(
+            "/api/teams/sync/push",
+            json=chat_body(root, scope="oldest-mid", messages=[msg(root, "x", "h" + root)]),
+            headers=AUTH,
+        )
+        assert res.status == 200
+    assert len(list(vault.rglob("thread.json"))) == 2
+
+
+@pytest.mark.asyncio
+async def test_an_unknown_scope_falls_back_to_the_strict_key(
+    client: TestClient, vault: Path
+) -> None:
+    """Never widen matching because of a value this version does not understand."""
+    for root in ("1784800000000", "1770000000000"):
+        await client.post(
+            "/api/teams/sync/push",
+            json=chat_body(root, scope="something-new", messages=[msg(root, "x", "h" + root)]),
+            headers=AUTH,
+        )
+    assert len(list(vault.rglob("thread.json"))) == 2
+
+
+@pytest.mark.asyncio
+async def test_plan_advertises_conversation_scope_support(client: TestClient) -> None:
+    """The client must be able to tell an upgraded server from an old one.
+
+    Without this it cannot know whether flushing a partial scan is safe, and the
+    safe default (never flush) would keep long chats unsyncable forever.
+    """
+    plan = await client.post("/api/teams/sync/plan", json=thread_body(), headers=AUTH)
+    body = await plan.json()
+    assert body.get("capabilities", {}).get("conversation_scope") is True


### PR DESCRIPTION
## Problem

A chat has no team GUID, so the extension derives one — previously from the chat's **oldest message id**. That made the identity depend on how far the client had scrolled: a partial scan reported a different root, and this server opened a **second folder for the same conversation** and re-uploaded the history into it.

To avoid that, the client had to reach the very top before anything could be stored. On a long chat Teams itself becomes unstable well before that point, so the client discarded the partial scan. **The longest conversations were the ones that could never sync at all.**

Measured on the real vault: 267 synced Y2S folders, **zero** of which have the user in `participants` — every chat is missing, only channel posts got through.

## Change

A thread ref may now declare `identity_scope: "conversation"`, meaning **the team alone is the identity** and `root_mid` is free to move as the client works backwards.

- Safe only for chats, whose derived team already maps 1:1 to a Teams conversation id. A real channel GUID holds many threads and keeps the strict `{team}/{root_mid}` pair.
- **Unknown scope values fall back to the strict key** rather than widening the match. A wrong merge interleaves two conversations in one folder and cannot be undone by re-syncing — unlike a wrong split, which costs one re-upload.
- `thread.json` keeps the **oldest root ever seen**, so out-of-order chunks converge on the real beginning instead of walking back and forth with the scroll position. The folder name is never rewritten (wikilinks point into it).
- `/plan` advertises `capabilities.conversation_scope` so a client can tell an upgraded server from an old one **before** it risks uploading a partial scan.

## Tests

6 new tests in `tests/test_api_teams_sync.py` covering: a moving root reusing one folder, the oldest root being retained, plan resolving by team alone, and both fallbacks (explicit `oldest-mid` and an unrecognised value) still splitting.

`pytest tests/` — 2468 passed. The 6 failures are pre-existing on `main` in this environment (`test_teams_relay` storage-queue and an env-dependent api-port test), unrelated to this change. `ruff check`, `ruff format --check`, `pyright` all clean.

Client side: ebibibi/teams-channel-exporter#43

🤖 Generated with [Claude Code](https://claude.com/claude-code)