### PR TITLE
[release] Release AG-UI support as v3.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-Last updated: 2026-07-27
+Last updated: 2026-08-11
 
 All notable changes to this project will be documented in this file.
 
@@ -9,11 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.4.0] - 2026-08-11
+
 ### Fixed
 
 - **Teams rejected every genuine inbound request — the token claim is `serviceurl`, not `serviceUrl`** — found by pointing a real Teams tenant at the endpoint for the first time. The signature, issuer, audience and expiry all verified; the request then died on the last check with "token has no serviceUrl claim". Measured on a live Bot Framework token, the claim set is exactly `['aud', 'exp', 'iss', 'nbf', 'serviceurl']` — the camelCase spelling that appears throughout the activity *body* does not exist in the token. **The whole suite was green the entire time**, because the fixtures were built with the same wrong name the implementation read: a test that constructs its own input cannot catch a wrong assumption about that input. Both spellings are accepted now, and `TestTheClaimNameIsLowerCase` pins the real one along with the reason it went unseen.
 
 ### Added
+
+- **AG-UI agents as an optional backend** — `AgUiBackend` sends standard `RunAgentInput` requests to a configured HTTP(S) endpoint and maps JSON SSE lifecycle, text, reasoning, and tool events into the relay's existing `StreamEvent` contract. Select it with `/backend agui` or `CCDB_BACKEND=agui`; Discord thread identity is preserved as the AG-UI `threadId`, and images are sent as inline base64 input. The transport is isolated behind the `agui` optional dependency and treats the endpoint as a security boundary: URL credentials and redirects are rejected, bearer tokens are stripped from child CLI environments, response details are bounded, and oversized SSE frames fail closed. Durable HITL resume, state/activity rendering, protobuf, and client tools remain explicit follow-ups. (#605, #607)
 
 - **Teams can run without putting the session host on the internet — `claude_teams.relay`** — Discord was safe in a way that had nothing to do with the code: the transport was outbound only, so the machine running coding-agent sessions never appeared on the internet's attack surface. Teams requires inbound HTTPS, but *where* that inbound lands is a choice. A disposable receiver takes the request, verifies the token, and puts the activity on a queue; the session host **polls that queue outbound** and replies straight to the Bot Connector, also outbound. The host opens no listening port — the Discord shape, restored on a platform that does not offer it. The receiver holds the bot's *public* application id and a write credential for one queue, and **no client secret**, because it never replies: owning it yields the traffic passing through from that moment on, not the ability to speak as the bot, read past conversations, or reach the host. It verifies rather than forwarding, because forwarding would make the queue the trust boundary and put the Bot Connector's keys on the private machine; the envelope records what was checked, so the host's trust is auditable rather than assumed, and carries the **token's** `serviceurl` rather than the body's copy — the distinction that stops a replayed token redirecting the host's authenticated calls, and one that moving machines must not quietly lose.
 - **The failure modes that come with a queue, handled rather than discovered** — acknowledgement is separate from delivery, so a host that dies mid-handler gets the message again instead of losing it (a user's message that vanishes because a process restarted is indistinguishable from a bot that ignored them). That makes duplicates possible, so the puller filters by activity id: running a session twice for one message is worse than the crash that caused the redelivery. A message that fails every time is dropped after a bounded number of deliveries, loudly and with its id, because the alternative blocks every message behind it. An unreadable one is dropped immediately — unreadable now is unreadable next time. And a poll that returns nothing pauses, because a queue with no long poll would otherwise turn the loop into a spin against it.

--- a/docs/adr/0005-classify-feature-backends-as-minor-releases.md
+++ b/docs/adr/0005-classify-feature-backends-as-minor-releases.md
@@ -1,0 +1,75 @@
+---
+type: adr
+id: ADR-0005
+title: Classify new optional backends as minor releases
+decision: Release a new backward-compatible SessionBackend as a SemVer minor version, even when the default merge automation initially creates a patch bump.
+status: accepted
+date: 2026-08-11
+deciders: [Masahiko Ebi, Codex]
+scope: repository
+supersedes:
+superseded_by:
+---
+
+# ADR-0005: Classify new optional backends as minor releases
+
+## Context
+
+The default post-merge workflow increments the patch component for every ordinary pull request.
+PR #607 added AG-UI as a new optional `SessionBackend`, but the workflow therefore changed the
+version from 3.3.36 to 3.3.37. The implementation is backward compatible and disabled unless
+configured, yet it materially expands the public product capability and configuration surface.
+
+The repository declares Semantic Versioning and already documents a manual release path for minor
+and major versions.
+
+## Options considered
+
+### Keep 3.3.37
+
+Rejected. A patch version communicates a backward-compatible bug fix. Adding a new backend and
+public configuration surface is a backward-compatible feature, so a patch understates the change.
+
+### Release 3.4.0
+
+Accepted. A minor version is the SemVer classification for backward-compatible functionality. It
+also preserves the existing 3.x compatibility promise because the default Claude, Codex, and local
+backend behavior is unchanged.
+
+### Release 4.0.0
+
+Rejected. AG-UI is optional and additive. It does not remove or incompatibly change a public API,
+configuration key, stored session format, or default behavior, so a major version would falsely
+signal a breaking change.
+
+## Decision
+
+1. Correct the AG-UI release version to 3.4.0 and publish it through the documented `[release]`
+   workflow.
+2. Treat future new backward-compatible frontend or backend implementations as minor releases.
+3. Reserve major releases for incompatible public API, configuration, persistence, or default
+   behavior changes.
+4. Keep the automatic patch bump for ordinary fixes; a feature PR that deserves a minor release
+   must be followed by or prepared as an explicit release PR until the automation supports richer
+   classification.
+
+## Consequences and trade-offs
+
+### Positive
+
+- Version numbers communicate the compatibility and product significance of changes accurately.
+- Existing 3.x users can adopt AG-UI without interpreting it as a breaking migration.
+- The decision gives future backend additions a repeatable release rule.
+
+### Negative
+
+- The current automation cannot infer the release level from the merged change, so maintainers must
+  use the explicit release path for minor versions.
+- The intermediate 3.3.37 commit remains in history; 3.4.0 supersedes it as the intended release
+  version rather than rewriting published history.
+
+## Related
+
+- [ADR-0004: Add AG-UI as an optional backend transport](0004-add-ag-ui-as-an-optional-backend.md)
+- [PR #607](https://github.com/ebibibi/ebi-agent-chat-relay/pull/607)
+- [Contributing: versioning](../ja/CONTRIBUTING.md#バージョニング)

--- a/docs/adr/_index.md
+++ b/docs/adr/_index.md
@@ -10,3 +10,4 @@ earlier ADR instead of rewriting its history.
 - [ADR-0002: Gate session completion on owner PR lifecycle](0002-gate-session-completion-on-owner-prs.md)
 - [ADR-0003: Anonymize by rule, inspect by model](0003-anonymize-by-rule-inspect-by-model.md)
 - [ADR-0004: Add AG-UI as an optional backend transport](0004-add-ag-ui-as-an-optional-backend.md)
+- [ADR-0005: Classify new optional backends as minor releases](0005-classify-feature-backends-as-minor-releases.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "claude-code-discord-bridge"
-version = "3.3.37"
+version = "3.4.0"
 description = "Ebi Agent Chat Relay (formerly Claude & Codex Discord Bridge) — drive both Claude Code and OpenAI Codex from Discord with interactive chat, parallel sessions, and CI/CD automation"
 readme = "README.md"
 license = {text = "MIT"}

--- a/uv.lock
+++ b/uv.lock
@@ -184,7 +184,7 @@ wheels = [
 
 [[package]]
 name = "claude-code-discord-bridge"
-version = "3.3.37"
+version = "3.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

- correct the AG-UI feature release from the automatic patch version to SemVer minor `3.4.0`
- synchronize `pyproject.toml` and `uv.lock`
- publish the accumulated unreleased changes in `CHANGELOG.md`, including AG-UI support
- record the release classification rule in ADR-0005

## Rationale

AG-UI is backward-compatible, optional functionality. SemVer classifies that as a minor release, not a patch or a breaking major release.

## Verification

- `git diff --check`
- `uv lock --check`
- installed package metadata reports `3.4.0`

The `[release]` marker instructs the existing workflow to tag the current version without applying another patch bump.