### PR TITLE
Run Teams beside Discord in the normal launcher

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -142,3 +142,7 @@ SESSION_TIMEOUT_SECONDS=300
 # CCDB_TEAMS_PUBLIC_HOST=relay.example.com
 # CCDB_TEAMS_ENDPOINT_PATH=/api/teams/messages
 # CCDB_TEAMS_BOT_NAME=Agent Relay
+# Run the private-side queue poller beside Discord. The queue URL includes a
+# SAS credential; never commit its real value or print it in logs.
+# CCDB_FRONTENDS=discord,teams
+# CCDB_TEAMS_QUEUE_URL=https://account.queue.core.windows.net/relay?<SAS>

--- a/claude_code_core/codex_runner.py
+++ b/claude_code_core/codex_runner.py
@@ -516,6 +516,8 @@ class CodexRunner:
             "API_SECRET_KEY",
             "CCDB_AGUI_URL",
             "CCDB_AGUI_TOKEN",
+            "CCDB_TEAMS_APP_PASSWORD",
+            "CCDB_TEAMS_QUEUE_URL",
             "CCDB_API_URL",
             "CCDB_API_SECRET",
         }

--- a/claude_code_core/runner.py
+++ b/claude_code_core/runner.py
@@ -334,6 +334,8 @@ class ClaudeRunner:
             "API_SECRET_KEY",
             "CCDB_AGUI_URL",
             "CCDB_AGUI_TOKEN",
+            "CCDB_TEAMS_APP_PASSWORD",
+            "CCDB_TEAMS_QUEUE_URL",
             "CCDB_API_URL",
             "CCDB_API_SECRET",
         }

--- a/claude_discord/cogs/event_processor.py
+++ b/claude_discord/cogs/event_processor.py
@@ -413,6 +413,7 @@ class EventProcessor:
                     self._config.surface.thread_key,
                     self._state.session_id,
                     working_dir=wd,
+                    origin=self._config.session_origin,
                     backend=backend,
                 )
             else:
@@ -421,6 +422,7 @@ class EventProcessor:
                     self._config.surface.thread_key,
                     self._state.session_id,
                     working_dir=wd,
+                    origin=self._config.session_origin,
                     summary=summary,
                     backend=backend,
                 )
@@ -656,6 +658,7 @@ class EventProcessor:
                 await self._config.repo.save(
                     self._config.surface.thread_key,
                     event.session_id,
+                    origin=self._config.session_origin,
                     backend=_backend_name_from_runner(self._config.runner),
                 )
             self._state.session_id = event.session_id

--- a/claude_discord/cogs/run_config.py
+++ b/claude_discord/cogs/run_config.py
@@ -119,6 +119,9 @@ class RunConfig:
     backend_settings: BackendSettings | None = None
     # Command used to invoke Codex (for the Codex status probe in the footer).
     codex_command: str = "codex"
+    # Which frontend created this session mapping. Historical callers remain
+    # Discord by default; the Teams host sets this explicitly.
+    session_origin: str = "discord"
 
     # Prevent accidental field mutation — RunConfig is a value object.
     # Use dataclasses.replace() to create modified copies.

--- a/claude_discord/main.py
+++ b/claude_discord/main.py
@@ -20,6 +20,7 @@ from .bot import ClaudeDiscordBot
 from .cog_loader import load_custom_cogs
 from .deployment import DataLayout
 from .setup import setup_bridge
+from .teams_integration import FrontendRouter, build_teams_runtime, parse_frontends
 from .utils.logger import setup_logging
 
 logger = logging.getLogger(__name__)
@@ -44,6 +45,7 @@ def load_config() -> dict[str, str]:
         return os.getenv(new) or os.getenv(old, default)
 
     backend = os.getenv("CCDB_BACKEND", "claude")
+    frontends = parse_frontends(os.getenv("CCDB_FRONTENDS", ""))
     # Default model is backend-specific: Claude needs an explicit alias
     # ("sonnet"), but Codex defers to its own config.toml default when left
     # empty (so we never pin a stale Codex model version).
@@ -53,6 +55,7 @@ def load_config() -> dict[str, str]:
         "token": token,
         "channel_id": channel_id,
         "backend": backend,
