### PR TITLE
Update canonical repository URLs after rename

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -66,7 +66,7 @@ PATH="/home/ebi/.local/bin:$PATH" git commit -m "release: v1.4.0 [release]"
 git push -u origin release/v1.4.0
 
 gh pr create \
-  --repo ebibibi/claude-code-discord-bridge \
+  --repo ebibibi/ebi-agent-chat-relay \
   --base main \
   --title "release: v1.4.0 [release]" \
   --body "Release v1.4.0
@@ -82,7 +82,7 @@ See CHANGELOG.md for details."
 auto-approve により PR が自動マージされ、タグ `v1.4.0` と GitHub Release が作成される:
 
 ```bash
-gh release view v1.4.0 --repo ebibibi/claude-code-discord-bridge
+gh release view v1.4.0 --repo ebibibi/ebi-agent-chat-relay
 ```
 
 ---
@@ -108,4 +108,4 @@ PR マージ（auto-approve.yml）
 | 状況 | 原因 | 対処 |
 |------|------|------|
 | v1.4.1 になってしまった | PR タイトルに `[release]` がなかった | タグを削除して再度 release PR を作る |
-| タグが既に存在するエラー | 同じバージョンでタグを作ろうとした | タグを削除: `gh api repos/ebibibi/claude-code-discord-bridge/git/refs/tags/v1.4.0 --method DELETE` |
+| タグが既に存在するエラー | 同じバージョンでタグを作ろうとした | タグを削除: `gh api repos/ebibibi/ebi-agent-chat-relay/git/refs/tags/v1.4.0 --method DELETE` |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -494,18 +494,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CI pipeline: Python 3.10/3.11/3.12, ruff, pytest
 - Branch protection and PR workflow
 
-[Unreleased]: https://github.com/ebibibi/claude-code-discord-bridge/compare/v2.1.0...HEAD
-[2.1.0]: https://github.com/ebibibi/claude-code-discord-bridge/compare/v2.0.5...v2.1.0
-[2.0.0]: https://github.com/ebibibi/claude-code-discord-bridge/compare/v1.9.0...v2.0.5
-[1.9.0]: https://github.com/ebibibi/claude-code-discord-bridge/compare/v1.8.0...v1.9.0
-[1.8.0]: https://github.com/ebibibi/claude-code-discord-bridge/compare/v1.7.5...v1.8.0
-[1.7.5]: https://github.com/ebibibi/claude-code-discord-bridge/compare/v1.6.0...v1.7.5
-[1.6.0]: https://github.com/ebibibi/claude-code-discord-bridge/compare/v1.5.0...v1.6.0
-[1.5.0]: https://github.com/ebibibi/claude-code-discord-bridge/compare/v1.4.1...v1.5.0
-[1.4.1]: https://github.com/ebibibi/claude-code-discord-bridge/compare/v1.4.0...v1.4.1
-[1.4.0]: https://github.com/ebibibi/claude-code-discord-bridge/compare/v1.3.0...v1.4.0
-[1.3.0]: https://github.com/ebibibi/claude-code-discord-bridge/compare/v1.2.0...v1.3.0
-[1.2.0]: https://github.com/ebibibi/claude-code-discord-bridge/compare/v1.1.0...v1.2.0
-[1.1.0]: https://github.com/ebibibi/claude-code-discord-bridge/compare/v1.0.0...v1.1.0
-[1.0.0]: https://github.com/ebibibi/claude-code-discord-bridge/compare/v0.1.0...v1.0.0
-[0.1.0]: https://github.com/ebibibi/claude-code-discord-bridge/releases/tag/v0.1.0
+[Unreleased]: https://github.com/ebibibi/ebi-agent-chat-relay/compare/v2.1.0...HEAD
+[2.1.0]: https://github.com/ebibibi/ebi-agent-chat-relay/compare/v2.0.5...v2.1.0
+[2.0.0]: https://github.com/ebibibi/ebi-agent-chat-relay/compare/v1.9.0...v2.0.5
+[1.9.0]: https://github.com/ebibibi/ebi-agent-chat-relay/compare/v1.8.0...v1.9.0
+[1.8.0]: https://github.com/ebibibi/ebi-agent-chat-relay/compare/v1.7.5...v1.8.0
+[1.7.5]: https://github.com/ebibibi/ebi-agent-chat-relay/compare/v1.6.0...v1.7.5
+[1.6.0]: https://github.com/ebibibi/ebi-agent-chat-relay/compare/v1.5.0...v1.6.0
+[1.5.0]: https://github.com/ebibibi/ebi-agent-chat-relay/compare/v1.4.1...v1.5.0
+[1.4.1]: https://github.com/ebibibi/ebi-agent-chat-relay/compare/v1.4.0...v1.4.1
+[1.4.0]: https://github.com/ebibibi/ebi-agent-chat-relay/compare/v1.3.0...v1.4.0
+[1.3.0]: https://github.com/ebibibi/ebi-agent-chat-relay/compare/v1.2.0...v1.3.0
+[1.2.0]: https://github.com/ebibibi/ebi-agent-chat-relay/compare/v1.1.0...v1.2.0
+[1.1.0]: https://github.com/ebibibi/ebi-agent-chat-relay/compare/v1.0.0...v1.1.0
+[1.0.0]: https://github.com/ebibibi/ebi-agent-chat-relay/compare/v0.1.0...v1.0.0
+[0.1.0]: https://github.com/ebibibi/ebi-agent-chat-relay/releases/tag/v0.1.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,8 +57,8 @@ Alternative considered: Claude embeds `<!-- ccdb:schedule {...} -->` in response
 ### Setup
 
 ```bash
-git clone https://github.com/ebibibi/claude-code-discord-bridge.git
-cd claude-code-discord-bridge
+git clone https://github.com/ebibibi/ebi-agent-chat-relay.git
+cd ebi-agent-chat-relay
 uv sync --dev
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,8 +35,8 @@ main (always releasable)
 ## Development Setup
 
 ```bash
