### PR TITLE
fix: sync lockfile after version bump

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -184,7 +184,7 @@ wheels = [
 
 [[package]]
 name = "claude-code-discord-bridge"
-version = "3.3.32"
+version = "3.3.34"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

Synchronize the editable project version in `uv.lock` with the automatic v3.3.34 patch bump.

The version-bump workflow updates `pyproject.toml` with `[skip ci]`, but leaves the project entry in `uv.lock` at v3.3.32. This makes `uv lock --check` fail on the current `main`.

## Security impact

None. This changes only the local editable package metadata; resolved third-party dependencies and hashes are unchanged.

## Validation

- `uv lock --check`
- `ruff check` and `ruff format --check`
- `pyright` (0 errors)
- full test suite: 2,480 passed