+        "frontends": ",".join(frontends),
         "command": _env("CCDB_COMMAND", "CLAUDE_COMMAND", ""),
         # Per-backend explicit command paths. Used by BackendFactory when
         # the user switches backend at runtime via /backend.
@@ -88,6 +91,7 @@ async def main() -> None:
     """Start the bot."""
     setup_logging()
     config = load_config()
+    enabled_frontends = parse_frontends(config["frontends"])
 
     channel_id = int(config["channel_id"])
 
@@ -196,13 +200,37 @@ async def main() -> None:
         if api_server is not None:
             await api_server.start()
 
-        # Handle signals (add_signal_handler is not supported on Windows)
-        if sys.platform != "win32":
-            loop = asyncio.get_running_loop()
-            for sig in (signal.SIGINT, signal.SIGTERM):
-                loop.add_signal_handler(sig, lambda: asyncio.create_task(bot.close()))
+        teams_runtime = None
+        try:
+            if "teams" in enabled_frontends:
+                if (
+                    components.backend_settings is None
+                    or components.frontend_threads is None
+                    or not isinstance(components.frontend, FrontendRouter)
+                ):
+                    raise RuntimeError("Teams requires the normal backend and session-store wiring")
+                teams_runtime = await build_teams_runtime(
+                    os.environ,
+                    components=components,
+                    backend_factory=factory,
+                    registry=getattr(bot, "session_registry", None),
+                    worktree_manager=getattr(bot, "worktree_manager", None),
+                )
+                components.frontend.add(teams_runtime.frontend)
+                await teams_runtime.start()
+                logger.info("Teams activity puller started beside Discord")
 
-        await bot.start(config["token"])
+            # Handle signals (add_signal_handler is not supported on Windows)
+            if sys.platform != "win32":
+                loop = asyncio.get_running_loop()
+                for sig in (signal.SIGINT, signal.SIGTERM):
+                    loop.add_signal_handler(sig, lambda: asyncio.create_task(bot.close()))
+
+            await bot.start(config["token"])
+        finally:
+            if teams_runtime is not None:
+                await teams_runtime.close()
+                logger.info("Teams activity puller stopped")
 
 
 if __name__ == "__main__":

--- a/claude_discord/setup.py
+++ b/claude_discord/setup.py
@@ -19,11 +19,14 @@ if TYPE_CHECKING:
 
     from .backend_factory import BackendFactory
     from .backend_settings import BackendSettings
+    from .database.ask_repo import PendingAskRepository
     from .database.claims_repo import ClaimRepository
+    from .database.frontend_thread_repo import FrontendThreadRepository
     from .database.ingest_repo import IngestResultRepository
     from .database.lounge_repo import LoungeRepository
-    from .database.repository import SessionRepository
+    from .database.repository import SessionRepository, UsageStatsRepository
     from .database.resume_repo import PendingResumeRepository
+    from .database.settings_repo import SettingsRepository
     from .database.summary_repo import ThreadSummaryRepository
     from .database.task_repo import TaskRepository
     from .ext.api_server import ApiServer
@@ -61,6 +64,10 @@ class BridgeComponents:
     #: Discord's is built here; a custom Cog can read it instead of calling
     #: ``bot.get_channel`` and hard-coding Discord into its own logic.
     frontend: SessionFrontend | None = None