-git clone https://github.com/ebibibi/claude-code-discord-bridge.git
-cd claude-code-discord-bridge
+git clone https://github.com/ebibibi/ebi-agent-chat-relay.git
+cd ebi-agent-chat-relay
 uv sync --dev
 make setup   # register git hooks (one-time per clone)
 ```

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 identifier still works: the package is `claude-code-discord-bridge` (kebab-case), the
 command is `ccdb`, and `ccdb` remains the short name used throughout this document.*
 
-[![CI](https://github.com/ebibibi/claude-code-discord-bridge/actions/workflows/ci.yml/badge.svg)](https://github.com/ebibibi/claude-code-discord-bridge/actions/workflows/ci.yml)
-[![CodeQL](https://github.com/ebibibi/claude-code-discord-bridge/actions/workflows/codeql.yml/badge.svg)](https://github.com/ebibibi/claude-code-discord-bridge/actions/workflows/codeql.yml)
+[![CI](https://github.com/ebibibi/ebi-agent-chat-relay/actions/workflows/ci.yml/badge.svg)](https://github.com/ebibibi/ebi-agent-chat-relay/actions/workflows/ci.yml)
+[![CodeQL](https://github.com/ebibibi/ebi-agent-chat-relay/actions/workflows/codeql.yml/badge.svg)](https://github.com/ebibibi/ebi-agent-chat-relay/actions/workflows/codeql.yml)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12%2B-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
@@ -501,11 +501,11 @@ No cloning or `.env` editing required — the wizard does it for you:
 
 ```bash
 # With uvx (no install needed):
-uvx --from "git+https://github.com/ebibibi/claude-code-discord-bridge.git" ccdb setup
+uvx --from "git+https://github.com/ebibibi/ebi-agent-chat-relay.git" ccdb setup
 
 # Or after cloning:
-git clone https://github.com/ebibibi/claude-code-discord-bridge.git
-cd claude-code-discord-bridge
+git clone https://github.com/ebibibi/ebi-agent-chat-relay.git
+cd ebi-agent-chat-relay
 uv run ccdb setup
 ```
 
@@ -649,7 +649,7 @@ See [`examples/ebibot/`](examples/ebibot/) for a full real-world example with re
 If you already have a discord.py bot, add ccdb as a package instead:
 
 ```bash
