### PR TITLE
feat: add optional AG-UI backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,13 @@ CCDB_BACKEND=claude
 # CCDB_CLAUDE_COMMAND=/home/you/.local/bin/claude
 # CCDB_CODEX_COMMAND=/home/you/.npm-global/bin/codex
 
+# Remote AG-UI backend (optional). Install with `pip install
+# 'claude-code-discord-bridge[agui]'`, then select it with `/backend agui` or
+# set CCDB_BACKEND=agui. The token is sent only to this exact URL; redirects
+# are rejected and the token is stripped from Claude/Codex child processes.
+# CCDB_AGUI_URL=https://agent.example.com/run
+# CCDB_AGUI_TOKEN=replace-with-upstream-token
+
 # Discord Bot Configuration
 DISCORD_BOT_TOKEN=your-bot-token-here
 DISCORD_CHANNEL_ID=your-channel-id-here

--- a/README.md
+++ b/README.md
@@ -324,11 +324,11 @@ If the bot restarts mid-session, interrupted Claude sessions are automatically r
 - **Automatic (any shutdown)** — `ClaudeChatCog.cog_unload()` marks all mid-run sessions whenever the bot shuts down via any mechanism (`systemctl stop`, `bot.close()`, SIGTERM, etc.).
 - **Manual** — Any session can call `POST /api/mark-resume` directly.
 
-### Backend Switching — Claude / Codex on Demand
+### Backend Switching — Claude / Codex / AG-UI on Demand
 
 ccdb 3.0 introduces three slash commands that change which AI handles the next session, with no bot restart:
 