+    frontend_threads: FrontendThreadRepository | None = None
+    settings_repo: SettingsRepository | None = None
+    ask_repo: PendingAskRepository | None = None
+    usage_repo: UsageStatsRepository | None = None
 
     def apply_to_api_server(self, api_server: ApiServer) -> None:
         """Wire all optional repos to an ApiServer instance.
@@ -324,12 +331,13 @@ async def setup_bridge(
     # wiring that follows.
     from .frontend import DiscordFrontend
     from .stores import build_session_stores
+    from .teams_integration import FrontendRouter
 
     stores = await build_session_stores(session_db_path)
 
     # The frontend seam. Built once and handed to everything that needs to
     # reach a conversation, so a Cog never has to call bot.get_channel itself.
-    frontend = DiscordFrontend(bot, ledger=stores.frontend_threads)
+    frontend = FrontendRouter(DiscordFrontend(bot, ledger=stores.frontend_threads))
     session_repo = stores.sessions
     settings_repo = stores.settings
     ask_repo = stores.asks
@@ -489,6 +497,10 @@ async def setup_bridge(
         backend_factory=backend_factory,
         backend_settings=backend_settings,
         frontend=frontend,
+        frontend_threads=stores.frontend_threads,
+        settings_repo=settings_repo,
+        ask_repo=ask_repo,
+        usage_repo=usage_repo,
     )
 
     # Auto-wire repos to ApiServer and set runner.api_port if provided

--- a/claude_discord/teams_integration.py
+++ b/claude_discord/teams_integration.py
@@ -1,0 +1,281 @@
+"""Run the private half of the Teams relay beside the Discord bot.
+
+The Azure-facing receiver is deliberately not part of this module.  This side
+opens no port: it polls the verified-activity queue, resolves a Teams surface,
+and passes the message to the same session runner Discord uses.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+from collections.abc import Awaitable, Callable, Mapping
+from typing import TYPE_CHECKING, Any
+
+from claude_code_core.frontend import ConversationSurface, SessionFrontend, ThreadKey
+
+from .backend_settings import session_is_resumable
+from .cogs._run_helper import run_claude_with_config
+from .cogs.run_config import RunConfig
+
+if TYPE_CHECKING:
+    from aiohttp import ClientSession
+
+    from claude_teams.activity import InboundActivity
+    from claude_teams.frontend import TeamsFrontend
+    from claude_teams.relay import ActivityPuller
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "FrontendRouter",
+    "TeamsRuntime",
+    "TeamsSessionHost",
+    "build_teams_runtime",
+    "parse_frontends",
+]
+
+_KNOWN_FRONTENDS = frozenset({"discord", "teams"})
+
+
+def parse_frontends(value: str) -> tuple[str, ...]:
+    """Parse ``CCDB_FRONTENDS``, keeping the historical Discord default."""
+    if not value.strip():
+        return ("discord",)
+    names = tuple(part.strip().lower() for part in value.split(",") if part.strip())
+    if not names:
+        raise ValueError("CCDB_FRONTENDS must select at least one frontend")
+    unknown = set(names) - _KNOWN_FRONTENDS
+    if unknown:
+        names_text = ", ".join(sorted(unknown))
+        raise ValueError(f"CCDB_FRONTENDS contains unknown frontend(s): {names_text}")
+    if len(names) != len(set(names)):
+        raise ValueError("CCDB_FRONTENDS must not contain duplicate frontend names")
+    return names
+
+
+class FrontendRouter:
+    """Resolve across several frontends while creating on the primary one."""
+
+    name = "multi"
+
+    def __init__(self, primary: SessionFrontend) -> None:
+        self._primary = primary
+        self._frontends: dict[str, SessionFrontend] = {primary.name: primary}
+
+    def add(self, frontend: SessionFrontend) -> None:
+        if frontend.name in self._frontends:
+            raise ValueError(f"frontend {frontend.name!r} is already registered")
+        self._frontends[frontend.name] = frontend
+
+    async def start(self) -> None:
+        for frontend in self._frontends.values():
+            await frontend.start()
+
+    async def close(self) -> None:
+        for frontend in reversed(tuple(self._frontends.values())):
+            await frontend.close()
+
+    async def resolve_surface(self, thread_key: ThreadKey) -> ConversationSurface | None:
+        for frontend in self._frontends.values():
+            surface = await frontend.resolve_surface(thread_key)
+            if surface is not None:
+                return surface
+        return None
+
+    async def create_surface(self, *, parent_id: str, title: str) -> ConversationSurface:
+        return await self._primary.create_surface(parent_id=parent_id, title=title)
+
+
+class TeamsSessionHost:
+    """Turn trusted relayed activities into ordinary ccdb session turns."""
+
+    def __init__(
+        self,
+        *,
+        app_id: str,
+        frontend: TeamsFrontend,
+        ledger: Any,
+        session_repo: Any,
+        backend_factory: Any,
+        backend_settings: Any,
+        run_session: Callable[[RunConfig], Awaitable[str | None]] = run_claude_with_config,
+        lounge_repo: Any = None,
+        ask_repo: Any = None,
+        usage_repo: Any = None,
+        registry: Any = None,
+        worktree_manager: Any = None,
+    ) -> None:
+        self._app_id = app_id
+        self._frontend = frontend
+        self._ledger = ledger
+        self._session_repo = session_repo
+        self._factory = backend_factory
+        self._settings = backend_settings
+        self._run_session = run_session
+        self._lounge_repo = lounge_repo
+        self._ask_repo = ask_repo
+        self._usage_repo = usage_repo
+        self._registry = registry
+        self._worktree_manager = worktree_manager
+
+    async def handle(self, activity: InboundActivity) -> None:
+        """Route one already-verified activity from the relay queue."""
+        self._frontend.remember(activity.conversation_id, activity.service_url)
+
+        if activity.type == "invoke":
+            self._handle_invoke(activity)
+            return
+        if not activity.is_message or activity.is_from(self._app_id):
+            return
+        if activity.conversation_type != "personal" and not activity.mentions_bot(self._app_id):
+            return
+
+        prompt = activity.clean_text.strip()
+        if not prompt:
+            return
+
+        parent_id = activity.channel_id or activity.team_id
+        thread_key = await self._ledger.register(
+            "teams",
+            activity.conversation_id,
+            parent_external_id=parent_id,
+        )
+        surface = await self._frontend.resolve_surface(thread_key)
+        if surface is None:
+            raise LookupError(f"Teams conversation {activity.conversation_id!r} cannot be resolved")
+
+        record = await self._session_repo.get(thread_key)
+        backend = await self._settings.current_backend(thread_key)
+        model = await self._settings.current_model(backend, thread_key)
+        runner = self._factory.build(backend=backend, model=model, thread_id=thread_key)
+
+        session_id = None
+        if record is not None and session_is_resumable(record.backend, backend):
+            session_id = record.session_id
+            if record.working_dir:
+                runner.working_dir = record.working_dir
+
+        effort = await self._settings.current_effort(backend, thread_key)
+        if effort is not None and hasattr(runner, "effort"):
+            runner.effort = effort
+
+        await self._run_session(
+            RunConfig(
+                surface=surface,
+                runner=runner,
+                repo=self._session_repo,
+                prompt=prompt,
+                session_id=session_id,
+                lounge_repo=self._lounge_repo,
+                ask_repo=self._ask_repo,
+                usage_repo=self._usage_repo,
+                registry=self._registry,
+                worktree_manager=self._worktree_manager,
+                backend_settings=self._settings,
+                codex_command=self._factory.codex_command,
+                claude_command=runner.command,
+                session_origin="teams",
+            )
+        )
+
+    def _handle_invoke(self, activity: InboundActivity) -> None:
+        if activity.raw.get("name") != "adaptiveCard/action":
+            return
+        value = activity.raw.get("value")
+        action = value.get("action") if isinstance(value, dict) else None
+        data = action.get("data") if isinstance(action, dict) else None
+        if not self._frontend.interactions.resolve(activity.conversation_id, data):
+            logger.info("A relayed Teams card action did not match a live prompt")
+
+
+class TeamsRuntime:
+    """Resources whose lifetime matches the normal bot process."""
+
+    def __init__(self, *, frontend: TeamsFrontend, puller: ActivityPuller, session: ClientSession):
+        self.frontend = frontend
+        self._puller = puller
+        self._session = session
+        self._running = False
+
+    @property
+    def running(self) -> bool:
+        return self._running
+
+    async def start(self) -> None:
+        await self._puller.start()
+        self._running = True
+
+    async def close(self) -> None:
+        await self._puller.close()
+        await self._session.close()
+        self._running = False
+
+
+async def build_teams_runtime(
+    env: Mapping[str, str],
+    *,
+    components: Any,
+    backend_factory: Any,
+    registry: Any = None,
+    worktree_manager: Any = None,
+) -> TeamsRuntime:
+    """Assemble the private-side Teams transport from existing components."""
+    from aiohttp import ClientSession
+
+    from claude_teams.config import TeamsConfig
+    from claude_teams.connector import BotConnector
+    from claude_teams.frontend import TeamsFrontend
+    from claude_teams.http import bytes_putter, form_poster, json_poster, json_putter
+    from claude_teams.relay import ActivityPuller
+    from claude_teams.relay.storage_queue import StorageQueue, aiohttp_request
+    from claude_teams.token import OutboundTokenProvider
+
+    config = TeamsConfig.from_env(env)
+    if config.app_password is None:
+        raise ValueError("CCDB_TEAMS_APP_PASSWORD is required on the private session host")
+    queue_url = env.get("CCDB_TEAMS_QUEUE_URL", "").strip()
+    if not queue_url:
+        raise ValueError("CCDB_TEAMS_QUEUE_URL is required for the Teams frontend")
+
+    session = ClientSession()
+    try:
+        connector = BotConnector(
+            OutboundTokenProvider(
+                config.tenant_id,
+                config.app_id,
+                config.app_password,
+                form_poster(session),
+            ),
+            json_poster(session),
+            json_putter(session),
+        )
+        frontend = TeamsFrontend(
+            connector,
+            components.frontend_threads,
+            default_service_url=config.service_url or None,
+        )
+        host = TeamsSessionHost(
+            app_id=config.app_id,
+            frontend=frontend,
+            ledger=components.frontend_threads,
+            session_repo=components.session_repo,
+            backend_factory=backend_factory,
+            backend_settings=components.backend_settings,
+            lounge_repo=components.lounge_repo,
+            ask_repo=components.ask_repo,
+            usage_repo=components.usage_repo,
+            registry=registry,
+            worktree_manager=worktree_manager,
+        )
+        queue = StorageQueue(queue_url, aiohttp_request(session))
+        puller = ActivityPuller(queue, host.handle, on_service_url=frontend.remember)
+        # Keep the upload transport constructed beside the connector. File-consent
+        # dispatch is added here once its relay-specific acknowledgement contract
+        # can be represented without pretending the private host owns the HTTP reply.
+        _ = bytes_putter(session)
+        return TeamsRuntime(frontend=frontend, puller=puller, session=session)
+    except Exception:
+        with contextlib.suppress(Exception):
+            await session.close()
+        raise