-uv add git+https://github.com/ebibibi/claude-code-discord-bridge.git
+uv add git+https://github.com/ebibibi/ebi-agent-chat-relay.git
 ```
 
 Create a `bot.py`:

--- a/claude_discord/cli.py
+++ b/claude_discord/cli.py
@@ -6,7 +6,7 @@ Usage:
     ccdb         — show help
 
 Install via:
-    uvx --from git+https://github.com/ebibibi/claude-code-discord-bridge ccdb setup
+    uvx --from git+https://github.com/ebibibi/ebi-agent-chat-relay ccdb setup
 """
 
 from __future__ import annotations

--- a/claude_discord/cogs/_run_helper.py
+++ b/claude_discord/cogs/_run_helper.py
@@ -387,7 +387,7 @@ async def run_claude_with_config(config: RunConfig) -> str | None:
     # When system_context is present a fresh clone is created above, making the
     # original config.runner a "dead" runner with no process.  Without this
     # update the Stop button would send SIGINT to that dead runner and have no
-    # effect.  See: https://github.com/ebibibi/claude-code-discord-bridge/issues/174
+    # effect.  See: https://github.com/ebibibi/ebi-agent-chat-relay/issues/174
     if runner is not config.runner:
         if config.stop_view is not None:
             config.stop_view.update_runner(runner)
@@ -396,7 +396,7 @@ async def run_claude_with_config(config: RunConfig) -> str | None:
         # calls interrupt() on the runner that actually owns the subprocess.
         # Without this, compact_boundary and AskUserQuestion interrupt the
         # original (process-less) runner — a no-op that leaves Claude running
-        # invisibly.  See: https://github.com/ebibibi/claude-code-discord-bridge/issues/306
+        # invisibly.  See: https://github.com/ebibibi/ebi-agent-chat-relay/issues/306
         config = replace(config, runner=runner)
 
     processor = EventProcessor(config)

--- a/claude_discord/concurrency.py
+++ b/claude_discord/concurrency.py
@@ -4,7 +4,7 @@ Layer 1: Every session receives a generic concurrency warning in its prompt.
 Layer 2: An in-memory registry tracks active sessions so each one knows
          what others are doing and can avoid conflicts.
 
-See: https://github.com/ebibibi/claude-code-discord-bridge/issues/52
+See: https://github.com/ebibibi/ebi-agent-chat-relay/issues/52
 """
 
 from __future__ import annotations

--- a/claude_discord/discord_ui/thread_dashboard.py
+++ b/claude_discord/discord_ui/thread_dashboard.py
@@ -9,7 +9,7 @@ When THREAD_INBOX_ENABLED is set, the dashboard also shows a persistent
 inbox section (📬) that survives bot restarts and surfaces threads where
 the user owes a reply.
 
-Issue: https://github.com/ebibibi/claude-code-discord-bridge/issues/67
+Issue: https://github.com/ebibibi/ebi-agent-chat-relay/issues/67
 """
 
 from __future__ import annotations

--- a/docs/adr/0001-adopt-ebi-agent-chat-relay.md
+++ b/docs/adr/0001-adopt-ebi-agent-chat-relay.md
@@ -113,4 +113,4 @@ This ADR does not:
 
 - [Phased rename plan](../RENAME_PLAN.md)
 - [Design decisions](../DESIGN_DECISIONS.md)
-- [Issue #571](https://github.com/ebibibi/claude-code-discord-bridge/issues/571)
+- [Issue #571](https://github.com/ebibibi/ebi-agent-chat-relay/issues/571)

--- a/docs/adr/0002-gate-session-completion-on-owner-prs.md
+++ b/docs/adr/0002-gate-session-completion-on-owner-prs.md
@@ -100,5 +100,5 @@ forever.
 
 ## Related
 
-- [Issue #577](https://github.com/ebibibi/claude-code-discord-bridge/issues/577)
+- [Issue #577](https://github.com/ebibibi/ebi-agent-chat-relay/issues/577)
 - [Ebi Workspace PR #9](https://github.com/ebibibi/ebi-workspace/pull/9)

--- a/docs/es/README.md
+++ b/docs/es/README.md
@@ -7,8 +7,8 @@
 
 *Nombre del paquete: `claude-code-discord-bridge` (kebab-case)*
 
-[![CI](https://github.com/ebibibi/claude-code-discord-bridge/actions/workflows/ci.yml/badge.svg)](https://github.com/ebibibi/claude-code-discord-bridge/actions/workflows/ci.yml)
-[![CodeQL](https://github.com/ebibibi/claude-code-discord-bridge/actions/workflows/codeql.yml/badge.svg)](https://github.com/ebibibi/claude-code-discord-bridge/actions/workflows/codeql.yml)
+[![CI](https://github.com/ebibibi/ebi-agent-chat-relay/actions/workflows/ci.yml/badge.svg)](https://github.com/ebibibi/ebi-agent-chat-relay/actions/workflows/ci.yml)
+[![CodeQL](https://github.com/ebibibi/ebi-agent-chat-relay/actions/workflows/codeql.yml/badge.svg)](https://github.com/ebibibi/ebi-agent-chat-relay/actions/workflows/codeql.yml)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12%2B-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
@@ -444,11 +444,11 @@ Sin necesidad de clonar ni editar `.env` — el asistente lo hace por ti:
 
 ```bash
 # With uvx (no install needed):