-- `/backend [name] [scope]` — show or switch backend. `name` is `claude` or `codex`. `scope` is `thread` (this thread only) or `global` (server-wide default). When you omit `scope`, the command auto-resolves: in a thread it scopes to that thread, otherwise it sets the global default.
+- `/backend [name] [scope]` — show or switch backend. `name` is `claude`, `codex`, `local`, or `agui`. `scope` is `thread` (this thread only) or `global` (server-wide default). When you omit `scope`, the command auto-resolves: in a thread it scopes to that thread, otherwise it sets the global default.
 - `/model [name] [scope]` — show or switch the model used by the **current** backend. Each backend remembers its own model preference, so flipping backend back and forth keeps your favoured models intact. Leave a backend's model unset to defer to that CLI's own default (e.g. Codex uses the `model` in `~/.codex/config.toml`, so ccdb tracks the console default instead of pinning a version).
   The `name` autocomplete is **discovered live**: ccdb asks the Anthropic models endpoint (using the credentials the Claude Code CLI already has) which models your account can see, so a model released this morning shows up in the dropdown without a ccdb upgrade. Aliases (`opus`, `sonnet`, …) are labelled with the model they currently resolve to. Offline, unauthenticated, or on Bedrock/Vertex/Foundry it silently falls back to a small static list; set `CCDB_MODEL_DISCOVERY=0` to always use that list. Codex suggestions stay static (the Codex CLI exposes no model listing) — any id you type still works.
 - `/effort [level] [scope]` — show or switch the **reasoning effort** used by the current backend. Valid levels are backend-specific: Claude accepts `low/medium/high/max`; Codex accepts `minimal/low/medium/high/xhigh` (mapped to the CLI's `model_reasoning_effort`). Leave it unset to defer to the CLI default.
@@ -357,6 +357,7 @@ Concrete example:
 /effort xhigh                          # global → codex reasons at xhigh effort
                                        # …open a thread, send a message…
 /backend claude scope:thread          # this thread only → switch back to claude
+/backend agui scope:thread            # this thread only → configured remote AG-UI agent
 /model opus scope:thread              # this thread only → claude/opus
 /effort max scope:thread              # this thread only → claude reasons at max
                                        # other threads keep the global codex defaults
@@ -364,7 +365,7 @@ Concrete example:
 
 Behind the scenes:
 
-- `BackendFactory` — captures the static configuration at boot (per-backend command path, permission mode, working dir, allowed tools, timeout, append-system-prompt, effort, api_port, api_secret) and builds a fresh `ClaudeRunner` or `CodexRunner` on demand. `api_port` is wired automatically by `setup_bridge` after the REST API server starts, so factory-built runners always have `CCDB_API_URL` injected into their subprocess environment.
+- `BackendFactory` — captures the static configuration at boot (per-backend command path or AG-UI endpoint, permission mode, working dir, allowed tools, timeout, append-system-prompt, effort, api_port, api_secret) and builds a fresh `ClaudeRunner`, `CodexRunner`, or `AgUiBackend` on demand. `api_port` is wired automatically by `setup_bridge` after the REST API server starts, so factory-built CLI runners always have `CCDB_API_URL` injected into their subprocess environment.
 - `BackendSettings` — thin wrapper over `SettingsRepository` that resolves the active backend with **thread > global > env** precedence and persists writes from the slash commands.
 - `SessionBackend` Protocol — the abstract interface that both runners satisfy. Internal plumbing (cogs, embeds, views, scheduler, webhook trigger) takes a `SessionBackend`, never one concrete runner class.
 
@@ -471,6 +472,7 @@ Behind the scenes:
 - **User authorization** — `allowed_user_ids` restricts who can invoke Claude
 - **Log injection prevention** — User-provided API values are sanitized (newlines stripped) before writing to logs
 - **Local-model backend** (optional) — `/backend local` runs a thread against a model on your own hardware. ccdb owns a separate CLI home with the update check and analytics disabled, because a "local" run otherwise still contacts the vendor; it refuses to start if those settings are missing — see [docs/local-backend.md](docs/local-backend.md)
+- **Remote AG-UI backend** (optional) — `/backend agui` connects the existing Discord/Teams session machinery to any HTTP/SSE AG-UI agent while preserving ccdb's session ledger, rendering, cancellation, and operational controls — see [docs/agui-backend.md](docs/agui-backend.md)
 - **Anonymization gateway** (optional) — Replaces organisation-identifying terms with stable aliases before the prompt reaches Claude or Codex, and restores them in the answer. A local model checks the result for replacement misses and, by default, blocks the send when it finds one. Off until you write a rules file — see [docs/anonymization.md](docs/anonymization.md)
 
 ---
@@ -813,10 +815,12 @@ In chat-only mode, permission requests and `AskUserQuestion` prompts are **alway
 |----------|-------------|---------|
 | `DISCORD_BOT_TOKEN` | Your Discord bot token | (required) |
 | `DISCORD_CHANNEL_ID` | Channel ID for Claude chat | (required) |
-| `CCDB_BACKEND` | CLI backend to use: `claude` (Claude Code CLI) or `codex` (OpenAI Codex CLI) | `claude` |
+| `CCDB_BACKEND` | Backend to use: `claude`, `codex`, `local`, or `agui` | `claude` |
 | `CCDB_COMMAND` | Path or name of the CLI binary (overrides `CLAUDE_COMMAND`). Used by the initial runner picked from `CCDB_BACKEND`; superseded by the two per-backend variables below when `/backend` switches at runtime. | _(auto: `claude` or `codex`)_ |
 | `CCDB_CLAUDE_COMMAND` | Explicit path to the Claude CLI binary. Used by `BackendFactory` whenever `/backend claude` is active, regardless of the initial `CCDB_BACKEND`. Falls back to `CLAUDE_COMMAND`, then `claude` (PATH). | (optional) |
 | `CCDB_CODEX_COMMAND` | Explicit path to the OpenAI Codex CLI binary. Required when running the bot under systemd (default service PATH does not include `~/.npm-global/bin`). Falls back to `codex` (PATH). | (optional) |
+| `CCDB_AGUI_URL` | Exact HTTP(S) run endpoint for `/backend agui`. Redirects are rejected. | (required for `agui`) |
+| `CCDB_AGUI_TOKEN` | Optional bearer token for the AG-UI endpoint. Stripped from Claude/Codex subprocess environments. | (optional) |
 | `PATH` | Binary search path for the bot **and every CLI session it spawns** — sessions inherit the bot's environment. Set it in `.env` when running under systemd, which starts units with a minimal PATH and never reads `~/.bashrc` / `~/.profile`. See [Toolchain PATH](#toolchain-path--set-it-in-env). | (inherited from the parent process) |
 | `CCDB_MODEL` | Model to use (overrides `CLAUDE_MODEL`) | `sonnet` |
 | `CCDB_MODEL_DISCOVERY` | Set to `0` to stop the `/model` autocomplete from asking the Anthropic models endpoint which models your credentials can see, and always use the static suggestion list instead. Discovery is read-only, reuses the Claude Code CLI's own auth, and already falls back on its own when offline, unauthenticated, or on Bedrock/Vertex/Foundry | `1` |

--- a/claude_code_core/__init__.py
+++ b/claude_code_core/__init__.py
@@ -30,6 +30,8 @@ Usage::
 
 from __future__ import annotations
 
+from .agui_backend import AgUiBackend, AgUiEventMapper
+
 # API provider detection
 from .api_provider import detect_api_provider
 
@@ -119,6 +121,8 @@ __all__ = [
     "detect_api_provider",
     # Backend
     "CodexRunner",
+    "AgUiBackend",
+    "AgUiEventMapper",
     "SessionBackend",
     "create_backend",
     "parse_codex_line",

--- a/claude_code_core/agui_backend.py
+++ b/claude_code_core/agui_backend.py
@@ -1,0 +1,544 @@
+"""AG-UI HTTP/SSE backend for frontend-neutral relay sessions.
+
+The implementation intentionally speaks the wire protocol directly instead of
+depending on an agent framework.  ``aiohttp`` is imported only when this
+backend runs, so Claude/Codex-only installations keep their small dependency
+surface.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import AsyncGenerator, AsyncIterator
+from typing import TYPE_CHECKING, Any
+from urllib.parse import urlsplit
+from uuid import uuid4
+
+from .types import (
+    TOOL_CATEGORIES,
+    ImageData,
+    MessageType,
+    StreamEvent,
+    ToolCategory,
+    ToolUseEvent,
+)
+
+if TYPE_CHECKING:
+    from aiohttp import ClientResponse
+
+logger = logging.getLogger(__name__)
+
+_MAX_SSE_EVENT_BYTES = 1_048_576
+_MAX_ERROR_CHARS = 1_000
+
+
+class AgUiProtocolError(ValueError):
+    """Raised when an AG-UI peer returns an invalid or unsafe stream."""
+
+
+class AgUiEventMapper:
+    """Statefully translate AG-UI wire events into relay ``StreamEvent`` objects."""
+
+    def __init__(self) -> None:
+        self._thread_id: str | None = None
+        self._message_text: dict[str, str] = {}
+        self._message_roles: dict[str, str] = {}
+        self._tool_names: dict[str, str] = {}
+        self._tool_args: dict[str, str] = {}
+        self._chunk_tool_id: str | None = None
+        self._chunk_tool_name: str | None = None
+        self._chunk_tool_args = ""
+        self._reasoning_parts: list[str] = []
+
+    def feed(self, event: dict[str, Any]) -> list[StreamEvent]:
+        """Map one decoded AG-UI event; unsupported event types are ignored."""
+        event_type = event.get("type")
+        if not isinstance(event_type, str):
+            raise AgUiProtocolError("AG-UI event is missing a string type")
+        if event_type != "TOOL_CALL_CHUNK" and self._chunk_tool_id is not None:
+            # Compact chunk events are closed by the next non-chunk event, as
+            # specified by the AG-UI client transform.
+            pending = self._finish_tool_chunk()
+            return [pending, *self.feed(event)]
+
+        if event_type == "RUN_STARTED":
+            thread_id = _required_string(event, "threadId")
+            self._thread_id = thread_id
+            return [StreamEvent(message_type=MessageType.SYSTEM, session_id=thread_id)]
+
+        if event_type == "RUN_FINISHED":
+            thread_id = _optional_string(event.get("threadId")) or self._thread_id
+            outcome = event.get("outcome")
+            if isinstance(outcome, dict) and outcome.get("type") == "interrupt":
+                return [
+                    StreamEvent(
+                        message_type=MessageType.RESULT,
+                        session_id=thread_id,
+                        is_complete=True,
+                        error=(
+                            "AG-UI agent requested an interrupt response; "
+                            "interrupt/resume is not supported yet"
+                        ),
+                    )
+                ]
+            return [
+                StreamEvent(
+                    message_type=MessageType.RESULT,
+                    session_id=thread_id,
+                    is_complete=True,
+                )
+            ]
+
+        if event_type == "RUN_ERROR":
+            message = _optional_string(event.get("message")) or "AG-UI agent run failed"
+            return [
+                StreamEvent(
+                    message_type=MessageType.RESULT,
+                    is_complete=True,
+                    error=message[:_MAX_ERROR_CHARS],
+                )
+            ]
+
+        if event_type == "TEXT_MESSAGE_START":
+            message_id = _required_string(event, "messageId")
+            self._message_text[message_id] = ""
+            self._message_roles[message_id] = _optional_string(event.get("role")) or "assistant"
+            return []
+
+        if event_type == "TEXT_MESSAGE_CONTENT":
+            message_id = _required_string(event, "messageId")
+            if self._message_roles.get(message_id, "assistant") != "assistant":
+                return []
+            delta = _required_string(event, "delta", allow_empty=True)
+            text = self._message_text.get(message_id, "") + delta
+            self._message_text[message_id] = text
+            if not delta:
+                return []
+            return [
+                StreamEvent(
+                    message_type=MessageType.ASSISTANT,
+                    text=text,
+                    is_partial=True,
+                )
+            ]
+
+        if event_type == "TEXT_MESSAGE_END":
+            message_id = _required_string(event, "messageId")
+            role = self._message_roles.pop(message_id, "assistant")
+            text = self._message_text.pop(message_id, "")
+            if role != "assistant" or not text:
+                return []
+            return [
+                StreamEvent(
+                    message_type=MessageType.ASSISTANT,
+                    text=text,
+                    is_partial=False,
+                )
+            ]
+
+        if event_type == "TEXT_MESSAGE_CHUNK":
+            return self._feed_text_chunk(event)
+
+        if event_type == "TOOL_CALL_START":
+            tool_id = _required_string(event, "toolCallId")
+            self._tool_names[tool_id] = _required_string(event, "toolCallName")
+            self._tool_args[tool_id] = ""
+            return []
+
+        if event_type == "TOOL_CALL_ARGS":
+            tool_id = _required_string(event, "toolCallId")
+            delta = _required_string(event, "delta", allow_empty=True)
+            self._tool_args[tool_id] = self._tool_args.get(tool_id, "") + delta
+            return []
+
+        if event_type == "TOOL_CALL_END":
+            tool_id = _required_string(event, "toolCallId")
+            name = self._tool_names.pop(tool_id, "unknown")
+            raw_args = self._tool_args.pop(tool_id, "")
+            tool_input = _parse_tool_input(raw_args)
+            return [
+                StreamEvent(
+                    message_type=MessageType.ASSISTANT,
+                    tool_use=ToolUseEvent(
+                        tool_id=tool_id,
+                        tool_name=name,
+                        tool_input=tool_input,
+                        category=TOOL_CATEGORIES.get(name, ToolCategory.OTHER),
+                    ),
+                )
+            ]
+
+        if event_type == "TOOL_CALL_RESULT":
+            return [
+                StreamEvent(
+                    message_type=MessageType.USER,
+                    tool_result_id=_required_string(event, "toolCallId"),
+                    tool_result_content=_required_string(event, "content", allow_empty=True),
+                )
+            ]
+
+        if event_type == "TOOL_CALL_CHUNK":
+            return self._feed_tool_chunk(event)
+
+        if event_type in {"REASONING_START", "THINKING_START"}:
+            self._reasoning_parts.clear()
+            return []
+
+        if event_type in {"REASONING_MESSAGE_CONTENT", "THINKING_TEXT_MESSAGE_CONTENT"}:
+            delta = _required_string(event, "delta", allow_empty=True)
+            if delta:
+                self._reasoning_parts.append(delta)
+            return []
+
+        if event_type in {"REASONING_END", "THINKING_END"}:
+            thinking = "".join(self._reasoning_parts)
+            self._reasoning_parts.clear()
+            if not thinking:
+                return []
+            return [
+                StreamEvent(
+                    message_type=MessageType.ASSISTANT,
+                    thinking=thinking,
+                    is_partial=False,
+                )
+            ]
+
+        return []
+
+    def _feed_tool_chunk(self, event: dict[str, Any]) -> list[StreamEvent]:
+        incoming_id = _optional_string(event.get("toolCallId"))
+        incoming_name = _optional_string(event.get("toolCallName"))
+        completed: list[StreamEvent] = []
+        if self._chunk_tool_id is not None and incoming_id not in {None, self._chunk_tool_id}:
+            completed.append(self._finish_tool_chunk())
+        if self._chunk_tool_id is None:
+            if incoming_id is None or incoming_name is None:
+                raise AgUiProtocolError(
+                    "first AG-UI TOOL_CALL_CHUNK requires toolCallId and toolCallName"
+                )
+            self._chunk_tool_id = incoming_id
+            self._chunk_tool_name = incoming_name
+            self._chunk_tool_args = ""
+        delta = _optional_string(event.get("delta"))
+        if delta:
+            self._chunk_tool_args += delta
+        return completed
+
+    def _finish_tool_chunk(self) -> StreamEvent:
+        tool_id = self._chunk_tool_id
+        name = self._chunk_tool_name
+        if tool_id is None or name is None:  # pragma: no cover - internal invariant
+            raise AgUiProtocolError("AG-UI compact tool call has no identity")
+        event = StreamEvent(
+            message_type=MessageType.ASSISTANT,
+            tool_use=ToolUseEvent(
+                tool_id=tool_id,
+                tool_name=name,
+                tool_input=_parse_tool_input(self._chunk_tool_args),
+                category=TOOL_CATEGORIES.get(name, ToolCategory.OTHER),
+            ),
+        )
+        self._chunk_tool_id = None
+        self._chunk_tool_name = None
+        self._chunk_tool_args = ""
+        return event
+
+    def _feed_text_chunk(self, event: dict[str, Any]) -> list[StreamEvent]:
+        """Expand the compact AG-UI text event into the normal message lifecycle."""
+        message_id = _optional_string(event.get("messageId")) or f"chunk-{uuid4()}"
+        role = _optional_string(event.get("role"))
+        if message_id not in self._message_text:
+            self._message_text[message_id] = ""
+            self._message_roles[message_id] = role or "assistant"
+        if self._message_roles[message_id] != "assistant":
+            return []
+        delta = _optional_string(event.get("delta")) or ""
+        if not delta:
+            return []
+        text = self._message_text[message_id] + delta
+        self._message_text[message_id] = text
+        return [StreamEvent(message_type=MessageType.ASSISTANT, text=text, is_partial=True)]
+
+
+class AgUiBackend:
+    """Connect a relay session to a remote AG-UI HTTP agent."""
+
+    def __init__(
+        self,
+        endpoint_url: str,
+        *,
+        auth_token: str | None = None,
+        thread_id: int | str | None = None,
+        model: str | None = None,
+        command: str = "ag-ui",
+        permission_mode: str = "default",
+        working_dir: str | None = None,
+        timeout_seconds: int = 300,
+        dangerously_skip_permissions: bool = False,
+        allowed_tools: list[str] | None = None,
+        images: list[ImageData] | None = None,
+        api_port: int | None = None,
+        **_ignored: object,
+    ) -> None:
+        self.endpoint_url = _validate_endpoint_url(endpoint_url)
+        self.auth_token = auth_token
+        self.thread_id = thread_id
+        self.model = model or "remote"
+        self.command = command
+        self.permission_mode = permission_mode
+        self.working_dir = working_dir
+        self.timeout_seconds = timeout_seconds
+        self.dangerously_skip_permissions = dangerously_skip_permissions
+        self.allowed_tools = allowed_tools
+        self.images = images
+        self.api_port = api_port
+        self._response: ClientResponse | None = None
+        self._interrupted = False
+
+    def clone(self, **kwargs: object) -> AgUiBackend:
+        """Clone configuration without sharing request/cancellation state."""
+        config: dict[str, object] = {
+            "endpoint_url": self.endpoint_url,
+            "auth_token": self.auth_token,
+            "thread_id": self.thread_id,
+            "model": self.model,
+            "command": self.command,
+            "permission_mode": self.permission_mode,
+            "working_dir": self.working_dir,
+            "timeout_seconds": self.timeout_seconds,
+            "dangerously_skip_permissions": self.dangerously_skip_permissions,
+            "allowed_tools": self.allowed_tools,
+            "images": self.images,
+            "api_port": self.api_port,
+        }
+        config.update(kwargs)
+        return AgUiBackend(**config)  # type: ignore[arg-type]
+
+    async def run(
+        self,
+        prompt: str,
+        session_id: str | None = None,
+    ) -> AsyncGenerator[StreamEvent, None]:
+        """POST one AG-UI run and translate its SSE event stream."""
+        try:
+            import aiohttp
+        except ImportError:
+            yield _terminal_error("AG-UI backend requires the 'agui' optional dependency")
+            return
+
+        self._interrupted = False
+        thread_id = session_id or (
+            str(self.thread_id) if self.thread_id is not None else str(uuid4())
+        )
+        run_id = str(uuid4())
+        body = _build_run_input(
+            prompt=prompt,
+            thread_id=thread_id,
+            run_id=run_id,
+            images=self.images,
+        )
+        headers = {"Accept": "text/event-stream", "Content-Type": "application/json"}
+        if self.auth_token:
+            headers["Authorization"] = f"Bearer {self.auth_token}"
+
+        timeout = aiohttp.ClientTimeout(total=self.timeout_seconds)
+        mapper = AgUiEventMapper()
+        terminal_seen = False
+        try:
+            async with (
+                aiohttp.ClientSession(timeout=timeout) as client,
+                client.post(
+                    self.endpoint_url,
+                    json=body,
+                    headers=headers,
+                    allow_redirects=False,
+                ) as response,
+            ):
+                self._response = response
+                if response.status < 200 or response.status >= 300:
+                    yield _terminal_error(f"AG-UI endpoint returned HTTP {response.status}")
+                    return
+                content_type = response.headers.get("Content-Type", "").lower()
+                if "text/event-stream" not in content_type:
+                    yield _terminal_error("AG-UI endpoint did not return text/event-stream")
+                    return
+                async for wire_event in _iter_sse_events(response.content):
+                    if self._interrupted:
+                        return
+                    for mapped in mapper.feed(wire_event):
+                        terminal_seen = terminal_seen or mapped.is_complete
+                        yield mapped
+        except AgUiProtocolError as exc:
+            yield _terminal_error(str(exc))
+            return
+        except TimeoutError:
+            if not self._interrupted:
+                yield _terminal_error(
+                    f"AG-UI request timed out after {self.timeout_seconds} seconds"
+                )
+            return
+        except Exception:
+            if not self._interrupted:
+                logger.warning("AG-UI request failed", exc_info=True)
+                yield _terminal_error("AG-UI endpoint request failed")
+            return
+        finally:
+            self._response = None
+
+        if not terminal_seen and not self._interrupted:
+            yield _terminal_error("AG-UI stream ended without a terminal event")
+
+    async def interrupt(self) -> None:
+        """Stop reading the active remote stream."""
+        self._interrupted = True
+        if self._response is not None:
+            self._response.close()
+
+    async def kill(self) -> None:
+        """Terminate the active request (same transport action as interrupt)."""
+        await self.interrupt()
+
+    async def inject_tool_result(self, request_id: str, data: dict) -> None:
+        """Reject CLI-specific approval injection that AG-UI does not define."""
+        raise RuntimeError(
+            f"AG-UI backend cannot inject a result for request {request_id!r}; "
+            "use an AG-UI interrupt/resume flow"
+        )
+
+    def _build_env(self) -> dict[str, str]:
+        """AG-UI starts no subprocess and therefore exposes no child environment."""
+        return {}
+
+    def describe_api(self) -> str:
+        """Return a safe display label without exposing the configured URL or token."""
+        return "AG-UI"
+
+
+def _build_run_input(
+    *,
+    prompt: str,
+    thread_id: str,
+    run_id: str,
+    images: list[ImageData] | None,
+) -> dict[str, Any]:
+    content: str | list[dict[str, Any]] = prompt
+    if images:
+        content = [{"type": "text", "text": prompt}]
+        content.extend(
+            {
+                "type": "image",
+                "source": {
+                    "type": "data",
+                    "value": image.data,
+                    "mimeType": image.media_type,
+                },
+            }
+            for image in images
+        )
+    return {
+        "threadId": thread_id,
+        "runId": run_id,
+        "state": {},
+        "messages": [{"id": str(uuid4()), "role": "user", "content": content}],
+        "tools": [],
+        "context": [],
+        "forwardedProps": {},
+    }
+
+
+async def _iter_sse_events(content: Any) -> AsyncIterator[dict[str, Any]]:
+    """Parse bounded UTF-8 JSON SSE frames from an aiohttp response body."""
+    buffer = bytearray()
+    data_lines: list[bytes] = []
+    frame_bytes = 0
+
+    async for chunk in content.iter_chunked(8192):
+        buffer.extend(chunk)
+        while True:
+            newline = buffer.find(b"\n")
+            if newline < 0:
+                if frame_bytes + len(buffer) > _MAX_SSE_EVENT_BYTES:
+                    raise AgUiProtocolError("AG-UI SSE event exceeded the size limit")
+                break
+            line = bytes(buffer[:newline]).rstrip(b"\r")
+            del buffer[: newline + 1]
+            frame_bytes += len(line) + 1
+            if frame_bytes > _MAX_SSE_EVENT_BYTES:
+                raise AgUiProtocolError("AG-UI SSE event exceeded the size limit")
+            if not line:
+                if data_lines:
+                    yield _decode_sse_json(data_lines)
+                data_lines = []
+                frame_bytes = 0
+                continue
+            if line.startswith(b":"):
+                continue
+            if line == b"data":
+                data_lines.append(b"")
+            elif line.startswith(b"data:"):
+                value = line[5:]
+                if value.startswith(b" "):
+                    value = value[1:]
+                data_lines.append(value)
+
+    if buffer:
+        frame_bytes += len(buffer)
+        if frame_bytes > _MAX_SSE_EVENT_BYTES:
+            raise AgUiProtocolError("AG-UI SSE event exceeded the size limit")
+        line = bytes(buffer).rstrip(b"\r")
+        if line.startswith(b"data:"):
+            value = line[5:]
+            data_lines.append(value[1:] if value.startswith(b" ") else value)
+    if data_lines:
+        yield _decode_sse_json(data_lines)
+
+
+def _decode_sse_json(data_lines: list[bytes]) -> dict[str, Any]:
+    payload = b"\n".join(data_lines)
+    try:
+        decoded = json.loads(payload)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise AgUiProtocolError("AG-UI endpoint returned invalid JSON SSE data") from exc
+    if not isinstance(decoded, dict):
+        raise AgUiProtocolError("AG-UI SSE data must be a JSON object")
+    return decoded
+
+
+def _parse_tool_input(raw: str) -> dict[str, Any]:
+    if not raw:
+        return {}
+    try:
+        value = json.loads(raw)
+    except json.JSONDecodeError:
+        return {"raw": raw}
+    return value if isinstance(value, dict) else {"value": value}
+
+
+def _required_string(
+    event: dict[str, Any],
+    key: str,
+    *,
+    allow_empty: bool = False,
+) -> str:
+    value = event.get(key)
+    if not isinstance(value, str) or (not value and not allow_empty):
+        raise AgUiProtocolError(f"AG-UI event has invalid {key}")
+    return value
+
+
+def _optional_string(value: object) -> str | None:
+    return value if isinstance(value, str) else None
+
+
+def _validate_endpoint_url(endpoint_url: str) -> str:
+    parsed = urlsplit(endpoint_url)
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+        raise ValueError("AG-UI endpoint URL must use http or https")
+    if parsed.username is not None or parsed.password is not None:
+        raise ValueError("AG-UI endpoint URL must not contain credentials")
+    return endpoint_url
+
+
+def _terminal_error(message: str) -> StreamEvent:
+    return StreamEvent(message_type=MessageType.RESULT, is_complete=True, error=message)

--- a/claude_code_core/backend.py
+++ b/claude_code_core/backend.py
@@ -55,7 +55,7 @@ def create_backend(
     """Create a backend runner by name.
 
     Args:
-        backend: "claude", "codex", or "local".
+        backend: "claude", "codex", "local", or "agui".
         model: Model identifier (e.g. "sonnet", "o4-mini"). ``None`` lets the
             backend pick its own default — Codex omits ``--model`` and defers
             to its CLI config.
@@ -73,6 +73,10 @@ def create_backend(
         from .local_backend import LocalCodexRunner
 
         runner = LocalCodexRunner(model=model, **kwargs)  # type: ignore[arg-type]
+    elif backend == "agui":
+        from .agui_backend import AgUiBackend
+
+        runner = AgUiBackend(model=model, **kwargs)  # type: ignore[arg-type]
     else:
         raise ValueError(f"Unknown backend: {backend!r}")
 

--- a/claude_code_core/codex_runner.py
+++ b/claude_code_core/codex_runner.py
@@ -514,6 +514,10 @@ class CodexRunner:
             "DISCORD_BOT_TOKEN",
             "DISCORD_TOKEN",
             "API_SECRET_KEY",
+            "CCDB_AGUI_URL",
+            "CCDB_AGUI_TOKEN",
+            "CCDB_API_URL",
+            "CCDB_API_SECRET",
         }
     )
 

--- a/claude_code_core/runner.py
+++ b/claude_code_core/runner.py
@@ -332,6 +332,10 @@ class ClaudeRunner:
             "DISCORD_BOT_TOKEN",
             "DISCORD_TOKEN",
             "API_SECRET_KEY",
+            "CCDB_AGUI_URL",
+            "CCDB_AGUI_TOKEN",
+            "CCDB_API_URL",
+            "CCDB_API_SECRET",
         }
     )
 