--- a/docs/teams-relay.md
+++ b/docs/teams-relay.md
@@ -87,6 +87,25 @@ deployment has lost the property this document is about.
 The private side polls with `ActivityPuller` and replies with the ordinary
 `BotConnector`, which is where the client secret belongs.
 
+The normal bot launcher owns that private-side lifetime. To run Teams beside
+Discord in the same process, add these values to the deployment environment:
+
+```bash
+CCDB_FRONTENDS=discord,teams
+CCDB_TEAMS_QUEUE_URL='https://acct.queue.core.windows.net/relay?<SAS>'
+CCDB_TEAMS_APP_PASSWORD='...'
+```
+
+The remaining `CCDB_TEAMS_*` identity values are the same ones used to build
+the manifest. On startup the launcher creates one shared HTTP client, the
+`BotConnector`, `TeamsFrontend`, and `ActivityPuller`; on shutdown it stops the
+poller before closing the client. Discord's gateway connection remains active
+throughout. The private host still opens no Teams listener.
+
+`CCDB_FRONTENDS` defaults to `discord`, so upgrading an existing Discord-only
+deployment does not start a queue poller. Unknown and duplicate frontend names
+are rejected at startup.
+
 The queue SAS URL is a credential in a URL: it never appears in a log line, an
 exception, or a `repr`. The failures raised here name the operation and the
 status code and nothing else.