-uvx --from "git+https://github.com/ebibibi/claude-code-discord-bridge.git" ccdb setup
+uvx --from "git+https://github.com/ebibibi/ebi-agent-chat-relay.git" ccdb setup
 
 # Or after cloning:
-git clone https://github.com/ebibibi/claude-code-discord-bridge.git
-cd claude-code-discord-bridge
+git clone https://github.com/ebibibi/ebi-agent-chat-relay.git
+cd ebi-agent-chat-relay
 uv run ccdb setup
 ```
 
@@ -592,7 +592,7 @@ Ver [`examples/ebibot/`](examples/ebibot/) para un ejemplo completo del mundo re
 Si ya tienes un bot de discord.py, añade ccdb como paquete en su lugar:
 
 ```bash
-uv add git+https://github.com/ebibibi/claude-code-discord-bridge.git
+uv add git+https://github.com/ebibibi/ebi-agent-chat-relay.git
 ```
 
 Crea un `bot.py`:

--- a/docs/fr/README.md
+++ b/docs/fr/README.md
@@ -7,8 +7,8 @@
 
 *Nom du package : `claude-code-discord-bridge` (kebab-case)*
 
-[![CI](https://github.com/ebibibi/claude-code-discord-bridge/actions/workflows/ci.yml/badge.svg)](https://github.com/ebibibi/claude-code-discord-bridge/actions/workflows/ci.yml)
-[![CodeQL](https://github.com/ebibibi/claude-code-discord-bridge/actions/workflows/codeql.yml/badge.svg)](https://github.com/ebibibi/claude-code-discord-bridge/actions/workflows/codeql.yml)
+[![CI](https://github.com/ebibibi/ebi-agent-chat-relay/actions/workflows/ci.yml/badge.svg)](https://github.com/ebibibi/ebi-agent-chat-relay/actions/workflows/ci.yml)
+[![CodeQL](https://github.com/ebibibi/ebi-agent-chat-relay/actions/workflows/codeql.yml/badge.svg)](https://github.com/ebibibi/ebi-agent-chat-relay/actions/workflows/codeql.yml)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12%2B-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
@@ -444,11 +444,11 @@ Pas besoin de cloner ni d'éditer `.env` — l'assistant le fait pour vous :
 
 ```bash
 # With uvx (no install needed):
-uvx --from "git+https://github.com/ebibibi/claude-code-discord-bridge.git" ccdb setup
+uvx --from "git+https://github.com/ebibibi/ebi-agent-chat-relay.git" ccdb setup
 
 # Or after cloning:
-git clone https://github.com/ebibibi/claude-code-discord-bridge.git
-cd claude-code-discord-bridge
+git clone https://github.com/ebibibi/ebi-agent-chat-relay.git
+cd ebi-agent-chat-relay
 uv run ccdb setup
 ```
 
@@ -592,7 +592,7 @@ Voir [`examples/ebibot/`](examples/ebibot/) pour un exemple complet et réel ave
 Si vous avez déjà un bot discord.py, ajoutez plutôt ccdb comme package :
 
 ```bash
-uv add git+https://github.com/ebibibi/claude-code-discord-bridge.git
+uv add git+https://github.com/ebibibi/ebi-agent-chat-relay.git
 ```
 
 Créez un `bot.py` :

--- a/docs/ja/CONTRIBUTING.md
+++ b/docs/ja/CONTRIBUTING.md
@@ -40,8 +40,8 @@ main（常にリリース可能）
 ## 開発環境のセットアップ
 
 ```bash