--- a/claude_discord/backend_factory.py
+++ b/claude_discord/backend_factory.py
@@ -26,8 +26,13 @@ logger = logging.getLogger(__name__)
 # ``--model`` entirely so the Codex CLI uses its own default (the ``model``
 # key in ~/.codex/config.toml, currently gpt-5.6-sol). Hard-coding a version
 # here only goes stale as the Codex console default moves.
-DEFAULT_MODEL: dict[str, str | None] = {"claude": "sonnet", "codex": None, "local": None}
-DEFAULT_COMMAND = {"claude": "claude", "codex": "codex", "local": "codex"}
+DEFAULT_MODEL: dict[str, str | None] = {
+    "claude": "sonnet",
+    "codex": None,
+    "local": None,
+    "agui": None,
+}
+DEFAULT_COMMAND = {"claude": "claude", "codex": "codex", "local": "codex", "agui": "ag-ui"}
 
 
 class BackendFactory:
@@ -47,6 +52,8 @@ class BackendFactory:
         effort: str | None,
         api_port: int | None = None,
         api_secret: str | None = None,
+        agui_url: str | None = None,
+        agui_token: str | None = None,
     ) -> None:
         self.claude_command = claude_command or DEFAULT_COMMAND["claude"]
         self.codex_command = codex_command or DEFAULT_COMMAND["codex"]