--- a/tests/test_event_processor.py
+++ b/tests/test_event_processor.py
@@ -154,8 +154,26 @@ class TestOnSystem:
         await p.process(StreamEvent(message_type=MessageType.SYSTEM, session_id="s1"))
 
         repo.save.assert_called_once_with(
-            thread.id, "s1", working_dir=runner.working_dir, summary="test prompt", backend="claude"
+            thread.id,
+            "s1",
+            working_dir=runner.working_dir,
+            origin="discord",
+            summary="test prompt",
+            backend="claude",
         )
+
+    @pytest.mark.asyncio
+    async def test_saves_the_frontend_origin_for_a_teams_session(
+        self, thread: MagicMock, runner: MagicMock
+    ) -> None:
+        repo = MagicMock()
+        repo.save = AsyncMock()
+        config = _make_config(thread, runner, repo=repo, session_origin="teams")
+        p = EventProcessor(config)
+
+        await p.process(StreamEvent(message_type=MessageType.SYSTEM, session_id="s1"))
+
+        assert repo.save.call_args.kwargs["origin"] == "teams"
 
     @pytest.mark.asyncio
     async def test_saves_to_repo_without_summary_for_resumed_session(
@@ -170,7 +188,11 @@ class TestOnSystem:
         await p.process(StreamEvent(message_type=MessageType.SYSTEM, session_id="existing-sess"))
 
         repo.save.assert_called_once_with(
-            thread.id, "existing-sess", working_dir=runner.working_dir, backend="claude"
+            thread.id,
+            "existing-sess",
+            working_dir=runner.working_dir,
+            origin="discord",
+            backend="claude",
         )
 
     @pytest.mark.asyncio
@@ -187,7 +209,12 @@ class TestOnSystem:
         await p.process(StreamEvent(message_type=MessageType.SYSTEM, session_id="s1"))
 
         repo.save.assert_called_once_with(
-            thread.id, "s1", working_dir=runner.working_dir, summary="x" * 100, backend="claude"
+            thread.id,
+            "s1",
+            working_dir=runner.working_dir,
+            origin="discord",
+            summary="x" * 100,
+            backend="claude",
         )
 
     @pytest.mark.asyncio

--- a/tests/test_main_config.py
+++ b/tests/test_main_config.py
@@ -73,6 +73,44 @@ class TestLoadConfig:
         assert config["max_concurrent"] == "3"
         assert config["timeout"] == "300"
         assert config["custom_cogs_dir"] == ""
+        assert config["frontends"] == "discord"
+
+    def test_discord_and_teams_frontends_are_loaded(self) -> None:
+        from claude_discord.main import load_config
+
+        with (
+            patch("claude_discord.main.load_dotenv"),
+            patch.dict(
+                "os.environ",
+                {
+                    "DISCORD_BOT_TOKEN": "tok",
+                    "DISCORD_CHANNEL_ID": "111",
+                    "CCDB_FRONTENDS": "discord,teams",
+                },
+                clear=True,
+            ),
+        ):
+            config = load_config()
+
+        assert config["frontends"] == "discord,teams"
+
+    def test_invalid_frontend_selection_fails_before_startup(self) -> None:
+        from claude_discord.main import load_config
+
+        with (
+            patch("claude_discord.main.load_dotenv"),
+            patch.dict(
+                "os.environ",
+                {
+                    "DISCORD_BOT_TOKEN": "tok",
+                    "DISCORD_CHANNEL_ID": "111",
+                    "CCDB_FRONTENDS": "discord,email",
+                },
+                clear=True,
+            ),
+            pytest.raises(ValueError, match="CCDB_FRONTENDS"),
+        ):
+            load_config()
 
     def test_all_optional_env_vars(self) -> None:
         """Optional env vars are correctly read."""

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from claude_code_core.codex_runner import CodexRunner
 from claude_discord.claude.runner import ClaudeRunner, _resolve_windows_cmd
 from claude_discord.claude.types import ImageData
 
@@ -226,6 +227,18 @@ class TestBuildEnv:
             assert "DISCORD_TOKEN" not in env
         finally:
             del os.environ["DISCORD_TOKEN"]
+
+    @pytest.mark.parametrize(
+        "name",
+        ["CCDB_TEAMS_APP_PASSWORD", "CCDB_TEAMS_QUEUE_URL"],
+    )
+    def test_strips_teams_credentials(self, name: str) -> None:
+        os.environ[name] = "secret"
+        try:
+            for runner in (ClaudeRunner(), CodexRunner()):
+                assert name not in runner._build_env()
+        finally:
+            del os.environ[name]
 
     def test_preserves_path(self) -> None:
         runner = ClaudeRunner()

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -138,6 +138,11 @@ async def test_setup_bridge_returns_components(tmp_path: object) -> None:
     assert isinstance(result, BridgeComponents)
     assert result.session_repo is not None
     assert result.session_repo.db_path == str(tmp_path / "sessions.db")  # type: ignore[operator]
+    assert result.frontend_threads is not None
+    assert result.ask_repo is not None
+    assert result.usage_repo is not None
+    assert result.frontend is not None
+    assert result.frontend.name == "multi"
 
 
 @pytest.mark.asyncio

--- a/tests/test_teams_integration.py
+++ b/tests/test_teams_integration.py
@@ -1,0 +1,219 @@
+"""Normal-process wiring for the private half of the Teams relay."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from claude_discord.teams_integration import (
+    FrontendRouter,
+    TeamsRuntime,
+    TeamsSessionHost,
+    parse_frontends,
+)
+from claude_teams.activity import parse_activity
+
+
+def activity(
+    text: str = "ship it",
+    *,
+    conversation_id: str = "19:thread@thread.tacv2;messageid=1",
+    conversation_type: str = "channel",
+    mentioned: bool = True,
+    sender: str = "user-1",
+) -> Any:
+    entities = (
+        [{"type": "mention", "mentioned": {"id": "bot-id"}, "text": "<at>Relay</at>"}]
+        if mentioned
+        else []
+    )
+    return parse_activity(
+        {
+            "type": "message",
+            "id": "activity-1",
+            "serviceUrl": "https://smba.trafficmanager.net/jp/",
+            "conversation": {"id": conversation_id, "conversationType": conversation_type},
+            "from": {"id": sender, "name": "User"},
+            "recipient": {"id": "bot-id"},
+            "text": f"<at>Relay</at> {text}" if mentioned else text,
+            "entities": entities,
+            "channelData": {"channel": {"id": "channel-1"}, "tenant": {"id": "tenant-1"}},
+        }
+    )
+
+
+class TestFrontendSelection:
+    def test_default_remains_discord_only(self) -> None:
+        assert parse_frontends("") == ("discord",)
+
+    def test_discord_and_teams_are_selected_in_order(self) -> None:
+        assert parse_frontends(" discord, teams ") == ("discord", "teams")
+
+    @pytest.mark.parametrize("value", ["teams,teams", "discord,email", ","])
+    def test_invalid_selection_is_rejected(self, value: str) -> None:
+        with pytest.raises(ValueError, match="CCDB_FRONTENDS"):
+            parse_frontends(value)
+
+
+class TestFrontendRouter:
+    async def test_resolves_the_frontend_that_owns_the_key(self) -> None:
+        discord = SimpleNamespace(
+            name="discord", resolve_surface=AsyncMock(return_value=None), create_surface=AsyncMock()
+        )
+        teams_surface = object()
+        teams = SimpleNamespace(
+            name="teams",
+            resolve_surface=AsyncMock(return_value=teams_surface),
+            create_surface=AsyncMock(),
+        )
+        router = FrontendRouter(discord)
+        router.add(teams)
+
+        assert await router.resolve_surface(42) is teams_surface
+        discord.resolve_surface.assert_awaited_once_with(42)
+        teams.resolve_surface.assert_awaited_once_with(42)
+
+    def test_duplicate_frontend_names_are_rejected(self) -> None:
+        router = FrontendRouter(SimpleNamespace(name="discord"))
+        with pytest.raises(ValueError, match="discord"):
+            router.add(SimpleNamespace(name="discord"))
+
+
+@dataclass
+class Record:
+    session_id: str
+    backend: str | None = "claude"
+    working_dir: str | None = "/work"
+
+
+def make_host(*, record: Record | None = None) -> tuple[TeamsSessionHost, dict[str, Any]]:
+    surface = SimpleNamespace(thread_key=42)
+    frontend = SimpleNamespace(
+        interactions=SimpleNamespace(resolve=MagicMock(return_value=True)),
+        files=MagicMock(),
+        remember=MagicMock(),
+        resolve_surface=AsyncMock(return_value=surface),
+    )
+    ledger = SimpleNamespace(register=AsyncMock(return_value=42))
+    repo = SimpleNamespace(get=AsyncMock(return_value=record))
+    runner = SimpleNamespace(command="claude", working_dir="/work")
+    factory = SimpleNamespace(build=MagicMock(return_value=runner), codex_command="codex")
+    settings = SimpleNamespace(
+        current_backend=AsyncMock(return_value="claude"),
+        current_model=AsyncMock(return_value="sonnet"),
+        current_effort=AsyncMock(return_value=None),
+    )
+    calls: list[Any] = []
+
+    async def run_session(config: Any) -> str:
+        calls.append(config)
+        return "session-new"
+
+    host = TeamsSessionHost(
+        app_id="bot-id",
+        frontend=frontend,
+        ledger=ledger,
+        session_repo=repo,
+        backend_factory=factory,
+        backend_settings=settings,
+        run_session=run_session,
+    )
+    return host, {
+        "surface": surface,
+        "frontend": frontend,
+        "ledger": ledger,
+        "repo": repo,
+        "factory": factory,
+        "settings": settings,
+        "runner": runner,
+        "calls": calls,
+    }
+
+
+class TestTeamsSessionHost:
+    async def test_new_channel_message_reaches_the_real_session_path(self) -> None:
+        host, deps = make_host()
+
+        await host.handle(activity("build the feature"))
+
+        deps["ledger"].register.assert_awaited_once_with(
+            "teams", "19:thread@thread.tacv2;messageid=1", parent_external_id="channel-1"
+        )
+        deps["frontend"].remember.assert_called_once_with(
+            "19:thread@thread.tacv2;messageid=1", "https://smba.trafficmanager.net/jp/"
+        )
+        config = deps["calls"][0]
+        assert config.surface is deps["surface"]
+        assert config.prompt == "build the feature"
+        assert config.session_id is None
+        assert config.session_origin == "teams"
+        deps["factory"].build.assert_called_once_with(
+            backend="claude", model="sonnet", thread_id=42
+        )
+
+    async def test_existing_conversation_resumes_its_session(self) -> None:
+        host, deps = make_host(record=Record("session-old"))
+
+        await host.handle(activity(conversation_type="personal", mentioned=False))
+
+        assert deps["calls"][0].session_id == "session-old"
+        assert deps["calls"][0].runner.working_dir == "/work"
+
+    async def test_channel_message_without_a_bot_mention_is_ignored(self) -> None:
+        host, deps = make_host()
+        await host.handle(activity(mentioned=False))
+        assert deps["calls"] == []
+
+    async def test_personal_message_needs_no_mention(self) -> None:
+        host, deps = make_host()
+        await host.handle(activity(conversation_type="personal", mentioned=False))
+        assert len(deps["calls"]) == 1
+
+    async def test_the_bot_does_not_answer_itself(self) -> None:
+        host, deps = make_host()
+        await host.handle(activity(sender="bot-id"))
+        assert deps["calls"] == []
+
+    async def test_an_invoke_resolves_the_shared_interaction_registry(self) -> None:
+        host, deps = make_host()
+        invoke = parse_activity(
+            {
+                "type": "invoke",
+                "id": "invoke-1",
+                "serviceUrl": "https://smba.trafficmanager.net/jp/",
+                "conversation": {"id": "conversation-1", "conversationType": "personal"},
+                "from": {"id": "user-1"},
+                "recipient": {"id": "bot-id"},
+                "name": "adaptiveCard/action",
+                "value": {"action": {"data": {"ccdb_prompt": "prompt-1", "ccdb_value": "yes"}}},
+            }
+        )
+
+        await host.handle(invoke)
+
+        deps["frontend"].interactions.resolve.assert_called_once_with(
+            "conversation-1", {"ccdb_prompt": "prompt-1", "ccdb_value": "yes"}
+        )
+        assert deps["calls"] == []
+
+
+class TestTeamsRuntime:
+    async def test_start_and_close_own_the_puller_and_http_session(self) -> None:
+        puller = SimpleNamespace(start=AsyncMock(), close=AsyncMock())
+        session = SimpleNamespace(close=AsyncMock())
+        runtime = TeamsRuntime(
+            frontend=SimpleNamespace(name="teams"), puller=puller, session=session
+        )
+
+        await runtime.start()
+        assert runtime.running is True
+        puller.start.assert_awaited_once()
+
+        await runtime.close()
+        puller.close.assert_awaited_once()
+        session.close.assert_awaited_once()
+        assert runtime.running is False


### PR DESCRIPTION
Closes #609.

## What changed

- parses `CCDB_FRONTENDS` with a Discord-only compatibility default
- starts the private-side `ActivityPuller` and `TeamsFrontend` in the normal process
- routes trusted Teams messages through the existing session runner and resumes by conversation key
- lets shared callers resolve Discord and Teams conversations through one frontend router
- records Teams session origin and strips Teams credentials from Claude and Codex subprocess environments
- closes the puller and HTTP client during shutdown

## Verification

- 2,532 tests passed
- Ruff format/check passed
- Pyright passed
- Live Discord + Teams validation will be completed before marking ready