-git clone https://github.com/ebibibi/claude-code-discord-bridge.git
-cd claude-code-discord-bridge
+git clone https://github.com/ebibibi/ebi-agent-chat-relay.git
+cd ebi-agent-chat-relay
 uv sync --dev
 make setup   # git hooks を登録（クローン後に一度だけ実行）
 ```

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -7,8 +7,8 @@
 
 *パッケージ名: `claude-code-discord-bridge`（ケバブケース）*
 
-[![CI](https://github.com/ebibibi/claude-code-discord-bridge/actions/workflows/ci.yml/badge.svg)](https://github.com/ebibibi/claude-code-discord-bridge/actions/workflows/ci.yml)
-[![CodeQL](https://github.com/ebibibi/claude-code-discord-bridge/actions/workflows/codeql.yml/badge.svg)](https://github.com/ebibibi/claude-code-discord-bridge/actions/workflows/codeql.yml)
+[![CI](https://github.com/ebibibi/ebi-agent-chat-relay/actions/workflows/ci.yml/badge.svg)](https://github.com/ebibibi/ebi-agent-chat-relay/actions/workflows/ci.yml)
+[![CodeQL](https://github.com/ebibibi/ebi-agent-chat-relay/actions/workflows/codeql.yml/badge.svg)](https://github.com/ebibibi/ebi-agent-chat-relay/actions/workflows/codeql.yml)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12%2B-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
@@ -493,11 +493,11 @@ ccdb がバックエンド情報を記録する前に作成されたレコード
 
 ```bash
 # uvx を使う場合（インストール不要）:
-uvx --from "git+https://github.com/ebibibi/claude-code-discord-bridge.git" ccdb setup
+uvx --from "git+https://github.com/ebibibi/ebi-agent-chat-relay.git" ccdb setup
 
 # または、クローン後:
-git clone https://github.com/ebibibi/claude-code-discord-bridge.git
-cd claude-code-discord-bridge
+git clone https://github.com/ebibibi/ebi-agent-chat-relay.git
+cd ebi-agent-chat-relay
 uv run ccdb setup
 ```
 
@@ -641,7 +641,7 @@ async def setup(bot, runner, components):
 すでに discord.py Bot を動かしている場合は、ccdb をパッケージとして追加します:
 
 ```bash
-uv add git+https://github.com/ebibibi/claude-code-discord-bridge.git
+uv add git+https://github.com/ebibibi/ebi-agent-chat-relay.git
 ```
 
 `bot.py` を作成します:

--- a/docs/ko/README.md
+++ b/docs/ko/README.md
@@ -7,8 +7,8 @@
 
 *패키지명: `claude-code-discord-bridge` (케밥 케이스)*
 
-[![CI](https://github.com/ebibibi/claude-code-discord-bridge/actions/workflows/ci.yml/badge.svg)](https://github.com/ebibibi/claude-code-discord-bridge/actions/workflows/ci.yml)
-[![CodeQL](https://github.com/ebibibi/claude-code-discord-bridge/actions/workflows/codeql.yml/badge.svg)](https://github.com/ebibibi/claude-code-discord-bridge/actions/workflows/codeql.yml)
+[![CI](https://github.com/ebibibi/ebi-agent-chat-relay/actions/workflows/ci.yml/badge.svg)](https://github.com/ebibibi/ebi-agent-chat-relay/actions/workflows/ci.yml)
+[![CodeQL](https://github.com/ebibibi/ebi-agent-chat-relay/actions/workflows/codeql.yml/badge.svg)](https://github.com/ebibibi/ebi-agent-chat-relay/actions/workflows/codeql.yml)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12%2B-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
@@ -444,11 +444,11 @@ ccdb가 백엔드 소유권을 추적하기 전에 작성된 레코드에는 저
 
 ```bash
 # With uvx (no install needed):
-uvx --from "git+https://github.com/ebibibi/claude-code-discord-bridge.git" ccdb setup
+uvx --from "git+https://github.com/ebibibi/ebi-agent-chat-relay.git" ccdb setup
 
 # Or after cloning:
-git clone https://github.com/ebibibi/claude-code-discord-bridge.git
-cd claude-code-discord-bridge
+git clone https://github.com/ebibibi/ebi-agent-chat-relay.git
+cd ebi-agent-chat-relay
 uv run ccdb setup
 ```
 
@@ -592,7 +592,7 @@ async def setup(bot, runner, components):
 이미 discord.py 봇이 있다면, 대신 ccdb를 패키지로 추가하세요:
 
 ```bash
-uv add git+https://github.com/ebibibi/claude-code-discord-bridge.git
+uv add git+https://github.com/ebibibi/ebi-agent-chat-relay.git
 ```
 
 `bot.py` 생성:

--- a/docs/pt-BR/README.md
+++ b/docs/pt-BR/README.md
@@ -7,8 +7,8 @@
 
 *Nome do pacote: `claude-code-discord-bridge` (kebab-case)*
 
-[![CI](https://github.com/ebibibi/claude-code-discord-bridge/actions/workflows/ci.yml/badge.svg)](https://github.com/ebibibi/claude-code-discord-bridge/actions/workflows/ci.yml)
-[![CodeQL](https://github.com/ebibibi/claude-code-discord-bridge/actions/workflows/codeql.yml/badge.svg)](https://github.com/ebibibi/claude-code-discord-bridge/actions/workflows/codeql.yml)
+[![CI](https://github.com/ebibibi/ebi-agent-chat-relay/actions/workflows/ci.yml/badge.svg)](https://github.com/ebibibi/ebi-agent-chat-relay/actions/workflows/ci.yml)
+[![CodeQL](https://github.com/ebibibi/ebi-agent-chat-relay/actions/workflows/codeql.yml/badge.svg)](https://github.com/ebibibi/ebi-agent-chat-relay/actions/workflows/codeql.yml)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12%2B-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
@@ -444,11 +444,11 @@ Sem necessidade de clonar ou editar `.env` — o assistente faz isso por você:
 
 ```bash
 # With uvx (no install needed):
-uvx --from "git+https://github.com/ebibibi/claude-code-discord-bridge.git" ccdb setup
+uvx --from "git+https://github.com/ebibibi/ebi-agent-chat-relay.git" ccdb setup
 
 # Or after cloning:
-git clone https://github.com/ebibibi/claude-code-discord-bridge.git
-cd claude-code-discord-bridge
+git clone https://github.com/ebibibi/ebi-agent-chat-relay.git
+cd ebi-agent-chat-relay
 uv run ccdb setup
 ```
 
@@ -592,7 +592,7 @@ Veja [`examples/ebibot/`](examples/ebibot/) para um exemplo completo do mundo re
 Se você já tem um bot discord.py, adicione o ccdb como um pacote:
 
 ```bash
-uv add git+https://github.com/ebibibi/claude-code-discord-bridge.git
+uv add git+https://github.com/ebibibi/ebi-agent-chat-relay.git
 ```
 
 Crie um `bot.py`:

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -7,8 +7,8 @@
 
 *包名：`claude-code-discord-bridge`（短横线命名）*
 
-[![CI](https://github.com/ebibibi/claude-code-discord-bridge/actions/workflows/ci.yml/badge.svg)](https://github.com/ebibibi/claude-code-discord-bridge/actions/workflows/ci.yml)
-[![CodeQL](https://github.com/ebibibi/claude-code-discord-bridge/actions/workflows/codeql.yml/badge.svg)](https://github.com/ebibibi/claude-code-discord-bridge/actions/workflows/codeql.yml)
+[![CI](https://github.com/ebibibi/ebi-agent-chat-relay/actions/workflows/ci.yml/badge.svg)](https://github.com/ebibibi/ebi-agent-chat-relay/actions/workflows/ci.yml)
+[![CodeQL](https://github.com/ebibibi/ebi-agent-chat-relay/actions/workflows/codeql.yml/badge.svg)](https://github.com/ebibibi/ebi-agent-chat-relay/actions/workflows/codeql.yml)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12%2B-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
@@ -444,11 +444,11 @@ ccdb 3.0 引入了三个斜杠命令，用来改变下一个会话由哪个 AI �
 
 ```bash
 # 使用 uvx（无需安装）：