@@ -59,6 +66,8 @@ class BackendFactory:
         self.effort = effort
         self.api_port = api_port
         self.api_secret = api_secret
+        self.agui_url = agui_url
+        self.agui_token = agui_token
 
     def command_for(self, backend: str) -> str:
         if backend == "claude":
@@ -67,6 +76,8 @@ class BackendFactory:
             # The local backend is the same CLI, pointed at a ccdb-owned
             # CODEX_HOME that pins it to a model on your own hardware.
             return self.codex_command
+        if backend == "agui":
+            return DEFAULT_COMMAND["agui"]
         raise ValueError(f"Unknown backend: {backend!r}")
 
     def default_model_for(self, backend: str) -> str | None:
@@ -95,6 +106,12 @@ class BackendFactory:
             "dangerously_skip_permissions": self.dangerously_skip_permissions,
             "allowed_tools": self.allowed_tools,
         }
+        if backend == "agui":
+            if not self.agui_url:
+                raise ValueError("CCDB_AGUI_URL is required for the AG-UI backend")
+            kwargs["endpoint_url"] = self.agui_url
+            if self.agui_token:
+                kwargs["auth_token"] = self.agui_token
         if thread_id is not None:
             kwargs["thread_id"] = thread_id
         # ``append_system_prompt`` and the env-level ``effort`` are Claude-only

