### PR TITLE
Update the production GHCR image path

### DIFF
--- a/docs/teams-relay.md
+++ b/docs/teams-relay.md
@@ -154,11 +154,11 @@ public registry instead. Nothing in it is secret; that is the point of the
 Dockerfile.
 
 The measured deployment was subsequently moved from Azure Container Registry
-to `ghcr.io/ebibibi/ccdb-teams-relay:v2`, and the dedicated Basic registry was
-deleted. The image digest remained identical across registries. A fresh
+to `ghcr.io/ebibibi/ebi-agent-chat-relay:v2`, and the dedicated Basic registry
+was deleted. The image digest remained identical across registries. A fresh
 Container Apps replica was then pulled and started after the Azure registry and
-its credentials were gone; three health checks completed in 65 ms. This removes
-the $5.1/month registry line from the table above.
+its credentials were gone; three health checks completed in 71–74 ms. This
+removes the $5.1/month registry line from the table above.
 
 GitHub Container Registry makes command-line-published packages private by
 default, and changing package visibility is a web-settings operation rather


### PR DESCRIPTION
## Summary

- update the Teams relay deployment record to the production GHCR package path
- record the measured health-check latency after the final cutover
- leave the old package untouched for rollback

## Why

The Container App now runs `ghcr.io/ebibibi/ebi-agent-chat-relay:v2`, while the deployment document still named the pre-cutover package.

## Validation

- `git diff --check`
- repository search confirms the old GHCR path is absent
- live Container App configuration reports revision `0000006`, `Running`, and the new image path
- live `/healthz` returned HTTP 200

Closes #602