-uvx --from "git+https://github.com/ebibibi/claude-code-discord-bridge.git" ccdb setup
+uvx --from "git+https://github.com/ebibibi/ebi-agent-chat-relay.git" ccdb setup
 
 # 或克隆后：
-git clone https://github.com/ebibibi/claude-code-discord-bridge.git
-cd claude-code-discord-bridge
+git clone https://github.com/ebibibi/ebi-agent-chat-relay.git
+cd ebi-agent-chat-relay
 uv run ccdb setup
 ```
 
@@ -592,7 +592,7 @@ async def setup(bot, runner, components):
 如果你已经有一个 discord.py Bot，可以将 ccdb 作为包添加，而不必另起炉灶：
 
 ```bash
-uv add git+https://github.com/ebibibi/claude-code-discord-bridge.git
+uv add git+https://github.com/ebibibi/ebi-agent-chat-relay.git
 ```
 
 创建一个 `bot.py`：

--- a/examples/ebibot/README.md
+++ b/examples/ebibot/README.md
@@ -1,6 +1,6 @@
 # EbiBot — Example Custom Bot using ccdb
 
-Personal Discord bot built on top of [claude-code-discord-bridge](https://github.com/ebibibi/claude-code-discord-bridge).
+Personal Discord bot built on top of [claude-code-discord-bridge](https://github.com/ebibibi/ebi-agent-chat-relay).
 
 This example demonstrates how to extend ccdb with custom Cogs using the `CUSTOM_COGS_DIR` mechanism — no need for a separate repository.
 
@@ -18,8 +18,8 @@ This example demonstrates how to extend ccdb with custom Cogs using the `CUSTOM_
 
 ```bash
 # 1. Clone and install ccdb
-git clone https://github.com/ebibibi/claude-code-discord-bridge.git
-cd claude-code-discord-bridge
+git clone https://github.com/ebibibi/ebi-agent-chat-relay.git
+cd ebi-agent-chat-relay
 uv sync
 
 # 2. Copy and edit .env

--- a/scripts/cleanup_worktrees.sh
+++ b/scripts/cleanup_worktrees.sh
@@ -90,7 +90,7 @@ while IFS= read -r line; do
         echo "--- Worktree: $current_path (branch: $current_branch)"
 
         # Check PR status via gh CLI
-        pr_json=$(gh pr list --repo ebibibi/claude-code-discord-bridge \
+        pr_json=$(gh pr list --repo ebibibi/ebi-agent-chat-relay \
             --head "$current_branch" --state all --json state --limit 1 2>/dev/null || echo "[]")
 
         pr_state=$(echo "$pr_json" | jq -r '.[0].state // empty' 2>/dev/null || true)

--- a/tests/test_run_helper.py
+++ b/tests/test_run_helper.py
@@ -728,7 +728,7 @@ class TestStopViewRunnerSync:
     subprocess.  Without this, Stop sends SIGINT to the original runner whose
     _process is None and has no effect.
 
-    See: https://github.com/ebibibi/claude-code-discord-bridge/issues/174
+    See: https://github.com/ebibibi/ebi-agent-chat-relay/issues/174
     """
 
     @pytest.fixture

--- a/tests/test_thread_dashboard.py
+++ b/tests/test_thread_dashboard.py
@@ -1,6 +1,6 @@
 """Tests for the ThreadStatusDashboard — live session status embed.
 
-Issue: https://github.com/ebibibi/claude-code-discord-bridge/issues/67
+Issue: https://github.com/ebibibi/ebi-agent-chat-relay/issues/67
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

- replace the former GitHub repository URL with `ebibibi/ebi-agent-chat-relay` across documentation, source references, tests, and maintenance scripts
- update clone examples to enter the new default checkout directory
- keep compatibility identifiers such as `ccdb`, `CCDB_*`, Python imports, and the existing package name unchanged

## Verification

- `uv run ruff check claude_discord/`
- `uv run ruff format --check claude_discord/`
- `uv run pyright claude_discord/`
- `env -u CCDB_API_URL uv run pytest tests/ -q --cov=claude_discord` (2478 passed, 85% coverage)
- former and new Git remotes resolve to the same HEAD
- former repository, pull request, release, Actions, and raw-content URLs were checked after the rename
- no external workflow under `/home/ebi` references this repository as a reusable GitHub Action

Closes #598
