### PR TITLE
[release] Publish Ebi Agent Chat Relay 4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.0.0] - 2026-08-11
+
+### Added
+
+- **Microsoft Teams as a production frontend** — the normal launcher can run Discord and Teams in
+  one process with `CCDB_FRONTENDS=discord,teams`. A public receiver verifies Bot Framework
+  activities and enqueues them without holding the bot client secret; a private `ActivityPuller`
+  polls outbound, invokes the same real session runner Discord uses, and posts results back to Teams.
+- **A complete Teams operator guide** — documents Entra registration, Azure Bot, separate queue
+  credentials, public receiver deployment, private host configuration, generated app packaging,
+  tenant consent, staged validation, security boundaries, and troubleshooting.
+- **A unified backend guide** — explains Claude Code, OpenAI Codex, guarded local, and AG-UI choices
+  independently from Discord or Teams.
+- **Curated v4 release notes** — make the product boundary and 3.x compatibility position explicit.
+
+### Changed
+
+- **The public product contract is frontend × backend** — any supported chat frontend can select any
+  supported backend per conversation while sharing persistence and coordination.
+- **Release version is 4.0.0** — the major version communicates the combined multi-frontend product
+  and Teams deployment boundary. Existing package names, commands, settings, data, APIs, default
+  backend, and Discord-only startup remain compatible.
+
 ## [3.4.0] - 2026-08-11
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -9,13 +9,47 @@ command is `ccdb`, and `ccdb` remains the short name used throughout this docume
 [![Python 3.12+](https://img.shields.io/badge/python-3.12%2B-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-**Use Claude Code _or_ OpenAI Codex on your phone. Multiple threads. All at once. Real development included.**
+**Run coding agents from Discord or Microsoft Teams. Choose Claude Code, OpenAI Codex,
+a local model, or any compatible AG-UI agent behind the same conversation.**
 
-Open Claude Code or OpenAI Codex from your smartphone's Discord app, spin up multiple threads, and run parallel development sessions — all without touching a keyboard. Each Discord thread becomes a fully isolated AI session. Work on a feature in one thread, review a PR in another, and run a background task in a third — simultaneously, even mixing backends per thread. The relay handles all the coordination so sessions never clobber each other.
+Ebi Agent Chat Relay turns each Discord thread or Teams conversation into an isolated,
+persistent agent session. Work on a feature in one conversation, review a PR in another, and run
+a background task in a third — simultaneously. Discord can mix backends per thread; Teams uses the
+configured/global backend in v4. The relay handles coordination so sessions do not clobber each
+other.
 
-**Why the name changed.** This started as a bridge between one AI and one chat app, and the old name said exactly that. It is now a relay: several agent backends (Claude Code, OpenAI Codex) reachable from a chat surface, with the surface itself becoming pluggable — Discord today, Microsoft Teams next. Three of the four words in the old name had stopped being true. See [ADR-0001](docs/adr/0001-adopt-ebi-agent-chat-relay.md) for the decision and [the rename plan](docs/RENAME_PLAN.md) for how the change is being made without breaking a single existing install.
+**Why the name changed.** This started as a bridge between one AI and one chat app. It is now a
+relay with two production frontends and four backend choices. Three of the four words in the old
+name had stopped being true. See [ADR-0001](docs/adr/0001-adopt-ebi-agent-chat-relay.md) for the
+decision and [the rename plan](docs/RENAME_PLAN.md) for the compatibility-preserving transition.
 
-**Use your existing subscriptions. No API key wrangling.** ccdb runs on top of the official CLIs — Claude Code (included with your [Claude Pro/Max subscription](https://claude.ai/pricing)) and OpenAI Codex (included with [ChatGPT Plus/Pro/Business](https://chatgpt.com)). Switch backends with `/backend` or set a per-thread override — your team gets both AIs through Discord at predictable cost.
+**Use your existing subscriptions, your own infrastructure, or a remote agent.** ccdb can run the
+official Claude Code and Codex CLIs, a Codex-compatible local endpoint, or an AG-UI HTTP/SSE
+agent. Discord exposes runtime `/backend` switching; Teams uses the configured backend through the
+same factory in v4.
+
+## What's new in v4
+
+Version 4 makes two independent choices explicit: **where people talk** and **which agent does the
+work**. Any supported frontend can use any supported backend.
+
+### Frontend × backend
+
+| | Claude Code | OpenAI Codex | Local | AG-UI |
+|---|---:|---:|---:|---:|
+| Discord | ✅ | ✅ | ✅ | ✅ |
+| Microsoft Teams | ✅ | ✅ | ✅ | ✅ |
+
+- **Discord** remains the zero-migration default. Existing deployments start exactly as before.
+- **Microsoft Teams** is production-ready through a small public receiver and an outbound-only
+  `ActivityPuller` on the private session host. Discord and Teams can run together in one process
+  with `CCDB_FRONTENDS=discord,teams`.
+- **AG-UI** connects either chat surface to an HTTP/SSE agent implementing the Agent–User
+  Interaction Protocol. Claude Code, Codex, and the guarded local backend remain available.
+
+Start with the [backend guide](docs/backends.md). For Teams, follow the complete
+[Microsoft Teams setup guide](docs/teams-setup.md), then use the deeper
+[surface behavior](docs/teams.md) and [relay security model](docs/teams-relay.md) references.
 
 **[日本語](docs/ja/README.md)** | **[简体中文](docs/zh-CN/README.md)** | **[한국어](docs/ko/README.md)** | **[Español](docs/es/README.md)** | **[Português](docs/pt-BR/README.md)** | **[Français](docs/fr/README.md)**
 
@@ -1068,7 +1102,7 @@ Session marking is fully opt-in — it only activates when `setup_bridge()` has 
 Optional REST API for notifications and task management. Requires aiohttp:
 
 ```bash
-uv add "claude-code-discord-bridge[api]"
+uv sync --extra api
 ```
 
 ### Endpoints
@@ -1139,23 +1173,24 @@ curl -X POST http://localhost:8080/api/tasks \
 
 ---
 
-## Microsoft Teams (in progress)
+## Microsoft Teams
 
-Teams is being added as a **sibling** frontend, not a port. `claude_discord` and
+Teams is a production **sibling** frontend, not a port. `claude_discord` and
 `claude_teams` each implement the vocabulary in `claude_code_core.frontend`,
 neither imports the other, and the same conformance contract runs against both —
 which is what stops "the Teams side is missing something" from being found by a
 user months later.
 
 ```bash
-uv add "claude-code-discord-bridge[teams]"
+uv sync --extra teams
 python -m claude_teams manifest --out dist/teams-app.zip
 ```
 
-What exists today: configuration and validation, the app package generator
-(resource-specific consent and SSO included), inbound Bot Framework token
-verification, an endpoint, and `TeamsSurface` — the output side, which the
-shared conformance contract is run against.
+The normal launcher runs Discord and Teams concurrently with
+`CCDB_FRONTENDS=discord,teams`. The public receiver verifies Bot Framework tokens and enqueues
+activities; the private `ActivityPuller` consumes them outbound, sends each prompt through the same
+session runner Discord uses, and posts the result back to Teams. The session host does not need an
+inbound Teams listener.
 
 The Teams experience is not a port of the Discord one. An answer that Discord
 fragments into fifteen messages arrives as **one**, and the column of embeds
@@ -1169,15 +1204,19 @@ unanswered permission request denies, and so does one whose card could not be
 posted — a prompt nobody could see must not be safer to ignore than one nobody
 answered.
 
-Files reach a personal chat through a consent card and a one-time upload URL —
-whose host is checked against Microsoft's own domains before a byte moves. A
-channel is told plainly that it cannot receive files yet. The conformance
-contract runs twice because of that: a personal chat passes all 18 checks, a
-channel fails exactly one, and the test asserts which.
+The Teams surface supports personal-chat file consent through a one-time upload URL — whose host is
+checked against Microsoft's own domains before a byte moves. Channel file delivery is not
+supported, and the private queue relay does not yet bridge the file-consent invoke. The conformance
+contract runs twice because of the surface-level channel gap: a personal chat passes all 18 checks,
+a channel fails exactly one, and the test asserts which.
 
-Unlike Discord, Teams needs a **public HTTPS endpoint**, and coding-agent
-sessions sit behind it. See [docs/teams.md](docs/teams.md) for the setup and for
-what that endpoint refuses to do.
+Unlike Discord, Teams needs a **public HTTPS endpoint**, an Entra application, an Azure Bot,
+an installable Teams app package, and a queue between the public and private sides. The values are
+tenant-specific, so no one-size-fits-all checked-in manifest can be safe or correct.
+
+Follow the [end-to-end Teams setup guide](docs/teams-setup.md) from registration through the first
+Teams → agent → Teams round trip. See [Teams surface behavior](docs/teams.md) for capability details
+and [the relay security model](docs/teams-relay.md) for the trust boundary and measured operation.
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,234 +1,167 @@
 # Architecture
 
-## Overview
+Ebi Agent Chat Relay has two independent adapter axes around one session core:
 
-claude-code-discord-bridge is a thin UI layer that bridges Discord messages to the Claude Code CLI. It has no AI logic of its own — all intelligence comes from Claude Code's existing capabilities (CLAUDE.md, skills, tools, memory, MCP servers). The bridge's sole responsibility is: accept user input from Discord, spawn the CLI, parse its output, and render results back to Discord.
+- a **frontend** turns a Discord thread or Teams conversation into a `ConversationSurface`; and
+- a **backend** turns Claude Code, Codex, local, or AG-UI output into neutral `StreamEvent` values.
 
-```
-┌─────────────────────────────────────────────────────────┐
-│                    Discord (Gateway)                     │
-│  ┌──────────┐  ┌──────────┐  ┌──────────────────────┐  │
-│  │ Channel   │  │ Threads  │  │ Reactions / Embeds   │  │
-│  └─────┬────┘  └────┬─────┘  └──────────┬───────────┘  │
-└────────┼────────────┼───────────────────┼───────────────┘
-         │            │                   ▲
-         ▼            ▼                   │
-┌─────────────────────────────────────────┼───────────────┐
-│              discord.py Bot (bot.py)    │               │
-│  ┌────────────────┐  ┌─────────────────┴──────┐        │
-│  │ ClaudeChatCog  │  │ SkillCommandCog        │        │
-│  │ (claude_chat)  │  │ (skill_command)        │        │
-│  └───────┬────────┘  └───────┬────────────────┘        │
-│          │                   │                          │
-│          └─────────┬─────────┘                          │
-│                    ▼                                    │
-│          ┌─────────────────┐                            │
-│          │ _run_helper.py  │  ← shared execution logic  │
-│          └────────┬────────┘                            │
-│                   │                                     │
-│     ┌─────────────┼──────────────┐                      │
-│     ▼             ▼              ▼                      │
-│  ┌────────┐  ┌──────────┐  ┌──────────┐                │
-│  │ runner │  │ status   │  │ chunker  │                │
-│  │  .py   │  │  .py     │  │  .py     │                │
-│  └───┬────┘  └──────────┘  └──────────┘                │
-│      │                                                  │
-│      ▼                                                  │
-│  ┌──────────┐  ┌──────────────┐                         │
-│  │ parser   │  │ repository   │                         │
-│  │  .py     │  │  .py (SQLite)│                         │
-│  └──────────┘  └──────────────┘                         │
-└─────────────────────────────────────────────────────────┘
-         │
-         ▼
-┌─────────────────────────────────────────────────────────┐
-│              Claude Code CLI (subprocess)                │
-│  claude -p --output-format stream-json --model sonnet   │
-│                                                         │
-│  ┌─────────────────────────────────────────────────┐    │
-│  │ CLAUDE.md, skills, tools, memory, MCP servers   │    │
-│  │ (all inherited from the host environment)       │    │
-│  └─────────────────────────────────────────────────┘    │
-└─────────────────────────────────────────────────────────┘
+The core owns session persistence, approvals, streaming, concurrency, worktrees, AI Lounge,
+claims, and collision detection. It contains no model of its own.
+
+## v4 overview
+
+```text
+Discord Gateway                       Teams / Bot Framework
+      │                                       │ signed HTTPS
+      │                                       ▼
+      │                              public relay receiver
+      │                                       │ verified envelope
+      │                                       ▼
+      │                              Azure Storage Queue
+      │                                       ▲ outbound poll
+      ▼                                       │
+DiscordFrontend ◀──────── FrontendRouter ── TeamsFrontend
+      │                                       │
+      └──────────── ConversationSurface ──────┘
+                              │
+                              ▼
+                 shared session execution core
+        persistence · prompts · streams · Lounge · claims
+                              │
+                              ▼
+                        BackendFactory
+                ┌────────┬────────┬────────┬────────┐
+                ▼        ▼        ▼        ▼
+             Claude    Codex    Local    AG-UI
+              CLI       CLI      CLI     HTTP/SSE
 ```
 
-## Module Responsibilities
+Discord remains the primary frontend for creating scheduled conversations and exposes the richest
+administration command surface. Teams inbound activities reach the same session runner through the
+private `ActivityPuller`. The public receiver can neither authenticate as the bot nor run an agent.
 
-### Entry Points
+## Frontend contract
 
-| Module | Role |
-|--------|------|
-| `main.py` | Standalone entry point. Loads `.env`, initializes DB, creates components, starts bot. For users who run this as their only bot. |
-| `__init__.py` | Public API surface. Exports `ClaudeChatCog`, `ClaudeRunner`, `SessionRepository`, and all types needed by consumers who embed this into their own bot. |
-| `bot.py` | `ClaudeDiscordBot` — minimal `commands.Bot` subclass. Configures intents (message_content, guilds), stores `channel_id`, syncs slash commands on ready. Only used in standalone mode. |
+`claude_code_core.frontend` defines two protocols:
 
-### Cogs Layer (`cogs/`)
+- `SessionFrontend` creates or resolves conversations; and
+- `ConversationSurface` renders one conversation's text, status, activity, prompts, interrupt
+  control, and file delivery.
 
-| Module | Class | Role |
-|--------|-------|------|
-| `claude_chat.py` | `ClaudeChatCog` | Core message handler. Listens for `on_message` in the configured channel and its child threads. Creates threads for new conversations, resumes sessions for thread replies. Manages concurrency via `asyncio.Semaphore`. Provides `/clear` slash command to reset sessions. |
-| `skill_command.py` | `SkillCommandCog` | Provides `/skill` and `/skills` slash commands. Scans `~/.claude/skills/` at startup, parses YAML frontmatter from `SKILL.md` files, offers Discord autocomplete. Creates a thread and delegates to `_run_helper`. |
-| `_run_helper.py` | `run_claude_in_thread()` | Shared function extracted to avoid duplicating the Claude CLI streaming logic between ClaudeChatCog and SkillCommandCog. Handles the full event loop: session init, tool use embeds, status updates, text accumulation, chunked response posting, error handling, and session persistence. |
+`DiscordFrontend` and `TeamsFrontend` are siblings. Neither is implemented in terms of the other.
+The same executable conformance suites run against both, which pins behavior that Python protocols
+alone cannot express.
 
-### Claude CLI Layer (`claude/`)
+Platform differences live in `SurfaceCapabilities` rather than scattered name checks:
 
-| Module | Class/Function | Role |
-|--------|---------------|------|
-| `runner.py` | `ClaudeRunner` | Subprocess lifecycle manager. Builds command args, sanitizes environment, spawns `claude` via `create_subprocess_exec`, reads stdout line-by-line, yields `StreamEvent` objects. Handles timeout, cleanup, and `kill()`. Supports `clone()` for creating fresh runner instances per session. |
-| `parser.py` | `parse_line()` | Stateless JSON parser. Takes a single line of stream-json output, returns a `StreamEvent` or `None`. Dispatches to `_parse_system`, `_parse_assistant`, `_parse_user`, `_parse_result` based on message type. |
-| `types.py` | `StreamEvent`, `ToolUseEvent`, `SessionState`, enums | Type definitions. `MessageType` (system/assistant/user/result), `ContentBlockType` (text/tool_use/tool_result), `ToolCategory` (read/edit/command/web/think/other). `TOOL_CATEGORIES` maps Claude Code tool names to categories. `ToolUseEvent.display_name` provides human-readable descriptions. |
+| Capability | Discord | Teams |
+|---|---:|---:|
+| message size | 2,000 chars | 80,000 chars |
+| bot reactions | yes | no |
+| live update budget | roughly every 1.5 s | 1,800/hour/conversation |
+| files | attachment | personal-chat consent upload at the surface layer |
+| native bot slash commands | yes | no |
 
-### Database Layer (`database/`)
+The `FrontendRouter` resolves a stored thread key through every registered frontend and creates new
+surfaces through the primary frontend. `frontend_threads` maps Teams string conversation IDs into
+the integer keyspace used by the existing session tables, while preserving the frontend origin so
+results cannot cross platforms.
 
-| Module | Class/Function | Role |
-|--------|---------------|------|
-| `models.py` | `init_db()` | Schema definition and initialization. Single `sessions` table with `thread_id` (PK), `session_id`, `working_dir`, `model`, timestamps. Uses `datetime('now', 'localtime')` for timestamps. |
-| `repository.py` | `SessionRepository` | CRUD operations. `get()` by thread_id, `save()` with upsert, `delete()`, `cleanup_old()` for age-based cleanup. Each operation opens and closes its own `aiosqlite` connection (simple, no connection pooling). |
+## Teams transport boundary
 
-### Discord UI Layer (`discord_ui/`)
+Teams requires inbound HTTPS; the agent host should not. The recommended transport is split:
 
-| Module | Class/Function | Role |
-|--------|---------------|------|
-| `status.py` | `StatusManager` | Emoji reaction manager. Shows one status emoji at a time on the user's original message. Debounced at 700ms to avoid rate limits. Includes stall detection: soft warning (hourglass) at 10s, hard warning at 30s. Maps `ToolCategory` to emoji. Cleans up reactions when done. |
-| `chunker.py` | `chunk_message()` | Fence-aware message splitter. Splits at paragraph boundaries (preferred), then line boundaries, then hard-splits. Tracks open code fences and properly closes/reopens them across chunk boundaries. Limits chunks to 1950 chars (2000 minus overhead). |
-| `embeds.py` | `tool_use_embed()`, `session_start_embed()`, etc. | Discord embed builders. Color-coded: blurple for info, green for success, red for error, yellow for tool use. Consistent visual language across all bot output. |
+1. The public receiver verifies Bot Framework signature, issuer, audience, expiry, and the signed
+   `serviceurl` claim before parsing an activity into a bounded envelope.
+2. It writes that envelope to a dedicated queue using an add-only credential.
+3. `ActivityPuller` on the private host reads outbound, deduplicates activity IDs, and dispatches
+   the activity to `TeamsSessionHost`.
+4. The session host resolves the Teams surface, selects the backend through the shared settings and
+   factory, and calls the same `run_claude_with_config` execution path used by Discord.
+5. `BotConnector` posts the response directly to Microsoft's regional service URL using the client
+   credential that exists only on the private host.
 
-### Utilities (`utils/`)
+Delivery is at least once. The puller deduplicates successful activity IDs, retries transient
+failures, and drops a poison message after a bounded attempt count rather than blocking the queue.
+See [Teams relay](teams-relay.md) and [Teams setup](teams-setup.md).
 
-| Module | Function | Role |
-|--------|----------|------|
-| `logger.py` | `setup_logging()` | Configures root logger with timestamp format. Silences discord.py's verbose logging (`WARNING` level). |
+## Backend contract
 
-## Data Flow
+`SessionBackend` exposes one asynchronous event stream regardless of transport. `BackendFactory`
+constructs the selected implementation at the start of each turn:
 
-### New Conversation
+- `ClaudeRunner` executes Claude Code stream-json;
+- `CodexRunner` executes Codex JSONL;
+- the local backend executes Codex against a ccdb-owned OpenAI-compatible configuration; and
+- `AgUiBackend` sends `RunAgentInput` over HTTP and parses JSON server-sent events.
 
-```
-1. User sends message in configured channel
+`BackendSettings` resolves values in thread → global → environment order. Session IDs are only
+resumed when the stored backend matches the selected backend; native Claude, Codex, and remote
+AG-UI identifiers are not interchangeable.
+
+See [Choose an agent backend](backends.md).
+
+## Shared execution flow
+
+```text
+inbound user turn
    │
-2. on_message() in ClaudeChatCog
-   │
-3. _handle_new_conversation()
-   ├── Create Discord thread (name = first 100 chars of message)
-   │
-4. _run_claude()
-   ├── Check semaphore (post "waiting" if full)
-   ├── Create StatusManager on user's message
-   ├── Clone runner (fresh subprocess state)
-   │
-5. run_claude_in_thread()
-   ├── Create SessionState
-   │
-6. runner.run(prompt, session_id=None)
-   ├── _build_args() → [claude, -p, --output-format, stream-json, ...]
-   ├── _build_env() → strip DISCORD_BOT_TOKEN etc.
-   ├── create_subprocess_exec()
-   │
-7. Stream events:
-   ├── SYSTEM {session_id} → save to DB, post session_start_embed
-   ├── ASSISTANT {text}    → accumulate in SessionState
-   ├── ASSISTANT {tool_use} → set status emoji, post tool_use_embed
-   ├── USER {tool_result}  → set thinking emoji
-   ├── RESULT {text, cost} → post chunked text, session_complete_embed
-   │
-8. Cleanup
-   ├── Kill subprocess
-   ├── Clean up status reactions
-   └── Return session_id
-```
-
-### Thread Reply (Session Resume)
-
-```
-1. User replies in existing thread
-   │
-2. on_message() → _handle_thread_reply()
-   ├── repo.get(thread_id) → SessionRecord with session_id
-   │
-3. _run_claude(session_id=existing_id)
-   │
-4. runner.run(prompt, session_id=existing_id)
-   ├── _build_args includes --resume {session_id}
-   │
-5. Same streaming flow as above
-   └── Session ID persisted on RESULT event
+   ├─ resolve frontend conversation and stable ThreadKey
+   ├─ load session record and backend settings
+   ├─ build one backend runner for this turn
+   ├─ construct RunConfig with the platform-neutral surface
+   ▼
+run_claude_with_config
+   ├─ enforce shared concurrency
+   ├─ inject coordination/worktree context
+   ├─ consume StreamEvent values
+   ├─ render through ConversationSurface
+   ├─ fail closed on unanswered approvals
+   └─ persist session id, backend, working directory, and origin
 ```
 
-### Skill Execution
+The execution helper retains its historical name for compatibility; it is backend-neutral.
 
-```
-1. User invokes /skill goodmorning
-   │
-2. SkillCommandCog.run_skill()
-   ├── Validate skill name (regex)
-   ├── Look up in loaded skills list
-   ├── Defer interaction
-   ├── Create thread named "/goodmorning"
-   │
-3. run_claude_in_thread(prompt="/goodmorning", session_id=None)
-   │
-4. Same streaming flow as new conversation
-   └── Claude Code interprets "/goodmorning" as a skill invocation
-```
+## Persistence and isolation
 
-## Concurrency Model
+One `DataLayout` root contains the session database and related stores. Sessions, settings,
+approval state, Lounge entries, claims, usage, summaries, ingestion, and frontend mappings share
+the deployment boundary deliberately so concurrent agents can see and coordinate with one another.
 
-```
-                    ┌──────────────────┐
-                    │   Semaphore(N)   │  N = MAX_CONCURRENT_SESSIONS (default 3)
-                    └────────┬─────────┘
-                             │
-          ┌──────────────────┼──────────────────┐
-          ▼                  ▼                  ▼
-   ┌─────────────┐   ┌─────────────┐   ┌─────────────┐
-   │ Thread #1   │   │ Thread #2   │   │ Thread #3   │
-   │ Runner (A)  │   │ Runner (B)  │   │ Runner (C)  │
-   │ claude proc │   │ claude proc │   │ claude proc │
-   └─────────────┘   └─────────────┘   └─────────────┘
-```
+That same property means unrelated customers must not share a data root. Use a separate process,
+bot identity, queue, and `CCDB_DATA_ROOT` for each isolation boundary.
 
-- Each Claude CLI invocation gets its own `ClaudeRunner` instance via `clone()`.
-- The `_active_runners` dict tracks runners by thread_id for kill-on-demand (`/clear`).
-- The semaphore is held in `_run_helper.run_claude_with_config()` and applies to **all** code paths — chat, skills, scheduler, and webhooks. It is released in the `finally` block before compact/ask reruns to prevent deadlocks on recursive calls.
-- Excess requests queue with a "waiting" message to prevent resource exhaustion.
-- All I/O is async (asyncio subprocess, aiosqlite), so the event loop is never blocked.
+## Main modules
 
-## Extension Points
+| Module | Responsibility |
+|---|---|
+| `claude_code_core/frontend.py` | frontend/surface protocols, capabilities, stable thread keys |
+| `claude_code_core/backend.py` | backend protocol and common construction vocabulary |
+| `claude_discord/frontend.py` | Discord conversation adapter |
+| `claude_teams/frontend.py` | Teams conversation adapter |
+| `claude_discord/teams_integration.py` | normal-process Teams runtime and `ActivityPuller` dispatch |
+| `claude_teams/relay/` | verified envelope, receiver, queue client, and poller |
+| `claude_discord/backend_factory.py` | Claude, Codex, local, and AG-UI construction |
+| `claude_discord/cogs/event_processor.py` | neutral stream-event rendering and prompt dispatch |
+| `claude_discord/stores.py` | construction of the shared SQLite repositories |
+| `claude_discord/deployment.py` | one configurable data-root layout |
 
-### For Framework Consumers (Package Users)
+## Extension points
 
-1. **Custom Cogs**: Import `ClaudeChatCog` and `SkillCommandCog`, add to your own `commands.Bot`. Add your own Cogs alongside them.
-2. **Custom Runner Configuration**: `ClaudeRunner` accepts `command`, `model`, `permission_mode`, `working_dir`, `timeout_seconds`, `allowed_tools`, `dangerously_skip_permissions`.
-3. **Selective Imports**: `__init__.py` exports individual components — use only what you need. Import `parse_line` and `chunk_message` for custom pipelines.
-4. **run_claude_in_thread()**: Can be called from any Cog or async context. Needs a `Thread`, `ClaudeRunner`, `SessionRepository`, and a prompt.
+### Add a frontend
 
-### For Framework Contributors
+Implement `SessionFrontend` and `ConversationSurface`, declare accurate capabilities, then run both
+frontend and surface conformance suites against the real adapter with only its transport faked.
+Do not import Discord components into the new frontend.
 
-1. **New Cog**: Follow CONTRIBUTING.md pattern. Use `_run_helper.run_claude_in_thread()` for Claude execution.
-2. **New Tool Category**: Add to `ToolCategory` enum, update `TOOL_CATEGORIES` mapping in `types.py`, add emoji in `status.py` `CATEGORY_EMOJI` and `embeds.py` `CATEGORY_ICON`.
-3. **New Event Type**: Add to `MessageType` enum, add `_parse_xxx()` function in `parser.py`, handle in `_run_helper.py` event loop.
-4. **New Embed Type**: Add builder function in `embeds.py`, call from `_run_helper.py`.
+### Add a backend
 
-## Dependency Graph
+Implement `SessionBackend`, emit neutral `StreamEvent` values, register it in `BackendFactory` and
+`BackendSettings`, and make credentials explicit. A remote backend is a data boundary; do not echo
+untrusted response bodies or leak its credentials into child processes.
 
-```
-claude_discord/
-  __init__.py ──────────┬──→ claude/runner.py
-                        ├──→ claude/parser.py
-                        ├──→ claude/types.py
-                        ├──→ cogs/claude_chat.py ──→ _run_helper.py ──→ runner, types
-                        ├──→ cogs/skill_command.py ──→ _run_helper.py     parser, repo
-                        ├──→ database/repository.py                       status, chunker
-                        ├──→ discord_ui/status.py                         embeds
-                        ├──→ discord_ui/chunker.py
-                        └──→ discord_ui/embeds.py
+### Embed the relay
 
-  main.py ──→ bot.py, runner, claude_chat, models, repository, logger
-
-External:
-  discord.py (Gateway, commands, app_commands)
-  aiosqlite (async SQLite)
-  python-dotenv (env loading, standalone mode only)
-```
-
-Key design constraint: `claude/` and `discord_ui/` have zero dependencies on each other. The `cogs/` layer (specifically `_run_helper.py`) is the only place where CLI output meets Discord rendering. This keeps the parser testable without Discord mocks and the UI components testable without subprocess mocks.
+`setup_bridge()` wires the standard Discord deployment and exposes `BridgeComponents` for custom
+cogs. Public names remain compatibility constrained even though the product name changed; see
+[the rename plan](RENAME_PLAN.md).

--- a/docs/adr/0005-classify-feature-backends-as-minor-releases.md
+++ b/docs/adr/0005-classify-feature-backends-as-minor-releases.md
@@ -3,12 +3,12 @@ type: adr
 id: ADR-0005
 title: Classify new optional backends as minor releases
 decision: Release a new backward-compatible SessionBackend as a SemVer minor version, even when the default merge automation initially creates a patch bump.
-status: accepted
+status: superseded
 date: 2026-08-11
 deciders: [Masahiko Ebi, Codex]
 scope: repository
 supersedes:
-superseded_by:
+superseded_by: ADR-0006
 ---
 
 # ADR-0005: Classify new optional backends as minor releases

--- a/docs/adr/0006-publish-the-multi-frontend-platform-as-v4.md
+++ b/docs/adr/0006-publish-the-multi-frontend-platform-as-v4.md
@@ -1,0 +1,85 @@
+---
+type: adr
+id: ADR-0006
+title: Publish the multi-frontend platform as version 4
+decision: Treat the combined Discord and Microsoft Teams frontend contract plus the multi-backend platform as the v4 product boundary, while preserving 3.x runtime compatibility.
+status: accepted
+date: 2026-08-11
+deciders: [Masahiko Ebi, Codex]
+scope: repository
+supersedes: ADR-0005
+superseded_by:
+---
+
+# ADR-0006: Publish the multi-frontend platform as version 4
+
+## Context
+
+ADR-0005 correctly classified AG-UI *by itself* as a backward-compatible feature and released it
+as 3.4.0. Since that decision, the Microsoft Teams work also reached its production boundary: the
+surface contract, authenticated public receiver, queue relay, private `ActivityPuller`, simultaneous
+Discord startup, and a live Teams → real agent → Teams round trip are complete.
+
+The product is no longer accurately described as a Discord bridge with another optional backend.
+There are now two independent public axes:
+
+- frontend: Discord or Microsoft Teams; and
+- backend: Claude Code, Codex, local, or AG-UI.
+
+Teams also introduces an operator-visible deployment contract — Entra identity, Azure Bot,
+public HTTPS receiver, queue credentials, private polling host, app manifest, and tenant consent.
+That boundary needs a prominent release and migration-quality documentation, even though the
+existing Discord default and identifiers remain compatible.
+
+## Options considered
+
+### Keep 3.4.x
+
+Rejected. It is technically compatible but materially understates the change in product scope and
+leaves operators likely to miss the Teams deployment and trust-boundary review.
+
+### Release 3.5.0
+
+Rejected. A minor version accurately describes the additive APIs, but not the deliberate change in
+the product's public contract from one chat surface to a frontend × backend platform.
+
+### Release 4.0.0 with an explicit compatibility statement
+
+Accepted. The major version marks the new product and deployment boundary. Release notes must say
+plainly that v4 does not intentionally remove the 3.x package name, command, environment variables,
+stored data, REST routes, or Discord-only default.
+
+## Decision
+
+1. Publish the completed multi-frontend, multi-backend platform as version 4.0.0.
+2. Make the frontend × backend model the primary README explanation.
+3. Provide one end-to-end Teams operator guide covering the full Azure/Entra/relay/private-host path.
+4. Keep the `claude-code-discord-bridge` distribution, `ccdb` command, Python import names,
+   `CCDB_*` settings, storage layout, APIs, and default `CCDB_FRONTENDS=discord` behavior.
+5. Continue using minor releases for an isolated, backward-compatible frontend or backend addition.
+   A future major version still requires an explicit ADR; this combined product-boundary decision
+   is not a blanket exception to Semantic Versioning.
+
+## Consequences and trade-offs
+
+### Positive
+
+- External users can discover Teams and AG-UI as first-class capabilities instead of buried work.
+- Operators are directed to the security and setup review that a public Teams endpoint requires.
+- The new name, architecture, and release number tell the same product story.
+- Existing Discord-only deployments can upgrade without a forced configuration migration.
+
+### Negative
+
+- Some users will assume “4.0” means a breaking API change, so every release surface must include
+  the compatibility statement.
+- Superseding ADR-0005 requires nuance: its SemVer reasoning remains correct for AG-UI alone, while
+  its rejected v4 conclusion no longer covers the later combined platform milestone.
+
+## Related
+
+- [ADR-0001: Adopt Ebi Agent Chat Relay as the product name](0001-adopt-ebi-agent-chat-relay.md)
+- [ADR-0004: Add AG-UI as an optional backend transport](0004-add-ag-ui-as-an-optional-backend.md)
+- [ADR-0005: Classify new optional backends as minor releases](0005-classify-feature-backends-as-minor-releases.md)
+- [Microsoft Teams setup](../teams-setup.md)
+- [Issue #611](https://github.com/ebibibi/ebi-agent-chat-relay/issues/611)

--- a/docs/adr/_index.md
+++ b/docs/adr/_index.md
@@ -11,3 +11,4 @@ earlier ADR instead of rewriting its history.
 - [ADR-0003: Anonymize by rule, inspect by model](0003-anonymize-by-rule-inspect-by-model.md)
 - [ADR-0004: Add AG-UI as an optional backend transport](0004-add-ag-ui-as-an-optional-backend.md)
 - [ADR-0005: Classify new optional backends as minor releases](0005-classify-feature-backends-as-minor-releases.md)
+- [ADR-0006: Publish the multi-frontend platform as version 4](0006-publish-the-multi-frontend-platform-as-v4.md)

--- a/docs/agui-backend.md
+++ b/docs/agui-backend.md
@@ -9,7 +9,7 @@ conversation surfaces while replacing the local Claude/Codex CLI process with an
 Install the optional HTTP dependency:
 
 ```bash
-pip install 'claude-code-discord-bridge[agui]'
+uv sync --extra agui
 ```
 
 Configure the exact run endpoint and, when required, its bearer token:
@@ -21,6 +21,10 @@ CCDB_AGUI_TOKEN=replace-with-upstream-token
 
 Then select it globally with `CCDB_BACKEND=agui` or at runtime with `/backend agui`. A thread-scoped
 selection affects only that conversation.
+
+The selection works identically from Discord and Microsoft Teams. The chat platform remains the
+frontend — it renders streamed text, tool activity, and status — while AG-UI is the backend that
+generates those events. See [Choose an agent backend](backends.md) for the complete matrix.
 
 ## Wire behavior
 

--- a/docs/backends.md
+++ b/docs/backends.md
@@ -1,0 +1,116 @@
+# Choose an agent backend
+
+Ebi Agent Chat Relay separates the **frontend** where a person talks from the **backend** that
+does the work. Discord and Microsoft Teams use the same session ledger, coordination layer, and
+backend factory. Selecting a backend therefore does not require a different bot or a different
+Teams app.
+
+## Supported combinations
+
+| Backend | Transport | Authentication | Best fit |
+|---|---|---|---|
+| Claude Code | local `claude` CLI | the CLI's existing login | Claude-native coding workflows |
+| OpenAI Codex | local `codex` CLI | the CLI's existing login | Codex coding and review workflows |
+| Local | local `codex` CLI to an OpenAI-compatible `/v1/responses` endpoint | none by default | data that should stay on a controlled network |
+| AG-UI | HTTP request plus JSON server-sent events | optional bearer token | custom and hosted agents that implement AG-UI |
+
+All four work from both Discord and Microsoft Teams. The frontend controls message rendering,
+buttons, files, and rate limits; the backend controls model execution and streamed events.
+
+## Select a backend
+
+Set the default before startup:
+
+```dotenv
+CCDB_BACKEND=codex
+```
+
+On Discord, switch an individual conversation without restarting:
+
+```text
+/backend claude
+/backend codex
+/backend local
+/backend agui
+```
+
+These are Discord slash commands, and a conversation override is persisted in SQLite so it survives
+a process restart. The normal Teams queue integration in v4 does not dispatch the text-command
+router yet; Teams conversations use the configured/global backend. Set `CCDB_BACKEND` before
+startup or change the global setting from the Discord administration surface when both frontends
+run together.
+
+Use `/model` and `/effort` to inspect or change backend-specific choices. Each backend remembers
+its own model and reasoning setting.
+
+## Claude Code and Codex
+
+Install and authenticate the official CLI on the private session host before starting ccdb. The
+relay reuses that CLI login; it does not copy a subscription token into Discord or Teams.
+
+```bash
+claude --version
+codex --version
+ccdb start
+```
+
+The default backend remains `claude`, so upgrading an existing deployment does not change which
+agent receives the next turn.
+
+## Local
+
+The local backend drives an OpenAI-compatible `/v1/responses` endpoint through a ccdb-owned Codex
+configuration. It disables the measured startup update check and analytics rather than assuming
+that “logged out” means “offline.”
+
+```dotenv
+CCDB_LOCAL_BASE_URL=http://127.0.0.1:11434/v1
+CCDB_LOCAL_MODEL=gpt-oss:120b
+```
+
+Read [Local-model backend](local-backend.md) before using this for sensitive data. The guard is a
+configuration control, not an operating-system egress firewall, and should be re-measured after
+Codex CLI upgrades.
+
+## AG-UI
+
+Install the optional HTTP dependency and configure the exact run endpoint:
+
+```bash
+uv sync --extra agui
+```
+
+```dotenv
+CCDB_AGUI_URL=https://agent.example.com/run
+CCDB_AGUI_TOKEN=replace-with-a-dedicated-token
+```
+
+Then set `CCDB_BACKEND=agui`, or enter `/backend agui` in Discord. Whichever frontend supplies the
+turn also supplies a stable AG-UI `threadId`, so the remote endpoint can preserve its own
+conversation state.
+
+See [AG-UI backend](agui-backend.md) for the event mapping, security boundary, and intentionally
+unsupported protocol features.
+
+## Mixing frontends and backends
+
+Backend resolution belongs to the shared session layer, not the platform implementation. In v4,
+Discord can set per-conversation overrides; Teams consumes the configured/global choice. A
+deployment can therefore run, for example:
+
+- a Discord thread on Claude Code;
+- another Discord thread on a local model;
+- Teams conversations on the configured Codex default; or
+- Teams conversations on an internal AG-UI agent when AG-UI is the configured/global backend.
+
+The same AI Lounge, claims, collision detection, worktree rules, and session persistence cover all
+of them. Frontend identity is stored with each session, so a Teams result cannot accidentally be
+posted into a Discord thread with a numerically similar key.
+
+## Security boundary
+
+Every selected backend receives that conversation's prompts and attachments. Treat a remote AG-UI
+endpoint or local model host as part of the data-processing path. A customer-tenant Teams app does
+not by itself keep data inside that tenant: messages still travel through Bot Framework, the public
+receiver, the queue, the private session host, and the selected backend. Deploy the complete stack
+inside the required boundary when the contract requires that literal property.

--- a/docs/releases/v4.0.0.md
+++ b/docs/releases/v4.0.0.md
@@ -1,0 +1,104 @@
+# Ebi Agent Chat Relay 4.0.0
+
+Version 4 turns the project from a Discord bridge with several runners into a
+**multi-frontend, multi-backend agent relay**.
+
+People can now work with the same persistent agent sessions from **Discord or Microsoft Teams**,
+with **Claude Code, OpenAI Codex, a guarded local model, or an AG-UI agent** behind the shared
+session layer.
+
+## Microsoft Teams is production-ready
+
+Teams is not a skin over the Discord implementation. It is a sibling frontend that implements the
+same conversation contract and adapts the experience to Teams:
+
+- long answers are kept together rather than fragmented at Discord's 2,000-character boundary;
+- tool activity and session state are coalesced into one Adaptive Card within Teams rate limits;
+- approvals and forms fail closed and bind every response to the conversation that received it;
+- the surface implements Microsoft's one-time personal-chat upload flow; and
+- Teams and Discord conversations share session persistence, AI Lounge coordination, claims,
+  collision detection, and backend resolution.
+
+The normal launcher runs both frontends together with:
+
+```dotenv
+CCDB_FRONTENDS=discord,teams
+```
+
+On the private session host, `ActivityPuller` polls verified activities from Azure Storage Queue
+outbound. Discord's gateway remains connected in the same process. The public receiver holds no bot
+client secret and cannot start an agent session.
+
+Teams setup necessarily has more moving parts than Discord: Entra application registration, an
+Azure Bot, a public HTTPS receiver, a queue, the private host, and a tenant-specific app package.
+The new [end-to-end Teams setup guide](https://github.com/ebibibi/ebi-agent-chat-relay/blob/main/docs/teams-setup.md) explains the complete path, security
+boundary, validation sequence, and common silent-failure cases.
+
+## AG-UI and multiple backends
+
+The backend is independent of the chat frontend. A Discord thread and a Teams conversation can each
+choose among:
+
+- **Claude Code** through the official local CLI;
+- **OpenAI Codex** through the official local CLI;
+- **Local** through a ccdb-controlled Codex configuration and an OpenAI-compatible
+  `/v1/responses` endpoint; or
+- **AG-UI** through a remote HTTP/SSE endpoint implementing the Agent–User Interaction Protocol.
+
+AG-UI maps standard run, text, reasoning, tool-call, and tool-result events into the same neutral
+stream used by the native CLI backends. It rejects URL credentials and redirects, bounds SSE event
+size, strips its token from child CLI environments, and keeps durable human-in-the-loop resume as an
+explicit future capability rather than pretending it is safe today.
+
+See [Choose an agent backend](https://github.com/ebibibi/ebi-agent-chat-relay/blob/main/docs/backends.md)
+and the detailed [AG-UI guide](https://github.com/ebibibi/ebi-agent-chat-relay/blob/main/docs/agui-backend.md).
+
+The v4 private queue path deliberately has two narrower edges than the surface contract: it does
+not yet dispatch the Teams text-command router or bridge file-consent invokes. Teams uses the
+configured/global backend, and agent-created file delivery through that path remains a follow-up.
+These limits are called out in the setup guide rather than hidden behind the platform capability.
+
+## Compatibility
+
+This major release marks a new **product and deployment contract**, not a deliberate removal of 3.x
+interfaces. Existing Discord-only deployments retain:
+
+- the `claude-code-discord-bridge` Python distribution name;
+- the `ccdb` command and Python import paths;
+- existing `CCDB_*` environment variables, REST routes, and stored data;
+- `claude` as the default backend; and
+- Discord as the only frontend unless `CCDB_FRONTENDS` explicitly enables Teams.
+
+No Teams receiver or queue poller starts merely because an existing deployment upgrades.
+
+## Upgrade
+
+```bash
+git fetch --tags origin
+git checkout v4.0.0
+uv sync
+```
+
+The distribution is not published on PyPI yet; install from this GitHub tag or use `uvx --from`
+with the tagged Git URL. For Discord-only operation, restart normally; no new configuration is
+required. To add Teams, install the optional dependency and follow the setup guide:
+
+```bash
+uv sync --extra teams
+```
+
+For AG-UI:
+
+```bash
+uv sync --extra agui
+```
+
+## Documentation
+
+- [README: v4 overview](https://github.com/ebibibi/ebi-agent-chat-relay#whats-new-in-v4)
+- [Choose an agent backend](https://github.com/ebibibi/ebi-agent-chat-relay/blob/main/docs/backends.md)
+- [Set up Microsoft Teams end to end](https://github.com/ebibibi/ebi-agent-chat-relay/blob/main/docs/teams-setup.md)
+- [Microsoft Teams surface behavior](https://github.com/ebibibi/ebi-agent-chat-relay/blob/main/docs/teams.md)
+- [Private-host relay security model](https://github.com/ebibibi/ebi-agent-chat-relay/blob/main/docs/teams-relay.md)
+- [AG-UI backend](https://github.com/ebibibi/ebi-agent-chat-relay/blob/main/docs/agui-backend.md)
+- [ADR-0006: Publish the multi-frontend platform as version 4](https://github.com/ebibibi/ebi-agent-chat-relay/blob/main/docs/adr/0006-publish-the-multi-frontend-platform-as-v4.md)

--- a/docs/teams-setup.md
+++ b/docs/teams-setup.md
@@ -1,0 +1,254 @@
+# Set up Microsoft Teams end to end
+
+This guide takes a new deployment from an empty Microsoft tenant to a real
+**Teams → agent → Teams** round trip. It uses the recommended split architecture: a small public
+receiver accepts Microsoft Bot Framework traffic, while the machine that runs Claude Code, Codex,
+local models, or AG-UI remains private and polls outbound.
+
+## The pieces you are creating
+
+```text
+Teams user
+   │
+   ▼
+Microsoft Teams / Bot Framework
+   │ HTTPS: signed Activity
+   ▼
+public receiver                     Azure Container Apps is one option
+   │ verify token, enqueue only     no bot client secret, cannot run an agent
+   ▼
+Azure Storage Queue
+   ▲
+   │ outbound poll
+private session host                ccdb, CLI logins, repositories, bot secret
+   │ outbound HTTPS
+   ├──────────────▶ selected backend: Claude / Codex / Local / AG-UI
+   └──────────────▶ Bot Connector ──▶ Teams user
+```
+
+The public receiver and private host use different queue credentials. The receiver needs only the
+ability to add messages. The private host needs to read, update visibility, and delete them.
+
+## Prerequisites
+
+- Permission to create an Entra application and an Azure Bot resource.
+- Permission to upload or publish a custom Teams app and grant its requested consent.
+- An Azure subscription with a Storage account and an HTTPS container host, or equivalent services.
+- A private machine that can run Python 3.12 or 3.13 and the desired agent backend.
+- A public DNS host such as `relay.example.com` with a valid TLS certificate.
+
+Microsoft portal labels change over time. The invariant values are the **application (client) ID**,
+**directory (tenant) ID**, **client credential**, and **messaging endpoint**.
+
+## 1. Create the Entra application
+
+In Microsoft Entra admin center:
+
+1. Open **App registrations → New registration**.
+2. Choose a stable operator-facing name such as “Ebi Agent Chat Relay”.
+3. Choose the supported account type that matches the deployment. A single-customer deployment
+   normally uses “Accounts in this organizational directory only.” A SaaS deployment requires a
+   separate multi-tenant design and customer consent process.
+4. Record the **Application (client) ID** as `CCDB_TEAMS_APP_ID`.
+5. Record the **Directory (tenant) ID** as `CCDB_TEAMS_TENANT_ID`.
+6. Under **Certificates & secrets**, create a credential for the private session host. Store the
+   secret *value* immediately in a secret manager; the portal will not show it again.
+
+Do not put the secret in the Teams app package, container image, Git repository, or public receiver.
+The current launcher authenticates with `CCDB_TEAMS_APP_PASSWORD`; rotate it before expiration.
+
+## 2. Create the Azure Bot
+
+Create an **Azure Bot** resource and associate it with the application ID from step 1. Select the
+same tenant/account model as the Entra registration, then add the **Microsoft Teams** channel.
+
+The messaging endpoint will be:
+
+```text
+https://relay.example.com/api/teams/messages
+```
+
+You can enter it now or after the receiver is deployed. The host and path must match
+`CCDB_TEAMS_PUBLIC_HOST` and `CCDB_TEAMS_ENDPOINT_PATH` exactly.
+
+## 3. Create the Azure Storage Queue
+
+Create a Storage account and a queue dedicated to this deployment, for example `agent-activities`.
+Do not share one queue across customers: the queue and session database are isolation boundaries.
+
+Generate two short-lived, HTTPS-only SAS URLs:
+
+| Consumer | Minimum queue permissions | Where it is stored |
+|---|---|---|
+| public receiver | add | receiver secret/environment |
+| private session host | read, process/update, delete | private host secret/environment |
+
+Both processes call their own credential `CCDB_TEAMS_QUEUE_URL`. A SAS URL contains a secret in its
+query string; never paste the real value into logs, screenshots, an Issue, or a manifest. Prefer a
+managed rotation process and narrow network access where practical.
+
+## 4. Deploy the public receiver
+
+Build the included minimal image:
+
+```bash
+docker build -f deploy/teams-relay/Dockerfile -t your-registry.example/agent-relay:v4 .
+docker push your-registry.example/agent-relay:v4
+```
+
+Run it on Azure Container Apps or another HTTPS container service with:
+
+```dotenv
+CCDB_TEAMS_APP_ID=00000000-0000-0000-0000-000000000000
+CCDB_TEAMS_TENANT_ID=00000000-0000-0000-0000-000000000000
+CCDB_TEAMS_PUBLIC_HOST=relay.example.com
+CCDB_TEAMS_QUEUE_URL=https://account.queue.core.windows.net/agent-activities?RECEIVER_SAS
+```
+
+The container command is:
+
+```bash
+python -m claude_teams relay --host 0.0.0.0 --port 8080
+```
+
+Expose port 8080 through the platform's TLS ingress and map the custom DNS name. Keep at least one
+warm replica: a cold start can exceed the short response budget for Teams card invokes. Configure
+health checks against `/healthz`.
+
+The receiver must **not** have `CCDB_TEAMS_APP_PASSWORD`, repository access, or agent credentials.
+It verifies the inbound Bot Framework token and writes a bounded envelope to the queue. It cannot
+reply as the bot or start a shell session.
+
+Before continuing, verify:
+
+```bash
+curl --fail https://relay.example.com/healthz
+```
+
+Then set the Azure Bot messaging endpoint to
+`https://relay.example.com/api/teams/messages`.
+
+## 5. Configure the private session host
+
+On a checkout of the repository, install the Teams extra and at least one backend:
+
+```bash
+uv sync --extra teams
+claude --version   # or: codex --version
+```
+
+Add these values to the same protected environment file that starts the normal EbiBot process:
+
+```dotenv
+# Keep Discord active and add Teams in the same process.
+CCDB_FRONTENDS=discord,teams
+
+CCDB_TEAMS_APP_ID=00000000-0000-0000-0000-000000000000
+CCDB_TEAMS_TENANT_ID=00000000-0000-0000-0000-000000000000
+CCDB_TEAMS_APP_PASSWORD=replace-with-the-client-secret
+CCDB_TEAMS_PUBLIC_HOST=relay.example.com
+CCDB_TEAMS_QUEUE_URL=https://account.queue.core.windows.net/agent-activities?PRIVATE_HOST_SAS
+
+# Existing Discord configuration remains unchanged.
+DISCORD_BOT_TOKEN=replace-with-the-discord-token
+```
+
+Start the normal launcher:
+
+```bash
+uv run ccdb start
+```
+
+At startup, one process keeps the Discord gateway connection open and starts the private
+`ActivityPuller`. The puller performs outbound queue requests; no Teams listener is opened on this
+machine. `CCDB_FRONTENDS` defaults to `discord`, so omitting the setting preserves a Discord-only
+deployment.
+
+If Teams is the only frontend, `CCDB_FRONTENDS=teams` selects it, but the current normal launcher
+still requires its existing Discord bot configuration. Running both is the tested production path.
+
+## 6. Generate the Teams app package
+
+Use the same IDs and public host, but no secret is required:
+
+```bash
+export CCDB_TEAMS_APP_ID=00000000-0000-0000-0000-000000000000
+export CCDB_TEAMS_TENANT_ID=00000000-0000-0000-0000-000000000000
+export CCDB_TEAMS_PUBLIC_HOST=relay.example.com
+
+python -m claude_teams manifest \
+  --out dist/teams-app.zip \
+  --color-icon assets/color.png \
+  --outline-icon assets/outline.png
+```
+
+`CCDB_TEAMS_PUBLIC_HOST` is a bare DNS host: no `https://`, port, or path. The command prints the
+messaging endpoint; compare it character-for-character with the Azure Bot setting.
+
+The generated zip includes the manifest and required icons. It declares:
+
+- the Entra application ID as the bot identity;
+- `ChannelMessage.Read.Group` resource-specific consent, granted by a team owner on installation;
+- `webApplicationInfo`, so future SSO work does not unexpectedly change the consent shape; and
+- the exact public host in `validDomains`.
+
+## 7. Upload and consent in Teams
+
+Upload `dist/teams-app.zip` through **Manage your apps → Upload an app** or publish it through the
+organization's Teams admin process. Install it first in a personal chat, then in a test team.
+
+In channels, mention the bot on the first message. The resource-specific consent in the manifest
+allows the installed app to receive subsequent channel messages according to the tenant's policy.
+
+The generated package includes the command-list scaffold used by the standalone Teams surface.
+The normal private queue integration in v4 does not yet dispatch those text commands: slash-looking
+text is passed to the selected agent like any other prompt. Configure `CCDB_BACKEND` on the private
+host (or use the Discord global administration command when both frontends run together).
+
+## 8. Validate in three stages
+
+1. **Public edge:** `/healthz` returns success and the Azure Bot endpoint matches the generated URL.
+2. **Transport:** receiver logs show an accepted activity and private-host logs show the
+   `ActivityPuller` consuming it. No secret or SAS URL should appear in either log.
+3. **Agent round trip:** send a harmless prompt such as “Reply with exactly `teams-v4-ok`.” Confirm
+   the answer appears in the same Teams conversation, then send a Discord prompt and confirm both
+   frontends remain live together.
+
+After that, restart with the backend you intend to use and repeat the harmless prompt. AG-UI
+requires `CCDB_BACKEND=agui`, `CCDB_AGUI_URL`, and the optional `CCDB_AGUI_TOKEN`; see
+[Choose an agent backend](backends.md).
+
+## Security and tenancy checklist
+
+- The public receiver holds no bot client secret and no agent/repository credentials.
+- Inbound JWT signature, issuer, audience, expiry, and signed `serviceurl` are verified before enqueue.
+- The receiver and private host use separate least-privilege queue credentials.
+- Secrets live in a secret manager or protected environment file and are rotated.
+- Each customer has a separate bot identity, queue, data root/database, and process or deployment.
+- A customer-owned Entra registration alone does **not** keep data inside that tenant. The full data
+  path includes Bot Framework, receiver, queue, private host, and selected backend.
+- For a literal customer-boundary promise, deploy the entire stack and backend inside the approved
+  customer environment.
+
+Read [Running Teams without putting the session host on the internet](teams-relay.md) for the
+detailed threat model, delivery semantics, operational trade-offs, and measured latency/cost.
+
+## Troubleshooting
+
+| Symptom | Check |
+|---|---|
+| The app installs but every message is silent | Azure Bot has the Teams channel; messaging endpoint, DNS, TLS, and generated host/path match exactly |
+| Manifest generation rejects the host | Use `relay.example.com`, not a URL, port, or path |
+| Receiver answers 401 | Entra app ID/tenant/account type mismatch, wrong Azure Bot association, or invalid Bot Framework token |
+| Receiver answers 503 | Queue URL or receiver SAS lacks add permission, is expired, or cannot reach Storage |
+| Queue grows but no reply appears | `CCDB_FRONTENDS` includes `teams`; private process has the private SAS, app secret, and network access; inspect ActivityPuller logs |
+| Private startup says a Teams variable is required | Set all five identity/secret/queue variables shown in step 5 |
+| Reply fails after an activity was consumed | Verify the Entra client secret and tenant ID; rotate expired credentials; confirm the activity's `serviceUrl` was retained |
+| Channel messages only work with @mention | Confirm the app is installed in that team and the owner granted `ChannelMessage.Read.Group` consent |
+| A card press appears successful after the prompt expired | Expected relay trade-off: the public receiver acknowledges the invoke before the private prompt registry sees it; the private host still rejects the stale action |
+| A generated command-menu entry becomes an agent prompt | Expected v4 limitation of the normal queue path; configure `CCDB_BACKEND` on the private host |
+| Agent-created files are not delivered through the relay | Expected v4 limitation: the Teams surface has personal-chat file consent, but the private queue path does not yet bridge its invoke; channel delivery is also unsupported |
+| Discord works but Teams does not start | The default is Discord-only; set `CCDB_FRONTENDS=discord,teams` and restart through the deployment's safe drain procedure |
+
+For surface limits, prompts, commands, cards, and file behavior, continue with
+[The Microsoft Teams frontend](teams.md).

--- a/docs/teams.md
+++ b/docs/teams.md
@@ -5,6 +5,11 @@
 > passes every check; a channel fails exactly one**, file delivery, and that is
 > pinned by name rather than skipped.
 
+> Deployment note: this document explains the Teams surface itself. The recommended private-host
+> queue relay supports messages, streaming, activity cards, prompts, and interruption, but does not
+> yet bridge the personal-file consent invoke or dispatch the text-command router. Follow the
+> [end-to-end setup guide](teams-setup.md) for the v4 deployment path and its exact limits.
+
 Discord and Teams are siblings, not a base and a port. `claude_discord` and
 `claude_teams` each implement the vocabulary in `claude_code_core.frontend`,
 and neither imports the other. The same conformance contract runs against both,
@@ -38,6 +43,10 @@ A caller never branches on the platform name; it asks the capabilities.
 
 ## Setting it up
 
+For a production deployment, use the complete [Microsoft Teams setup guide](teams-setup.md). The
+short sequence below describes the common identity and manifest inputs; it does not replace the
+public receiver, queue, private `ActivityPuller`, consent, and validation steps in that guide.
+
 ### 1. Create the Entra application and Azure Bot
 
 You need an application (client) id, its tenant, and a client secret. The Azure
@@ -60,7 +69,7 @@ produces an app that installs and then receives nothing.
 ### 3. Generate the app package
 
 ```bash
-pip install "claude-code-discord-bridge[teams]"
+uv sync --extra teams
 python -m claude_teams manifest --out dist/teams-app.zip
 ```
 
@@ -85,10 +94,10 @@ Two things in the generated manifest are worth knowing about:
 
 ### 4. Expose the endpoint
 
-Teams must reach `https://<host>/api/teams/messages`. A tunnel (Cloudflare
-Tunnel, ngrok) in front of the machine running ccdb is the usual arrangement;
-what matters is that the host in the manifest, the Azure Bot messaging
-endpoint, and what actually answers are the same thing.
+Teams must reach `https://<host>/api/teams/messages`. The recommended arrangement is the public
+receiver described in [teams-relay.md](teams-relay.md), with the session host polling outbound.
+A tunnel to the direct endpoint remains useful for isolated echo development. In either case, the
+host in the manifest, the Azure Bot messaging endpoint, and what actually answers must agree.
 
 ## What the surface does differently from Discord
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "hatchling.build"
 
 [project]
 name = "claude-code-discord-bridge"
-version = "3.4.1"
-description = "Ebi Agent Chat Relay (formerly Claude & Codex Discord Bridge) — drive both Claude Code and OpenAI Codex from Discord with interactive chat, parallel sessions, and CI/CD automation"
+version = "4.0.0"
+description = "Ebi Agent Chat Relay — run Claude Code, Codex, local, and AG-UI agents from Discord or Microsoft Teams"
 readme = "README.md"
 license = {text = "MIT"}
 requires-python = ">=3.12,<3.14"

--- a/tests/test_v4_release_docs.py
+++ b/tests/test_v4_release_docs.py
@@ -1,0 +1,65 @@
+import tomllib
+from pathlib import Path
+
+ROOT = Path(__file__).parents[1]
+
+
+def read(relative: str) -> str:
+    return (ROOT / relative).read_text(encoding="utf-8")
+
+
+def test_v4_public_story_names_both_frontends_and_all_backends() -> None:
+    readme = read("README.md")
+
+    assert "Microsoft Teams (in progress)" not in readme
+    assert "Frontend × backend" in readme
+    for name in ("Discord", "Microsoft Teams", "Claude Code", "OpenAI Codex", "Local", "AG-UI"):
+        assert name in readme
+    assert "docs/teams-setup.md" in readme
+    assert "docs/backends.md" in readme
+
+
+def test_teams_setup_guide_covers_the_complete_relay_path() -> None:
+    guide = read("docs/teams-setup.md")
+
+    for concept in (
+        "Entra",
+        "Azure Bot",
+        "Azure Storage Queue",
+        "ActivityPuller",
+        "CCDB_FRONTENDS=discord,teams",
+        "CCDB_TEAMS_APP_ID",
+        "CCDB_TEAMS_TENANT_ID",
+        "CCDB_TEAMS_APP_PASSWORD",
+        "CCDB_TEAMS_PUBLIC_HOST",
+        "CCDB_TEAMS_QUEUE_URL",
+        "python -m claude_teams manifest",
+        "python -m claude_teams relay",
+        "does not yet dispatch those text commands",
+        "Troubleshooting",
+    ):
+        assert concept in guide
+
+
+def test_v4_release_artifacts_and_versions_are_in_sync() -> None:
+    project = tomllib.loads(read("pyproject.toml"))["project"]
+    lock = read("uv.lock")
+    changelog = read("CHANGELOG.md")
+    release_notes = read("docs/releases/v4.0.0.md")
+
+    assert project["version"] == "4.0.0"
+    assert 'name = "claude-code-discord-bridge"\nversion = "4.0.0"' in lock
+    assert "## [4.0.0] - 2026-08-11" in changelog
+    assert "# Ebi Agent Chat Relay 4.0.0" in release_notes
+    assert "Compatibility" in release_notes
+
+
+def test_v4_adr_supersedes_the_previous_release_classification() -> None:
+    old = read("docs/adr/0005-classify-feature-backends-as-minor-releases.md")
+    new = read("docs/adr/0006-publish-the-multi-frontend-platform-as-v4.md")
+    index = read("docs/adr/_index.md")
+
+    assert "status: superseded" in old
+    assert "superseded_by: ADR-0006" in old
+    assert "supersedes: ADR-0005" in new
+    assert "ADR-0006" in index

--- a/uv.lock
+++ b/uv.lock
@@ -184,7 +184,7 @@ wheels = [
 
 [[package]]
 name = "claude-code-discord-bridge"
-version = "3.4.1"
+version = "4.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

Publish Ebi Agent Chat Relay 4.0.0 as the first release whose public contract is a frontend × backend platform.

- presents Discord and Microsoft Teams as supported sibling frontends
- presents Claude Code, OpenAI Codex, guarded local, and AG-UI as backend choices
- adds one end-to-end Teams operator guide from Entra/Azure registration through the private ActivityPuller and a real round trip
- documents the exact v4 relay limits instead of confusing surface capability with deployed transport capability
- replaces the stale Discord-only architecture document
- records the product-boundary release decision in ADR-0006, superseding ADR-0005
- adds curated public release notes and synchronizes the package/lock version at 4.0.0

## Compatibility

v4 marks a product and deployment boundary. It intentionally preserves the 3.x distribution name, `ccdb` command, Python imports, `CCDB_*` settings, REST routes, stored data, Claude default backend, and Discord-only default startup. Existing deployments do not start Teams unless `CCDB_FRONTENDS` enables it.

## Verification

- `pytest -q`: 2536 passed
- `ruff check .`: passed
- `ruff format --check claude_discord/ claude_teams/`: passed
- `pyright claude_discord/ claude_teams/`: 0 errors
- `uv lock --check`: passed
- release-document local link validation: passed
- staged diff secret-pattern audit: passed

Closes #611
Closes #605