--- a/claude_discord/backend_settings.py
+++ b/claude_discord/backend_settings.py
@@ -1,6 +1,6 @@
 """Persistent, runtime-mutable backend/model selection.
 
-Reads and writes the current backend (claude/codex) and per-backend
+Reads and writes the current backend (claude/codex/local/agui) and per-backend
 model preference to ``SettingsRepository`` (sqlite key-value store).
 
 Resolution order for any field:
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 # Valid backend names. Keep in sync with claude_code_core.backend.create_backend().
-ALL_BACKENDS = ("claude", "codex", "local")
+ALL_BACKENDS = ("claude", "codex", "local", "agui")
 
 # Settings keys
 BACKEND_GLOBAL = "backend.global"
@@ -73,6 +73,8 @@ class BackendSettings:
             # The local model is chosen by CCDB_LOCAL_MODEL, read by
             # LocalModelConfig at spawn time; no separate env knob here.
             "local": "",
+            # AG-UI identifies the model on the remote agent, not in ccdb.
+            "agui": "",
         }
 
     # ── Resolution ──────────────────────────────────────────

--- a/claude_discord/cogs/backend_command.py
+++ b/claude_discord/cogs/backend_command.py
@@ -140,7 +140,7 @@ class BackendCommandCog(commands.Cog):
 
     @app_commands.command(
         name="backend",
-        description="Show or switch the AI backend (claude/codex)",
+        description="Show or switch the AI backend",
     )
     @app_commands.choices(
         name=[Choice(name=b, value=b) for b in ALL_BACKENDS],
@@ -150,7 +150,7 @@ class BackendCommandCog(commands.Cog):
         ],
     )
     @app_commands.describe(
-        name="claude or codex. Omit to show current setting.",
+        name="claude, codex, local, or agui. Omit to show current setting.",
         scope=(
             "thread: only this thread; global: server-wide default. "
             "Default: thread when invoked in a thread, otherwise global."
@@ -222,7 +222,9 @@ class BackendCommandCog(commands.Cog):
             if resolved_scope == SCOPE_THREAD and target_thread_id is not None
             else "**globally**"
         )
-        emoji = {"codex": "\U0001f300", "local": "\U0001f3e0"}.get(name, "\U0001f916")
+        emoji = {"codex": "\U0001f300", "local": "\U0001f3e0", "agui": "\U0001f50c"}.get(
+            name, "\U0001f916"
+        )
         await interaction.response.send_message(
             f"{emoji} Backend set to `{name}` {scope_label}. Next session will use it.",
             ephemeral=False,

--- a/claude_discord/cogs/event_processor.py
+++ b/claude_discord/cogs/event_processor.py
@@ -50,11 +50,17 @@ logger = logging.getLogger(__name__)
 def _backend_name_from_runner(runner: object) -> str:
     """Best-effort mapping from runner class name to embed backend tag."""
     cls = type(runner).__name__
+    if cls == "AnonymizingBackend":
+        inner = getattr(runner, "inner", None)
+        if inner is not None and inner is not runner:
+            return _backend_name_from_runner(inner)
     # LocalCodexRunner subclasses CodexRunner, so it has to be matched first.
     if cls == "LocalCodexRunner":
         return "local"
     if cls == "CodexRunner":
         return "codex"
+    if cls == "AgUiBackend":
+        return "agui"
     return "claude"
 
 

--- a/claude_discord/main.py
+++ b/claude_discord/main.py
@@ -16,8 +16,6 @@ from pathlib import Path
 
 from dotenv import find_dotenv, load_dotenv
 
-from claude_code_core.backend import create_backend
-
 from .bot import ClaudeDiscordBot
 from .cog_loader import load_custom_cogs
 from .deployment import DataLayout
@@ -49,7 +47,7 @@ def load_config() -> dict[str, str]:
     # Default model is backend-specific: Claude needs an explicit alias
     # ("sonnet"), but Codex defers to its own config.toml default when left
     # empty (so we never pin a stale Codex model version).
-    default_model = "" if backend == "codex" else "sonnet"
+    default_model = "sonnet" if backend == "claude" else ""
 
     return {
         "token": token,
@@ -60,6 +58,8 @@ def load_config() -> dict[str, str]:
         # the user switches backend at runtime via /backend.
         "claude_command": _env("CCDB_CLAUDE_COMMAND", "CLAUDE_COMMAND", ""),
         "codex_command": os.getenv("CCDB_CODEX_COMMAND", ""),
+        "agui_url": os.getenv("CCDB_AGUI_URL", ""),
+        "agui_token": os.getenv("CCDB_AGUI_TOKEN", ""),
         "model": _env("CCDB_MODEL", "CLAUDE_MODEL", default_model),
         "permission_mode": _env("CCDB_PERMISSION_MODE", "CLAUDE_PERMISSION_MODE", "acceptEdits"),
         "working_dir": _env("CCDB_WORKING_DIR", "CLAUDE_WORKING_DIR", ""),
@@ -105,8 +105,6 @@ async def main() -> None:
 
     # Create runner via backend factory (CCDB_BACKEND=claude|codex)
     backend_name = config["backend"]
-    default_command = "codex" if backend_name == "codex" else "claude"
-
     # BackendFactory is the runtime authority for building Claude/Codex
     # runners on demand (e.g. when the user switches via /backend).
     from .backend_factory import BackendFactory
@@ -126,21 +124,11 @@ async def main() -> None:
         allowed_tools=allowed_tools,
         append_system_prompt=config["append_system_prompt"] or None,
         effort=config["effort"] or None,
+        agui_url=config["agui_url"] or None,
+        agui_token=config["agui_token"] or None,
     )
 
-    runner = create_backend(
-        backend=backend_name,
-        command=config["command"] or default_command,
-        model=config["model"],
-        permission_mode=config["permission_mode"],
-        working_dir=config["working_dir"] or None,
-        timeout_seconds=int(config["timeout"]),
-        dangerously_skip_permissions=config["dangerously_skip_permissions"].lower()
-        in ("true", "1", "yes"),
-        allowed_tools=allowed_tools,
-        append_system_prompt=config["append_system_prompt"] or None,
-        effort=config["effort"] or None,
-    )
+    runner = factory.build(backend=backend_name, model=config["model"] or None)
 
     owner_id = int(config["owner_id"]) if config["owner_id"] else None
     bot = ClaudeDiscordBot(

--- a/docs/adr/0004-add-ag-ui-as-an-optional-backend.md
+++ b/docs/adr/0004-add-ag-ui-as-an-optional-backend.md
@@ -1,0 +1,98 @@
+---
+type: adr
+id: ADR-0004
+title: Add AG-UI as an optional backend transport
+decision: Implement AG-UI as an optional direct HTTP/SSE SessionBackend while retaining the relay's semantic frontend contract and operational core.
+status: accepted
+date: 2026-08-10
+deciders: [Masahiko Ebi, Codex]
+scope: repository
+supersedes:
+superseded_by:
+---
+
+# ADR-0004: Add AG-UI as an optional backend transport
+
+## Context
+
+Ebi Agent Chat Relay and CopilotKit Channels overlap at the visible product boundary: both connect
+agents to chat surfaces. Their strongest responsibilities differ. Channels and AG-UI provide broad
+agent-framework interoperability, while this relay already owns durable sessions, Discord and Teams
+behavior, permissions, scheduling, coordination, restarts, and operational safety.
+
+The relay needs an extension point for agents beyond the Claude and Codex CLIs without replacing
+those mature operational capabilities or importing an entire TypeScript chat stack.
+
+## Options considered
+
+### Replace the relay with CopilotKit Channels
+
+Rejected. It would discard mature session and operational behavior, require a cross-language
+migration, and expand the credential and data-plane boundary substantially.
+
+### Vendor the Channels packages
+
+Rejected. Vendoring a large TypeScript implementation would create a permanent synchronization and
+supply-chain maintenance burden while duplicating Discord and Teams adapters already present here.
+
+### Depend on the AG-UI Python SDK in the core package
+
+Rejected for the first transport layer. The wire contract needed by a client is small, while a
+mandatory framework dependency would affect every Claude/Codex-only installation. The protocol can
+be implemented and tested directly, with `aiohttp` kept behind an optional extra.
+
+### Add a direct AG-UI `SessionBackend`
+
+Accepted. It preserves the existing frontend-neutral `StreamEvent` and `ConversationSurface`
+contracts while allowing a configured remote AG-UI agent to reuse the relay's chat surfaces and
+operational controls.
+
+## Decision
+
+1. `AgUiBackend` is an optional `SessionBackend`, selected with `/backend agui` or
+   `CCDB_BACKEND=agui`.
+2. It posts the standard `RunAgentInput` JSON shape to one configured HTTP(S) endpoint and consumes
+   JSON Server-Sent Events.
+3. AG-UI lifecycle, text, reasoning, and tool events map into the existing semantic `StreamEvent`
+   vocabulary. The frontend contract does not become AG-UI- or JSX-specific.
+4. `aiohttp` is exposed through the `agui` optional dependency. Importing or running other backends
+   does not require it.
+5. The endpoint is an explicit trust boundary: URL credentials and redirects are rejected, bearer
+   tokens are excluded from child CLI environments, response errors are bounded, and SSE frames
+   have a size limit.
+6. Unsupported interrupt/resume outcomes fail visibly. They must not appear as successful
+   completions until a durable interaction store can recover them across restarts.
+7. The remote agent owns conversation persistence by `threadId` in this first version. Full local
+   transcript replay, state rendering, client tools, and protobuf are follow-up capabilities.
+
+## Rationale
+
+This is the smallest interoperable seam: agent frameworks can speak an open event protocol, while
+the relay keeps the behavior users already depend on. Direct wire support also keeps the security
+boundary inspectable and avoids coupling the Python core to one agent framework's release cadence.
+
+Failing explicitly on interrupts is deliberate. Reporting “Done” would lose a human decision and
+could leave a remote run suspended indefinitely; a visible limitation is safer than false success.
+
+## Consequences and trade-offs
+
+### Positive
+
+- AG-UI agents gain Discord and Teams access without new platform adapters.
+- Claude, Codex, and local backends retain their existing behavior and dependency footprint.
+- The protocol adapter is isolated, unit-testable, and replaceable by an SDK later.
+- Security controls apply at one outbound transport boundary.
+
+### Negative
+
+- The first version requires the remote endpoint to persist context by `threadId`.
+- Human-in-the-loop AG-UI interrupts cannot yet resume through the relay.
+- Supporting only JSON SSE excludes protobuf-only endpoints.
+- Direct protocol maintenance must track compatible AG-UI specification changes.
+
+## Related
+
+- [Issue #605](https://github.com/ebibibi/ebi-agent-chat-relay/issues/605)
+- [AG-UI backend guide](../agui-backend.md)
+- [AG-UI documentation](https://docs.ag-ui.com/)
+- [AG-UI protocol repository](https://github.com/ag-ui-protocol/ag-ui)

--- a/docs/adr/_index.md
+++ b/docs/adr/_index.md
@@ -9,3 +9,4 @@ earlier ADR instead of rewriting its history.
 - [ADR-0001: Adopt Ebi Agent Chat Relay as the product name](0001-adopt-ebi-agent-chat-relay.md)
 - [ADR-0002: Gate session completion on owner PR lifecycle](0002-gate-session-completion-on-owner-prs.md)
 - [ADR-0003: Anonymize by rule, inspect by model](0003-anonymize-by-rule-inspect-by-model.md)
+- [ADR-0004: Add AG-UI as an optional backend transport](0004-add-ag-ui-as-an-optional-backend.md)

--- a/docs/agui-backend.md
+++ b/docs/agui-backend.md
@@ -1,0 +1,67 @@
+# AG-UI backend
+
+The AG-UI backend connects Ebi Agent Chat Relay to a remote agent that implements the
+[Agent–User Interaction Protocol](https://docs.ag-ui.com/). It keeps Discord and Teams as the
+conversation surfaces while replacing the local Claude/Codex CLI process with an HTTP/SSE agent.
+
+## Install and configure
+
+Install the optional HTTP dependency:
+
+```bash
+pip install 'claude-code-discord-bridge[agui]'
+```
+
+Configure the exact run endpoint and, when required, its bearer token:
+
+```dotenv
+CCDB_AGUI_URL=https://agent.example.com/run
+CCDB_AGUI_TOKEN=replace-with-upstream-token
+```
+
+Then select it globally with `CCDB_BACKEND=agui` or at runtime with `/backend agui`. A thread-scoped
+selection affects only that conversation.
+
+## Wire behavior
+
+For every turn, ccdb sends the standard `RunAgentInput` JSON shape with:
+
+- a stable `threadId` (the remote ID returned by `RUN_STARTED` is persisted for later turns);
+- a fresh `runId`;
+- the current user prompt and any image attachments;
+- empty `state`, `tools`, `context`, and `forwardedProps` values.
+
+The endpoint must return `text/event-stream` containing JSON AG-UI events. The backend currently
+maps run lifecycle, streamed assistant text, reasoning text, tool calls, and tool results into
+ccdb's frontend-neutral `StreamEvent` model.
+
+The remote endpoint must retain conversation state by `threadId`. This first interoperability
+layer sends the current user turn rather than replaying a full local transcript on every request.
+
+## Deliberate limits
+
+This version fails explicitly instead of pretending to support protocol features it cannot yet
+resume safely:
+
+- interrupt/resume outcomes (human-in-the-loop);
+- client-provided AG-UI tools;
+- protobuf event streams;
+- AG-UI state and activity rendering.
+
+An interrupt outcome is reported as an error to the conversation. A future durable interaction
+store can add restart-safe resume support without changing the transport contract.
+
+## Security boundary
+
+Treat the endpoint as an AI backend with access to every prompt sent through a selected thread.
+
+- Prefer HTTPS. HTTP is accepted for local development and trusted private networks.
+- Credentials in the URL are rejected; use `CCDB_AGUI_TOKEN`.
+- HTTP redirects are not followed, preventing bearer-token forwarding to another endpoint.
+- `CCDB_AGUI_TOKEN` is removed from Claude and Codex child-process environments.
+- Non-success response bodies are not echoed into Discord or Teams.
+- Each SSE event is bounded to 1 MiB and must be a JSON object.
+- The endpoint URL and token are omitted from status labels and logs.
+
+Use a dedicated, least-privilege token and do not route customer or regulated data to an endpoint
+until its data handling boundary has been approved.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
 
 [project.optional-dependencies]
 api = ["aiohttp>=3.14.3"]
+agui = ["aiohttp>=3.14.3"]
 images = ["pillow>=12.3.0"]
 # The Teams frontend needs an inbound HTTPS listener and asymmetric JWT
 # verification. Discord deployments never call either, so they are not made to

--- a/tests/test_agui_backend.py
+++ b/tests/test_agui_backend.py
@@ -1,0 +1,606 @@
+"""AG-UI backend protocol mapping and HTTP integration tests."""
+
+from __future__ import annotations
+
+import json
+import os
+from unittest.mock import patch
+
+import pytest
+from aiohttp import web
+
+from claude_code_core.agui_backend import (
+    AgUiBackend,
+    AgUiEventMapper,
+    AgUiProtocolError,
+    _iter_sse_events,
+)
+from claude_code_core.codex_runner import CodexRunner
+from claude_code_core.privacy.backend import AnonymizingBackend
+from claude_code_core.runner import ClaudeRunner
+from claude_code_core.types import ImageData, MessageType, ToolCategory
+from claude_discord.backend_factory import BackendFactory
+from claude_discord.backend_settings import ALL_BACKENDS
+from claude_discord.cogs.event_processor import _backend_name_from_runner
+
+
+def _only(mapper: AgUiEventMapper, event: dict[str, object]):
+    mapped = mapper.feed(event)
+    assert len(mapped) == 1
+    return mapped[0]
+
+
+class TestAgUiEventMapper:
+    def test_rejects_event_without_string_type(self) -> None:
+        with pytest.raises(AgUiProtocolError, match="string type"):
+            AgUiEventMapper().feed({"type": 123})
+
+    def test_run_lifecycle_maps_to_session_and_completion(self) -> None:
+        mapper = AgUiEventMapper()
+
+        started = _only(
+            mapper,
+            {"type": "RUN_STARTED", "threadId": "thread-1", "runId": "run-1"},
+        )
+        assert started.message_type is MessageType.SYSTEM
+        assert started.session_id == "thread-1"
+
+        finished = _only(
+            mapper,
+            {"type": "RUN_FINISHED", "threadId": "thread-1", "runId": "run-1"},
+        )
+        assert finished.message_type is MessageType.RESULT
+        assert finished.session_id == "thread-1"
+        assert finished.is_complete is True
+
+    def test_text_deltas_become_cumulative_partial_events(self) -> None:
+        mapper = AgUiEventMapper()
+        assert (
+            mapper.feed(
+                {
+                    "type": "TEXT_MESSAGE_START",
+                    "messageId": "message-1",
+                    "role": "assistant",
+                }
+            )
+            == []
+        )
+
+        first = _only(
+            mapper,
+            {"type": "TEXT_MESSAGE_CONTENT", "messageId": "message-1", "delta": "Hel"},
+        )
+        second = _only(
+            mapper,
+            {"type": "TEXT_MESSAGE_CONTENT", "messageId": "message-1", "delta": "lo"},
+        )
+        final = _only(
+            mapper,
+            {"type": "TEXT_MESSAGE_END", "messageId": "message-1"},
+        )
+
+        assert (first.text, first.is_partial) == ("Hel", True)
+        assert (second.text, second.is_partial) == ("Hello", True)
+        assert (final.text, final.is_partial) == ("Hello", False)
+
+    def test_tool_call_is_emitted_after_arguments_are_complete(self) -> None:
+        mapper = AgUiEventMapper()
+        assert (
+            mapper.feed(
+                {
+                    "type": "TOOL_CALL_START",
+                    "toolCallId": "tool-1",
+                    "toolCallName": "search",
+                }
+            )
+            == []
+        )
+        assert (
+            mapper.feed({"type": "TOOL_CALL_ARGS", "toolCallId": "tool-1", "delta": '{"q":'}) == []
+        )
+        assert (
+            mapper.feed({"type": "TOOL_CALL_ARGS", "toolCallId": "tool-1", "delta": '"AG-UI"}'})
+            == []
+        )
+
+        call = _only(mapper, {"type": "TOOL_CALL_END", "toolCallId": "tool-1"})
+        assert call.message_type is MessageType.ASSISTANT
+        assert call.tool_use is not None
+        assert call.tool_use.tool_id == "tool-1"
+        assert call.tool_use.tool_name == "search"
+        assert call.tool_use.tool_input == {"q": "AG-UI"}
+        assert call.tool_use.category is ToolCategory.OTHER
+
+        result = _only(
+            mapper,
+            {
+                "type": "TOOL_CALL_RESULT",
+                "messageId": "result-1",
+                "toolCallId": "tool-1",
+                "content": "found",
+            },
+        )
+        assert result.message_type is MessageType.USER
+        assert result.tool_result_id == "tool-1"
+        assert result.tool_result_content == "found"
+
+    def test_compact_tool_chunks_are_closed_before_run_finishes(self) -> None:
+        mapper = AgUiEventMapper()
+        assert (
+            mapper.feed(
+                {
+                    "type": "TOOL_CALL_CHUNK",
+                    "toolCallId": "tool-compact",
+                    "toolCallName": "lookup",
+                    "delta": '{"q":',
+                }
+            )
+            == []
+        )
+        assert mapper.feed({"type": "TOOL_CALL_CHUNK", "delta": '"relay"}'}) == []
+
+        events = mapper.feed({"type": "RUN_FINISHED", "threadId": "thread-1", "runId": "run-1"})
+        assert len(events) == 2
+        assert events[0].tool_use is not None
+        assert events[0].tool_use.tool_id == "tool-compact"
+        assert events[0].tool_use.tool_input == {"q": "relay"}
+        assert events[1].is_complete is True
+
+    def test_compact_tool_chunk_switch_closes_previous_call(self) -> None:
+        mapper = AgUiEventMapper()
+        mapper.feed(
+            {
+                "type": "TOOL_CALL_CHUNK",
+                "toolCallId": "one",
+                "toolCallName": "first",
+                "delta": "[]",
+            }
+        )
+        completed = mapper.feed(
+            {
+                "type": "TOOL_CALL_CHUNK",
+                "toolCallId": "two",
+                "toolCallName": "second",
+                "delta": "not-json",
+            }
+        )
+        assert completed[0].tool_use is not None
+        assert completed[0].tool_use.tool_input == {"value": []}
+        final = mapper.feed({"type": "RUN_ERROR", "message": "stop"})
+        assert final[0].tool_use is not None
+        assert final[0].tool_use.tool_input == {"raw": "not-json"}
+
+    def test_first_compact_tool_chunk_requires_identity(self) -> None:
+        with pytest.raises(AgUiProtocolError, match="toolCallId"):
+            AgUiEventMapper().feed({"type": "TOOL_CALL_CHUNK", "delta": "{}"})
+
+    def test_compact_text_chunks_stream_and_ignore_non_assistant_roles(self) -> None:
+        mapper = AgUiEventMapper()
+        first = _only(
+            mapper,
+            {
+                "type": "TEXT_MESSAGE_CHUNK",
+                "messageId": "assistant-1",
+                "role": "assistant",
+                "delta": "a",
+            },
+        )
+        second = _only(
+            mapper,
+            {"type": "TEXT_MESSAGE_CHUNK", "messageId": "assistant-1", "delta": "b"},
+        )
+        assert (first.text, second.text) == ("a", "ab")
+        assert (
+            mapper.feed(
+                {
+                    "type": "TEXT_MESSAGE_CHUNK",
+                    "messageId": "user-1",
+                    "role": "user",
+                    "delta": "hidden",
+                }
+            )
+            == []
+        )
+        assert mapper.feed({"type": "TEXT_MESSAGE_CHUNK", "messageId": "empty"}) == []
+
+    def test_empty_or_non_assistant_text_and_unknown_events_are_ignored(self) -> None:
+        mapper = AgUiEventMapper()
+        mapper.feed({"type": "TEXT_MESSAGE_START", "messageId": "u", "role": "user"})
+        assert mapper.feed({"type": "TEXT_MESSAGE_CONTENT", "messageId": "u", "delta": "x"}) == []
+        assert mapper.feed({"type": "TEXT_MESSAGE_END", "messageId": "u"}) == []
+        assert mapper.feed({"type": "CUSTOM", "name": "ignored", "value": {}}) == []
+        assert mapper.feed({"type": "REASONING_START"}) == []
+        assert mapper.feed({"type": "REASONING_END"}) == []
+
+    def test_reasoning_is_emitted_only_when_complete(self) -> None:
+        mapper = AgUiEventMapper()
+        assert mapper.feed({"type": "REASONING_START"}) == []
+        assert (
+            mapper.feed(
+                {"type": "REASONING_MESSAGE_CONTENT", "messageId": "r", "delta": "checking"}
+            )
+            == []
+        )
+        reasoning = _only(mapper, {"type": "REASONING_END"})
+        assert reasoning.thinking == "checking"
+        assert reasoning.is_partial is False
+
+    def test_run_error_is_terminal_and_does_not_expose_raw_payload(self) -> None:
+        mapper = AgUiEventMapper()
+        error = _only(
+            mapper,
+            {"type": "RUN_ERROR", "message": "agent failed", "secret": "do-not-copy"},
+        )
+        assert error.message_type is MessageType.RESULT
+        assert error.is_complete is True
+        assert error.error == "agent failed"
+        assert error.raw == {}
+
+    def test_interrupt_outcome_fails_explicitly_instead_of_reporting_success(self) -> None:
+        mapper = AgUiEventMapper()
+        finished = _only(
+            mapper,
+            {
+                "type": "RUN_FINISHED",
+                "threadId": "thread-1",
+                "runId": "run-1",
+                "outcome": {
+                    "type": "interrupt",
+                    "interrupts": [{"id": "approval-1", "value": {"question": "Continue?"}}],
+                },
+            },
+        )
+        assert finished.is_complete is True
+        assert finished.error is not None
+        assert "interrupt" in finished.error.lower()
+
+
+async def _serve(handler) -> tuple[web.AppRunner, str]:
+    app = web.Application()
+    app.router.add_post("/agent", handler)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, "127.0.0.1", 0)
+    await site.start()
+    sockets = site._server.sockets  # type: ignore[union-attr]
+    port = sockets[0].getsockname()[1]
+    return runner, f"http://127.0.0.1:{port}/agent"
+
+
+class TestAgUiBackendHttp:
+    async def test_posts_standard_input_and_streams_sse(self) -> None:
+        captured: dict[str, object] = {}
+
+        async def handler(request: web.Request) -> web.StreamResponse:
+            captured["body"] = await request.json()
+            captured["authorization"] = request.headers.get("Authorization")
+            response = web.StreamResponse(headers={"Content-Type": "text/event-stream"})
+            await response.prepare(request)
+            frames = [
+                {"type": "RUN_STARTED", "threadId": "remote-thread", "runId": "run-1"},
+                {
+                    "type": "TEXT_MESSAGE_START",
+                    "messageId": "message-1",
+                    "role": "assistant",
+                },
+                {
+                    "type": "TEXT_MESSAGE_CONTENT",
+                    "messageId": "message-1",
+                    "delta": "hello",
+                },
+                {"type": "TEXT_MESSAGE_END", "messageId": "message-1"},
+                {
+                    "type": "RUN_FINISHED",
+                    "threadId": "remote-thread",
+                    "runId": "run-1",
+                },
+            ]
+            for frame in frames:
+                await response.write(f"data: {json.dumps(frame)}\n\n".encode())
+            await response.write_eof()
+            return response
+
+        server, url = await _serve(handler)
+        try:
+            backend = AgUiBackend(endpoint_url=url, auth_token="token", thread_id=42)
+            events = [event async for event in backend.run("Hello")]
+        finally:
+            await server.cleanup()
+
+        body = captured["body"]
+        assert isinstance(body, dict)
+        assert body["threadId"] == "42"
+        assert body["messages"][0]["role"] == "user"
+        assert body["messages"][0]["content"] == "Hello"
+        assert body["state"] == {}
+        assert body["tools"] == []
+        assert body["context"] == []
+        assert body["forwardedProps"] == {}
+        assert captured["authorization"] == "Bearer token"
+        assert events[0].session_id == "remote-thread"
+        assert events[-1].is_complete is True
+
+    async def test_resume_uses_stored_session_as_thread_id(self) -> None:
+        thread_ids: list[str] = []
+
+        async def handler(request: web.Request) -> web.Response:
+            thread_ids.append((await request.json())["threadId"])
+            body = (
+                'data: {"type":"RUN_STARTED","threadId":"saved-thread","runId":"r"}\n\n'
+                'data: {"type":"RUN_FINISHED","threadId":"saved-thread","runId":"r"}\n\n'
+            )
+            return web.Response(text=body, content_type="text/event-stream")
+
+        server, url = await _serve(handler)
+        try:
+            backend = AgUiBackend(endpoint_url=url, thread_id=42)
+            _ = [event async for event in backend.run("Again", session_id="saved-thread")]
+        finally:
+            await server.cleanup()
+
+        assert thread_ids == ["saved-thread"]
+
+    async def test_http_error_is_bounded_and_does_not_echo_response_body(self) -> None:
+        async def handler(_request: web.Request) -> web.Response:
+            return web.Response(status=401, text="secret upstream diagnostic")
+
+        server, url = await _serve(handler)
+        try:
+            backend = AgUiBackend(endpoint_url=url)
+            events = [event async for event in backend.run("Hello")]
+        finally:
+            await server.cleanup()
+
+        assert len(events) == 1
+        assert events[0].is_complete is True
+        assert events[0].error == "AG-UI endpoint returned HTTP 401"
+        assert "secret" not in events[0].error
+
+    async def test_does_not_follow_redirects_with_authorization_header(self) -> None:
+        redirected_requests = 0
+
+        async def redirect(request: web.Request) -> web.Response:
+            target = f"http://127.0.0.1:{request.url.port}/redirected"
+            raise web.HTTPFound(target)
+
+        async def redirected(_request: web.Request) -> web.Response:
+            nonlocal redirected_requests
+            redirected_requests += 1
+            return web.Response(text="should not be reached")
+
+        app = web.Application()
+        app.router.add_post("/agent", redirect)
+        app.router.add_route("*", "/redirected", redirected)
+        server = web.AppRunner(app)
+        await server.setup()
+        site = web.TCPSite(server, "127.0.0.1", 0)
+        await site.start()
+        sockets = site._server.sockets  # type: ignore[union-attr]
+        url = f"http://127.0.0.1:{sockets[0].getsockname()[1]}/agent"
+        try:
+            backend = AgUiBackend(endpoint_url=url, auth_token="secret")
+            events = [event async for event in backend.run("Hello")]
+        finally:
+            await server.cleanup()
+
+        assert redirected_requests == 0
+        assert events[-1].error == "AG-UI endpoint returned HTTP 302"
+
+    async def test_rejects_non_http_endpoint(self) -> None:
+        try:
+            AgUiBackend(endpoint_url="file:///etc/passwd")
+        except ValueError as exc:
+            assert "http" in str(exc)
+        else:
+            raise AssertionError("non-HTTP AG-UI URL was accepted")
+
+    def test_rejects_credentials_embedded_in_endpoint(self) -> None:
+        with pytest.raises(ValueError, match="credentials"):
+            AgUiBackend(endpoint_url="https://user:password@agent.example/run")
+
+    async def test_rejects_wrong_content_type(self) -> None:
+        async def handler(_request: web.Request) -> web.Response:
+            return web.json_response({"type": "RUN_FINISHED"})
+
+        server, url = await _serve(handler)
+        try:
+            events = [event async for event in AgUiBackend(endpoint_url=url).run("Hello")]
+        finally:
+            await server.cleanup()
+        assert events[-1].error == "AG-UI endpoint did not return text/event-stream"
+
+    async def test_invalid_sse_json_and_missing_terminal_are_visible_errors(self) -> None:
+        async def invalid(_request: web.Request) -> web.Response:
+            return web.Response(text="data: not-json\n\n", content_type="text/event-stream")
+
+        server, url = await _serve(invalid)
+        try:
+            invalid_events = [event async for event in AgUiBackend(endpoint_url=url).run("x")]
+        finally:
+            await server.cleanup()
+        assert invalid_events[-1].error == "AG-UI endpoint returned invalid JSON SSE data"
+
+        async def incomplete(_request: web.Request) -> web.Response:
+            return web.Response(
+                text='data: {"type":"RUN_STARTED","threadId":"t","runId":"r"}\n\n',
+                content_type="text/event-stream",
+            )
+
+        server, url = await _serve(incomplete)
+        try:
+            incomplete_events = [event async for event in AgUiBackend(endpoint_url=url).run("x")]
+        finally:
+            await server.cleanup()
+        assert incomplete_events[-1].error == "AG-UI stream ended without a terminal event"
+
+    async def test_image_input_uses_standard_inline_data_source(self) -> None:
+        captured: dict[str, object] = {}
+
+        async def handler(request: web.Request) -> web.Response:
+            captured.update(await request.json())
+            body = (
+                'data: {"type":"RUN_STARTED","threadId":"t","runId":"r"}\n\n'
+                'data: {"type":"RUN_FINISHED","threadId":"t","runId":"r"}\n\n'
+            )
+            return web.Response(text=body, content_type="text/event-stream")
+
+        server, url = await _serve(handler)
+        try:
+            backend = AgUiBackend(
+                endpoint_url=url,
+                images=[ImageData(data="aGVsbG8=", media_type="image/png")],
+            )
+            _ = [event async for event in backend.run("inspect")]
+        finally:
+            await server.cleanup()
+        content = captured["messages"][0]["content"]
+        assert content[0] == {"type": "text", "text": "inspect"}
+        assert content[1]["source"] == {
+            "type": "data",
+            "value": "aGVsbG8=",
+            "mimeType": "image/png",
+        }
+
+    async def test_clone_keeps_configuration_without_sharing_active_request(self) -> None:
+        backend = AgUiBackend(
+            endpoint_url="https://agent.example/run",
+            auth_token="token",
+            thread_id=42,
+            timeout_seconds=123,
+        )
+        cloned = backend.clone(thread_id=99)
+        assert isinstance(cloned, AgUiBackend)
+        assert cloned.endpoint_url == backend.endpoint_url
+        assert cloned.auth_token == "token"
+        assert cloned.thread_id == 99
+        assert cloned.timeout_seconds == 123
+
+    async def test_backend_control_methods_fail_closed_and_hide_configuration(self) -> None:
+        backend = AgUiBackend(
+            endpoint_url="https://agent.example/run",
+            auth_token="secret",
+        )
+        assert backend._build_env() == {}
+        assert backend.describe_api() == "AG-UI"
+        with pytest.raises(RuntimeError, match="interrupt/resume"):
+            await backend.inject_tool_result("request-1", {})
+        await backend.kill()
+        assert backend._interrupted is True
+
+
+class _ChunkedContent:
+    def __init__(self, chunks: list[bytes]) -> None:
+        self._chunks = chunks
+
+    async def iter_chunked(self, _size: int):
+        for chunk in self._chunks:
+            yield chunk
+
+
+class TestSseParser:
+    async def test_comments_multiline_data_crlf_and_unterminated_frame(self) -> None:
+        content = _ChunkedContent(
+            [
+                b': keep-alive\r\ndata: {"type":\r\n',
+                b'data: "CUSTOM", "name": "x"}\r\n\r\n',
+                b'data: {"type":"RUN_ERROR","message":"x"}',
+            ]
+        )
+        events = [event async for event in _iter_sse_events(content)]
+        assert events == [
+            {"type": "CUSTOM", "name": "x"},
+            {"type": "RUN_ERROR", "message": "x"},
+        ]
+
+    async def test_rejects_non_object_and_oversized_frames(self) -> None:
+        with pytest.raises(AgUiProtocolError, match="JSON object"):
+            _ = [event async for event in _iter_sse_events(_ChunkedContent([b"data: []\n\n"]))]
+        oversized = b"data: " + (b"x" * 1_048_577)
+        with pytest.raises(AgUiProtocolError, match="size limit"):
+            _ = [event async for event in _iter_sse_events(_ChunkedContent([oversized]))]
+
+
+class TestAgUiBackendWiring:
+    def test_main_config_reads_agui_settings(self) -> None:
+        from claude_discord.main import load_config
+
+        with (
+            patch("claude_discord.main.load_dotenv"),
+            patch.dict(
+                "os.environ",
+                {
+                    "DISCORD_BOT_TOKEN": "fake-token",
+                    "DISCORD_CHANNEL_ID": "123",
+                    "CCDB_BACKEND": "agui",
+                    "CCDB_AGUI_URL": "https://agent.example/run",
+                    "CCDB_AGUI_TOKEN": "upstream-secret",
+                },
+                clear=True,
+            ),
+        ):
+            config = load_config()
+
+        assert config["backend"] == "agui"
+        assert config["agui_url"] == "https://agent.example/run"
+        assert config["agui_token"] == "upstream-secret"
+        assert config["model"] == ""
+
+    def test_backend_is_selectable(self) -> None:
+        assert "agui" in ALL_BACKENDS
+
+    def test_factory_builds_agui_with_remote_configuration(self) -> None:
+        factory = BackendFactory(
+            claude_command="claude",
+            codex_command="codex",
+            agui_url="https://agent.example/run",
+            agui_token="secret",
+            permission_mode="acceptEdits",
+            working_dir=None,
+            timeout_seconds=300,
+            dangerously_skip_permissions=False,
+            allowed_tools=None,
+            append_system_prompt=None,
+            effort=None,
+        )
+        backend = factory.build(backend="agui", thread_id=42)
+        assert isinstance(backend, AgUiBackend)
+        assert backend.endpoint_url == "https://agent.example/run"
+        assert backend.auth_token == "secret"
+        assert backend.thread_id == 42
+        assert _backend_name_from_runner(backend) == "agui"
+
+    def test_backend_name_survives_privacy_wrapper(self) -> None:
+        backend = AgUiBackend(endpoint_url="https://agent.example/run")
+        wrapped = AnonymizingBackend(backend, gateway=object())  # type: ignore[arg-type]
+        assert _backend_name_from_runner(wrapped) == "agui"
+
+    def test_factory_fails_closed_when_agui_url_is_missing(self) -> None:
+        factory = BackendFactory(
+            claude_command="claude",
+            codex_command="codex",
+            permission_mode="acceptEdits",
+            working_dir=None,
+            timeout_seconds=300,
+            dangerously_skip_permissions=False,
+            allowed_tools=None,
+            append_system_prompt=None,
+            effort=None,
+        )
+        try:
+            factory.build(backend="agui")
+        except ValueError as exc:
+            assert "CCDB_AGUI_URL" in str(exc)
+        else:
+            raise AssertionError("AG-UI backend started without an endpoint")
+
+    def test_agui_token_is_not_exposed_to_cli_backends(self) -> None:
+        os.environ["CCDB_AGUI_URL"] = "https://internal-agent.example/run"
+        os.environ["CCDB_AGUI_TOKEN"] = "upstream-secret"
+        try:
+            for runner in (ClaudeRunner(), CodexRunner()):
+                env = runner._build_env()
+                assert "CCDB_AGUI_URL" not in env
+                assert "CCDB_AGUI_TOKEN" not in env
+        finally:
+            del os.environ["CCDB_AGUI_URL"]
+            del os.environ["CCDB_AGUI_TOKEN"]

--- a/tests/test_backend_protocol.py
+++ b/tests/test_backend_protocol.py
@@ -55,6 +55,15 @@ class TestCreateBackend:
         backend = create_backend(backend="codex", model="o4-mini")
         assert isinstance(backend, CodexRunner)
 
+    def test_agui_backend(self) -> None:
+        from claude_code_core.agui_backend import AgUiBackend
+
+        backend = create_backend(
+            backend="agui",
+            endpoint_url="https://agent.example/run",
+        )
+        assert isinstance(backend, AgUiBackend)
+
     def test_unknown_backend_raises(self) -> None:
         with pytest.raises(ValueError, match="Unknown backend"):
             create_backend(backend="unknown", model="sonnet")

--- a/tests/test_event_processor.py
+++ b/tests/test_event_processor.py
@@ -27,7 +27,7 @@ from claude_discord.claude.types import (
     ToolCategory,
     ToolUseEvent,
 )
-from claude_discord.cogs.event_processor import EventProcessor
+from claude_discord.cogs.event_processor import EventProcessor, _backend_name_from_runner
 from claude_discord.cogs.run_config import RunConfig
 from claude_discord.discord_ui.prompt_views import ChoiceView
 from claude_discord.surface import DiscordActivity, FormLauncher
@@ -91,6 +91,11 @@ def _make_result_event(**kwargs) -> StreamEvent:
         duration_ms=500,
         **kwargs,
     )
+
+
+def test_backend_name_does_not_unwrap_arbitrary_mock_attributes() -> None:
+    """Only real backend wrappers should have their ``inner`` traversed."""
+    assert _backend_name_from_runner(MagicMock()) == "claude"
 
 
 class TestEventProcessorProperties:

--- a/uv.lock
+++ b/uv.lock
@@ -193,6 +193,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+agui = [
+    { name = "aiohttp" },
+]
 api = [
     { name = "aiohttp" },
 ]
@@ -220,6 +223,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "aiohttp", marker = "extra == 'agui'", specifier = ">=3.14.3" },
     { name = "aiohttp", marker = "extra == 'api'", specifier = ">=3.14.3" },
     { name = "aiohttp", marker = "extra == 'teams'", specifier = ">=3.14.3" },
     { name = "aiosqlite", specifier = ">=0.20,<1.0" },
@@ -229,7 +233,7 @@ requires-dist = [
     { name = "pyjwt", extras = ["crypto"], marker = "extra == 'teams'", specifier = ">=2.13.0,<3.0" },
     { name = "python-dotenv", specifier = ">=1.2.2,<2.0" },
 ]
-provides-extras = ["api", "images", "teams"]
+provides-extras = ["api", "agui", "images", "teams"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Closes #605

## Summary
- add an optional HTTP/SSE AG-UI `SessionBackend` with thread persistence
- expose AG-UI through `/backend agui` and environment configuration
- map text, reasoning, tool calls, results, images, and run lifecycle events
- document the integration boundary, unsupported capabilities, and architecture decision

## Security
- reject URL credentials and redirects to keep bearer tokens on the configured origin
- bound SSE frames and avoid exposing upstream error response bodies
- strip relay and AG-UI credentials from spawned CLI environments
- fail unsupported interrupt/resume requests explicitly

## Verification
- `2513 passed, 15 warnings`
- `ruff check` and `ruff format --check` pass
- Pyright reports 0 errors (6 pre-existing lazy-export warnings)
