### PR TITLE
fix: keep lockfile in sync during version bumps

### DIFF
--- a/.github/workflows/auto-version-bump.yml
+++ b/.github/workflows/auto-version-bump.yml
@@ -72,10 +72,19 @@ jobs:
           RELEASE_VERSION: ${{ steps.read.outputs.release_version }}
         run: |
           sed -i "s/^version = \"$CURRENT\"/version = \"$RELEASE_VERSION\"/" pyproject.toml
+          sed -i \
+            "/^name = \"claude-code-discord-bridge\"$/,/^source = { editable = \"\.\" }$/ s/^version = \"$CURRENT\"/version = \"$RELEASE_VERSION\"/" \
+            uv.lock
+
+          if ! grep -A2 '^name = "claude-code-discord-bridge"$' uv.lock \
+            | grep -Fxq "version = \"$RELEASE_VERSION\""; then
+            echo "Failed to synchronize the editable project version in uv.lock" >&2
+            exit 1
+          fi
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add pyproject.toml
+          git add pyproject.toml uv.lock
           git commit -m "chore: bump version to $RELEASE_VERSION [skip ci]"
           git push origin main
 

--- a/uv.lock
+++ b/uv.lock
@@ -184,7 +184,7 @@ wheels = [
 
 [[package]]
 name = "claude-code-discord-bridge"
-version = "3.3.34"
+version = "3.3.35"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

Keep the editable project entry in `uv.lock` synchronized when the automatic patch-version workflow updates `pyproject.toml`. Also repair the current v3.3.35 lock metadata.

Without this, every automatic patch bump leaves `main` failing `uv lock --check`. A lock-only follow-up PR cannot permanently fix it because merging that PR triggers another patch bump.

## Security review

- No new action or executable dependency is introduced into the privileged workflow.
- The existing `CURRENT` and computed numeric `RELEASE_VERSION` values are used only by the bounded local-package block update.
- The workflow fails before its admin-token push if the expected lock entry was not updated.
- Third-party dependencies and hashes remain unchanged.

## Validation

- Exercised the exact shell update against copies with v3.3.35 -> v3.3.36
- `uv lock --check`
- `git diff --check`
- Previous lock-sync head: Python 3.12/3.13 CI, CodeQL, and 2,480 local tests all passed