### PR TITLE
feat: add Z.ai as a first-class CLI backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,15 @@ CCDB_BACKEND=claude
 # CCDB_AGUI_URL=https://agent.example.com/run
 # CCDB_AGUI_TOKEN=replace-with-upstream-token
 
+# Z.ai backend (optional) — runs the Claude Code CLI against Z.ai's
+# Anthropic-compatible GLM endpoint. Select it with `/backend zai` or
+# CCDB_BACKEND=zai. Put the Z.ai credentials (ANTHROPIC_AUTH_TOKEN and, if
+# needed, a regional ANTHROPIC_BASE_URL) in a dedicated file referenced by
+# CCDB_ZAI_ENV_FILE so they never mix with — or fall back to — direct
+# Anthropic credentials. CCDB_ZAI_MODEL sets the default GLM model id.
+# CCDB_ZAI_ENV_FILE=/home/you/.ccdb/zai.env
+# CCDB_ZAI_MODEL=glm-5.2[1m]
+
 # Discord Bot Configuration
 DISCORD_BOT_TOKEN=your-bot-token-here
 DISCORD_CHANNEL_ID=your-channel-id-here

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ command is `ccdb`, and `ccdb` remains the short name used throughout this docume
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 **Run coding agents from Discord or Microsoft Teams. Choose Claude Code, OpenAI Codex,
-a local model, or any compatible AG-UI agent behind the same conversation.**
+Z.ai's GLM models, a local model, or any compatible AG-UI agent behind the same conversation.**
 
 Ebi Agent Chat Relay turns each Discord thread or Teams conversation into an isolated,
 persistent agent session. Work on a feature in one conversation, review a PR in another, and run
@@ -19,14 +19,14 @@ configured/global backend in v4. The relay handles coordination so sessions do n
 other.
 
 **Why the name changed.** This started as a bridge between one AI and one chat app. It is now a
-relay with two production frontends and four backend choices. Three of the four words in the old
+relay with two production frontends and five backend choices. Three of the four words in the old
 name had stopped being true. See [ADR-0001](docs/adr/0001-adopt-ebi-agent-chat-relay.md) for the
 decision and [the rename plan](docs/RENAME_PLAN.md) for the compatibility-preserving transition.
 
 **Use your existing subscriptions, your own infrastructure, or a remote agent.** ccdb can run the
-official Claude Code and Codex CLIs, a Codex-compatible local endpoint, or an AG-UI HTTP/SSE
-agent. Discord exposes runtime `/backend` switching; Teams uses the configured backend through the
-same factory in v4.
+official Claude Code and Codex CLIs, the same Claude Code CLI pointed at Z.ai's GLM models, a
+Codex-compatible local endpoint, or an AG-UI HTTP/SSE agent. Discord exposes runtime `/backend`
+switching; Teams uses the configured backend through the same factory in v4.
 
 ## What's new in v4
 
@@ -35,17 +35,20 @@ work**. Any supported frontend can use any supported backend.
 
 ### Frontend × backend
 
-| | Claude Code | OpenAI Codex | Local | AG-UI |
-|---|---:|---:|---:|---:|
-| Discord | ✅ | ✅ | ✅ | ✅ |
-| Microsoft Teams | ✅ | ✅ | ✅ | ✅ |
+| | Claude Code | OpenAI Codex | Z.ai | Local | AG-UI |
+|---|---:|---:|---:|---:|---:|
+| Discord | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Microsoft Teams | ✅ | ✅ | ✅ | ✅ | ✅ |
 
 - **Discord** remains the zero-migration default. Existing deployments start exactly as before.
 - **Microsoft Teams** is production-ready through a small public receiver and an outbound-only
   `ActivityPuller` on the private session host. Discord and Teams can run together in one process
   with `CCDB_FRONTENDS=discord,teams`.
+- **Z.ai** runs the same Claude Code CLI against Z.ai's Anthropic-compatible GLM endpoint —
+  `/backend zai` or `CCDB_BACKEND=zai` — with its own credential file so a Z.ai thread never
+  inherits or falls back to direct Anthropic credentials.
 - **AG-UI** connects either chat surface to an HTTP/SSE agent implementing the Agent–User
-  Interaction Protocol. Claude Code, Codex, and the guarded local backend remain available.
+  Interaction Protocol. Claude Code, Codex, Z.ai, and the guarded local backend remain available.
 
 Start with the [backend guide](docs/backends.md). For Teams, follow the complete
 [Microsoft Teams setup guide](docs/teams-setup.md), then use the deeper
@@ -362,7 +365,7 @@ If the bot restarts mid-session, interrupted Claude sessions are automatically r
 
 ccdb 3.0 introduces three slash commands that change which AI handles the next session, with no bot restart:
 
-- `/backend [name] [scope]` — show or switch backend. `name` is `claude`, `codex`, `local`, or `agui`. `scope` is `thread` (this thread only) or `global` (server-wide default). When you omit `scope`, the command auto-resolves: in a thread it scopes to that thread, otherwise it sets the global default.
+- `/backend [name] [scope]` — show or switch backend. `name` is `claude`, `codex`, `zai`, `local`, or `agui`. `scope` is `thread` (this thread only) or `global` (server-wide default). When you omit `scope`, the command auto-resolves: in a thread it scopes to that thread, otherwise it sets the global default.
 - `/model [name] [scope]` — show or switch the model used by the **current** backend. Each backend remembers its own model preference, so flipping backend back and forth keeps your favoured models intact. Leave a backend's model unset to defer to that CLI's own default (e.g. Codex uses the `model` in `~/.codex/config.toml`, so ccdb tracks the console default instead of pinning a version).
   The `name` autocomplete is **discovered live**: ccdb asks the Anthropic models endpoint (using the credentials the Claude Code CLI already has) which models your account can see, so a model released this morning shows up in the dropdown without a ccdb upgrade. Aliases (`opus`, `sonnet`, …) are labelled with the model they currently resolve to. Offline, unauthenticated, or on Bedrock/Vertex/Foundry it silently falls back to a small static list; set `CCDB_MODEL_DISCOVERY=0` to always use that list. Codex suggestions stay static (the Codex CLI exposes no model listing) — any id you type still works.
 - `/effort [level] [scope]` — show or switch the **reasoning effort** used by the current backend. Valid levels are backend-specific: Claude accepts `low/medium/high/max`; Codex accepts `minimal/low/medium/high/xhigh` (mapped to the CLI's `model_reasoning_effort`). Leave it unset to defer to the CLI default.
@@ -391,6 +394,7 @@ Concrete example:
 /effort xhigh                          # global → codex reasons at xhigh effort
                                        # …open a thread, send a message…
 /backend claude scope:thread          # this thread only → switch back to claude
+/backend zai scope:thread             # this thread only → Z.ai (GLM models, isolated credentials)
 /backend agui scope:thread            # this thread only → configured remote AG-UI agent
 /model opus scope:thread              # this thread only → claude/opus
 /effort max scope:thread              # this thread only → claude reasons at max
@@ -505,6 +509,7 @@ Behind the scenes:
 - **Secret isolation** — Bot token stripped from subprocess environment
 - **User authorization** — `allowed_user_ids` restricts who can invoke Claude
 - **Log injection prevention** — User-provided API values are sanitized (newlines stripped) before writing to logs
+- **Z.ai backend** (optional) — `/backend zai` runs the same Claude Code CLI against Z.ai's Anthropic-compatible GLM endpoint via a dedicated `CCDB_ZAI_ENV_FILE` credential file; direct Anthropic credentials (`ANTHROPIC_API_KEY` / `ANTHROPIC_AUTH_TOKEN`) are popped from the subprocess environment first, so a Z.ai thread never inherits or falls back to them
 - **Local-model backend** (optional) — `/backend local` runs a thread against a model on your own hardware. ccdb owns a separate CLI home with the update check and analytics disabled, because a "local" run otherwise still contacts the vendor; it refuses to start if those settings are missing — see [docs/local-backend.md](docs/local-backend.md)
 - **Remote AG-UI backend** (optional) — `/backend agui` connects the existing Discord/Teams session machinery to any HTTP/SSE AG-UI agent while preserving ccdb's session ledger, rendering, cancellation, and operational controls — see [docs/agui-backend.md](docs/agui-backend.md)
 - **Anonymization gateway** (optional) — Replaces organisation-identifying terms with stable aliases before the prompt reaches Claude or Codex, and restores them in the answer. A local model checks the result for replacement misses and, by default, blocks the send when it finds one. Off until you write a rules file — see [docs/anonymization.md](docs/anonymization.md)
@@ -651,6 +656,7 @@ Each `.py` file in the directory must expose an `async def setup(bot, runner, co
 ```python
 from discord.ext import commands
 
+
 class GreeterCog(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
@@ -659,6 +665,7 @@ class GreeterCog(commands.Cog):
     async def on_member_join(self, member):
         channel = self.bot.get_channel(self.bot.channel_id)
         await channel.send(f"Welcome {member.mention}!")
+
 
 async def setup(bot, runner, components):
     await bot.add_cog(GreeterCog(bot))
@@ -710,6 +717,7 @@ runner = ClaudeRunner(
     working_dir="/path/to/your/project",
 )
 
+
 @bot.event
 async def on_ready():
     print(f"Logged in as {bot.user}")
@@ -719,6 +727,7 @@ async def on_ready():
         claude_channel_id=int(os.environ["DISCORD_CHANNEL_ID"]),
         allowed_user_ids={int(os.environ["DISCORD_OWNER_ID"])},
     )
+
 
 asyncio.run(bot.start(os.environ["DISCORD_BOT_TOKEN"]))
 ```
@@ -737,7 +746,9 @@ To deploy the bot across multiple Discord channels, pass `claude_channel_ids` in
 await setup_bridge(
     bot,
     runner,
-    claude_channel_id=int(os.environ["DISCORD_CHANNEL_ID"]),   # primary (fallback for thread creation)
+    claude_channel_id=int(
+        os.environ["DISCORD_CHANNEL_ID"]
+    ),  # primary (fallback for thread creation)
     claude_channel_ids={
         int(os.environ["DISCORD_CHANNEL_ID"]),
         int(os.environ["DISCORD_CHANNEL_ID_2"]),
@@ -758,7 +769,7 @@ So the configuration describes where ccdb speaks *freely*, not where it exists. 
 await setup_bridge(
     bot,
     runner,
-    claude_channel_ids={111},          # #111: no mention needed, every message runs Claude
+    claude_channel_ids={111},  # #111: no mention needed, every message runs Claude
     allowed_user_ids={int(os.environ["DISCORD_OWNER_ID"])},
 )
 # Anywhere else in the guild: "@YourBot what do you think?" starts a session; silence otherwise.
@@ -849,10 +860,12 @@ In chat-only mode, permission requests and `AskUserQuestion` prompts are **alway
 |----------|-------------|---------|
 | `DISCORD_BOT_TOKEN` | Your Discord bot token | (required) |
 | `DISCORD_CHANNEL_ID` | Channel ID for Claude chat | (required) |
-| `CCDB_BACKEND` | Backend to use: `claude`, `codex`, `local`, or `agui` | `claude` |
+| `CCDB_BACKEND` | Backend to use: `claude`, `codex`, `zai`, `local`, or `agui` | `claude` |
 | `CCDB_COMMAND` | Path or name of the CLI binary (overrides `CLAUDE_COMMAND`). Used by the initial runner picked from `CCDB_BACKEND`; superseded by the two per-backend variables below when `/backend` switches at runtime. | _(auto: `claude` or `codex`)_ |
 | `CCDB_CLAUDE_COMMAND` | Explicit path to the Claude CLI binary. Used by `BackendFactory` whenever `/backend claude` is active, regardless of the initial `CCDB_BACKEND`. Falls back to `CLAUDE_COMMAND`, then `claude` (PATH). | (optional) |
 | `CCDB_CODEX_COMMAND` | Explicit path to the OpenAI Codex CLI binary. Required when running the bot under systemd (default service PATH does not include `~/.npm-global/bin`). Falls back to `codex` (PATH). | (optional) |
+| `CCDB_ZAI_ENV_FILE` | Path to a dedicated `KEY=VALUE` file with Z.ai credentials (`ANTHROPIC_AUTH_TOKEN`, optionally a regional `ANTHROPIC_BASE_URL`), applied only when `/backend zai` is active. | (required for `zai`) |
+| `CCDB_ZAI_MODEL` | Default GLM model id used when a Z.ai thread's `/model` is left unset. | (optional) |
 | `CCDB_AGUI_URL` | Exact HTTP(S) run endpoint for `/backend agui`. Redirects are rejected. | (required for `agui`) |
 | `CCDB_AGUI_TOKEN` | Optional bearer token for the AG-UI endpoint. Stripped from Claude/Codex subprocess environments. | (optional) |
 | `PATH` | Binary search path for the bot **and every CLI session it spawns** — sessions inherit the bot's environment. Set it in `.env` when running under systemd, which starts units with a minimal PATH and never reads `~/.bashrc` / `~/.profile`. See [Toolchain PATH](#toolchain-path--set-it-in-env). | (inherited from the parent process) |
@@ -990,12 +1003,14 @@ triggers = {
     ),
 }
 
-await bot.add_cog(WebhookTriggerCog(
-    bot=bot,
-    runner=runner,
-    triggers=triggers,
-    channel_ids={YOUR_CHANNEL_ID},
-))
+await bot.add_cog(
+    WebhookTriggerCog(
+        bot=bot,
+        runner=runner,
+        triggers=triggers,
+        channel_ids={YOUR_CHANNEL_ID},
+    )
+)
 ```
 
 **Security:** Prompts are defined server-side. Webhooks only select which trigger to fire — no arbitrary prompt injection.
@@ -1064,7 +1079,7 @@ config = UpgradeConfig(
     trigger_prefix="🔄 bot-upgrade",
     working_dir="/home/user/my-bot",
     restart_command=["sudo", "systemctl", "restart", "my-bot.service"],
-    restart_approval=True,       # React ✅ in thread, or click button in channel
+    restart_approval=True,  # React ✅ in thread, or click button in channel
     slash_command_enabled=True,  # Enable /upgrade slash command (opt-in, default False)
 )
 

--- a/claude_code_core/api_provider.py
+++ b/claude_code_core/api_provider.py
@@ -53,6 +53,8 @@ def detect_api_provider(env: Mapping[str, str]) -> str:
     base_url = (env.get("ANTHROPIC_BASE_URL") or "").strip()
     if base_url:
         host = urlparse(base_url).hostname or base_url
+        if host.lower() == "api.z.ai":
+            return "Z.ai"
         return f"Custom endpoint ({host})"
 
     return "Anthropic API (direct)"

--- a/claude_code_core/backend.py
+++ b/claude_code_core/backend.py
@@ -55,7 +55,7 @@ def create_backend(
     """Create a backend runner by name.
 
     Args:
-        backend: "claude", "codex", "local", or "agui".
+        backend: "claude", "zai", "codex", "local", or "agui".
         model: Model identifier (e.g. "sonnet", "o4-mini"). ``None`` lets the
             backend pick its own default — Codex omits ``--model`` and defers
             to its CLI config.
@@ -65,6 +65,10 @@ def create_backend(
         from .runner import ClaudeRunner
 
         runner: SessionBackend = ClaudeRunner(model=model, **kwargs)  # type: ignore[arg-type]
+    elif backend == "zai":
+        from .zai_runner import ZaiRunner
+
+        runner = ZaiRunner(model=model, **kwargs)  # type: ignore[arg-type]
     elif backend == "codex":
         from .codex_runner import CodexRunner
 

--- a/claude_code_core/runner.py
+++ b/claude_code_core/runner.py
@@ -19,6 +19,7 @@ import signal
 import sys
 from collections.abc import AsyncGenerator
 from pathlib import Path
+from typing import Any
 
 from .api_provider import detect_api_provider
 from .parser import parse_line
@@ -71,6 +72,8 @@ def _resolve_windows_cmd(cmd_path: Path) -> list[str] | None:
 
 class ClaudeRunner:
     """Manages Claude Code CLI subprocess execution."""
+
+    backend_name = "claude"
 
     def __init__(
         self,
@@ -176,7 +179,7 @@ class ClaudeRunner:
         effort: str | None | object = _UNSET,
     ) -> ClaudeRunner:
         """Create a fresh runner with the same configuration but no active process."""
-        return ClaudeRunner(
+        return type(self)(
             command=self.command,
             model=model if model is not None else self.model,
             permission_mode=self.permission_mode,
@@ -201,7 +204,16 @@ class ClaudeRunner:
             effort=(
                 self.effort if effort is _UNSET else effort  # type: ignore[arg-type]
             ),
+            **self._clone_extra_kwargs(),
         )
+
+    def _clone_extra_kwargs(self) -> dict[str, Any]:
+        """Constructor kwargs required by subclasses when cloning.
+
+        Base ClaudeRunner has no extra kwargs; subclasses (e.g. ZaiRunner)
+        override this so ``clone()`` preserves their distinguishing state.
+        """
+        return {}
 
     async def inject_tool_result(self, request_id: str, data: dict) -> None:
         """Send a tool result or permission/elicitation response via stdin."""
@@ -338,8 +350,28 @@ class ClaudeRunner:
             "CCDB_TEAMS_QUEUE_URL",
             "CCDB_API_URL",
             "CCDB_API_SECRET",
+            "CCDB_ZAI_ENV_FILE",
         }
     )
+
+    @staticmethod
+    def _merge_env_file(env: dict[str, str], path: str | None) -> None:
+        """Merge a simple KEY=VALUE file into *env* without logging values.
+
+        Shared by the process-wide ``CCDB_CLI_ENV_FILE`` overlay and by
+        backend-specific credential files (e.g. the Z.ai auth file), so each
+        keeps the same "parse once, never log the values" shape.
+        """
+        if not path:
+            return
+        try:
+            for line in Path(path).read_text().splitlines():
+                line = line.strip()
+                if line and not line.startswith("#") and "=" in line:
+                    key, value = line.split("=", 1)
+                    env[key] = value
+        except OSError:
+            logger.debug("CLI env overlay file not found: %s", path)
 
     def _build_env(self) -> dict[str, str]:
         """Build environment variables for the subprocess.
@@ -348,16 +380,7 @@ class ClaudeRunner:
         so that the CLI process cannot read them via Bash tool.
         """
         env = {k: v for k, v in os.environ.items() if k not in self._STRIPPED_ENV_KEYS}
-        overlay_path = os.environ.get("CCDB_CLI_ENV_FILE")
-        if overlay_path:
-            try:
-                for line in Path(overlay_path).read_text().splitlines():
-                    line = line.strip()
-                    if line and not line.startswith("#") and "=" in line:
-                        key, value = line.split("=", 1)
-                        env[key] = value
-            except OSError:
-                logger.debug("CLI env overlay file not found: %s", overlay_path)
+        self._merge_env_file(env, os.environ.get("CCDB_CLI_ENV_FILE"))
         if self.api_port is not None:
             env["CCDB_API_URL"] = f"http://127.0.0.1:{self.api_port}"
         if self.api_secret is not None:

--- a/claude_code_core/zai_runner.py
+++ b/claude_code_core/zai_runner.py
@@ -1,0 +1,45 @@
+"""Z.ai backend implemented through the Anthropic-compatible Claude Code CLI."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from .runner import ClaudeRunner
+
+ZAI_ANTHROPIC_BASE_URL = "https://api.z.ai/api/anthropic"
+
+
+class ZaiRunner(ClaudeRunner):
+    """Claude Code runner isolated to Z.ai credentials and endpoint.
+
+    Z.ai speaks the Anthropic Messages API, so the same Claude Code CLI works
+    unchanged once its environment points at Z.ai. The isolation is the point:
+    a Z.ai thread must never inherit (or fall back to) direct-Anthropic
+    credentials, so the inherited ``ANTHROPIC_API_KEY`` / ``ANTHROPIC_AUTH_TOKEN``
+    are popped before the Z.ai endpoint and credential file are applied.
+    """
+
+    backend_name = "zai"
+
+    def __init__(self, *, env_file: str | None = None, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.env_file = env_file or os.environ.get("CCDB_ZAI_ENV_FILE")
+
+    def _clone_extra_kwargs(self) -> dict[str, Any]:
+        return {"env_file": self.env_file}
+
+    def _build_env(self) -> dict[str, str]:
+        env = super()._build_env()
+
+        # Never reuse credentials intended for the direct Anthropic backend.
+        env.pop("ANTHROPIC_API_KEY", None)
+        env.pop("ANTHROPIC_AUTH_TOKEN", None)
+
+        # Fail toward Z.ai (an auth error when no key is configured), never
+        # silently toward Anthropic. The dedicated file may override the URL
+        # for a regional Z.ai endpoint.
+        env["ANTHROPIC_BASE_URL"] = ZAI_ANTHROPIC_BASE_URL
+        self._merge_env_file(env, self.env_file)
+        env.pop("CCDB_ZAI_ENV_FILE", None)
+        return env

--- a/claude_discord/backend_factory.py
+++ b/claude_discord/backend_factory.py
@@ -28,11 +28,18 @@ logger = logging.getLogger(__name__)
 # here only goes stale as the Codex console default moves.
 DEFAULT_MODEL: dict[str, str | None] = {
     "claude": "sonnet",
+    "zai": "glm-5.2[1m]",
     "codex": None,
     "local": None,
     "agui": None,
 }
-DEFAULT_COMMAND = {"claude": "claude", "codex": "codex", "local": "codex", "agui": "ag-ui"}
+DEFAULT_COMMAND = {
+    "claude": "claude",
+    "zai": "claude",
+    "codex": "codex",
+    "local": "codex",
+    "agui": "ag-ui",
+}
 
 
 class BackendFactory:
@@ -54,6 +61,8 @@ class BackendFactory:
         api_secret: str | None = None,
         agui_url: str | None = None,
         agui_token: str | None = None,
+        zai_env_file: str | None = None,
+        zai_model: str | None = None,
     ) -> None:
         self.claude_command = claude_command or DEFAULT_COMMAND["claude"]
         self.codex_command = codex_command or DEFAULT_COMMAND["codex"]
@@ -68,9 +77,11 @@ class BackendFactory:
         self.api_secret = api_secret
         self.agui_url = agui_url
         self.agui_token = agui_token
+        self.zai_env_file = zai_env_file
+        self.zai_model = zai_model or DEFAULT_MODEL["zai"]
 
     def command_for(self, backend: str) -> str:
-        if backend == "claude":
+        if backend in ("claude", "zai"):
             return self.claude_command
         if backend in ("codex", "local"):
             # The local backend is the same CLI, pointed at a ccdb-owned
@@ -86,6 +97,8 @@ class BackendFactory:
         ``None`` (codex) means "do not pass ``--model``" so the Codex CLI uses
         its own configured default.
         """
+        if backend == "zai":
+            return self.zai_model
         return DEFAULT_MODEL.get(backend, DEFAULT_MODEL["claude"])
 
     def build(
@@ -118,11 +131,14 @@ class BackendFactory:
         # defaults. We deliberately do NOT forward them to Codex: Codex effort
         # is resolved per-backend from BackendSettings at spawn time (and its
         # valid values differ — e.g. Claude's "max" is not a Codex level).
-        if backend == "claude":
+        # Z.ai runs the same Claude Code CLI, so it inherits the same knobs.
+        if backend in {"claude", "zai"}:
             if self.append_system_prompt is not None:
                 kwargs["append_system_prompt"] = self.append_system_prompt
             if self.effort is not None:
                 kwargs["effort"] = self.effort
+        if backend == "zai":
+            kwargs["env_file"] = self.zai_env_file
         if self.api_port is not None:
             kwargs["api_port"] = self.api_port
         if self.api_secret is not None:

--- a/claude_discord/backend_settings.py
+++ b/claude_discord/backend_settings.py
@@ -1,6 +1,6 @@
 """Persistent, runtime-mutable backend/model selection.
 
-Reads and writes the current backend (claude/codex/local/agui) and per-backend
+Reads and writes the current backend (claude/codex/local/agui/zai) and per-backend
 model preference to ``SettingsRepository`` (sqlite key-value store).
 
 Resolution order for any field:
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 # Valid backend names. Keep in sync with claude_code_core.backend.create_backend().
-ALL_BACKENDS = ("claude", "codex", "local", "agui")
+ALL_BACKENDS = ("claude", "codex", "local", "agui", "zai")
 
 # Settings keys
 BACKEND_GLOBAL = "backend.global"
@@ -64,6 +64,7 @@ class BackendSettings:
         env_backend: str,
         env_model_for_claude: str,
         env_model_for_codex: str,
+        env_model_for_zai: str = "",
     ) -> None:
         self.repo = repo
         self._env_backend = env_backend if env_backend in ALL_BACKENDS else "claude"
@@ -75,6 +76,7 @@ class BackendSettings:
             "local": "",
             # AG-UI identifies the model on the remote agent, not in ccdb.
             "agui": "",
+            "zai": env_model_for_zai or "",
         }
 
     # ── Resolution ──────────────────────────────────────────

--- a/claude_discord/cogs/backend_command.py
+++ b/claude_discord/cogs/backend_command.py
@@ -47,6 +47,7 @@ VALID_EFFORTS: dict[str, frozenset[str]] = {
     "claude": frozenset({"low", "medium", "high", "max"}),
     "codex": VALID_CODEX_EFFORTS,
     "local": VALID_CODEX_EFFORTS,  # same CLI, same levels
+    "zai": frozenset({"low", "medium", "high", "max"}),  # Claude Code CLI
 }
 
 # Ordered effort levels per backend for the /effort autocomplete (frozensets are
@@ -55,6 +56,7 @@ EFFORT_ORDER: dict[str, list[str]] = {
     "claude": ["low", "medium", "high", "max"],
     "codex": ["minimal", "low", "medium", "high", "xhigh"],
     "local": ["minimal", "low", "medium", "high", "xhigh"],
+    "zai": ["low", "medium", "high", "max"],
 }
 
 # Suggested model ids per backend for the /model autocomplete. The model field is
@@ -84,6 +86,14 @@ SUGGESTED_MODELS: dict[str, list[tuple[str, str]]] = {
     "local": [
         ("gpt-oss:120b", "gpt-oss 120B (tool use, needs real VRAM)"),
         ("qwen3.5:35b", "Qwen3.5 35B"),
+    ],
+    # Z.ai serves the Anthropic-compatible GLM family. The model id is free-text,
+    # so any id the Z.ai endpoint accepts works even if it is not listed here.
+    "zai": [
+        ("glm-5.2[1m]", "GLM-5.2 with 1M context"),
+        ("glm-5.2", "GLM-5.2"),
+        ("glm-5-turbo", "GLM-5 Turbo"),
+        ("glm-4.7", "GLM-4.7"),
     ],
 }
 
@@ -150,7 +160,7 @@ class BackendCommandCog(commands.Cog):
         ],
     )
     @app_commands.describe(
-        name="claude, codex, local, or agui. Omit to show current setting.",
+        name="claude, codex, local, agui, or zai. Omit to show current setting.",
         scope=(
             "thread: only this thread; global: server-wide default. "
             "Default: thread when invoked in a thread, otherwise global."
@@ -222,9 +232,12 @@ class BackendCommandCog(commands.Cog):
             if resolved_scope == SCOPE_THREAD and target_thread_id is not None
             else "**globally**"
         )
-        emoji = {"codex": "\U0001f300", "local": "\U0001f3e0", "agui": "\U0001f50c"}.get(
-            name, "\U0001f916"
-        )
+        emoji = {
+            "codex": "\U0001f300",
+            "local": "\U0001f3e0",
+            "agui": "\U0001f50c",
+            "zai": "\U0001f7e3",
+        }.get(name, "\U0001f916")
         await interaction.response.send_message(
             f"{emoji} Backend set to `{name}` {scope_label}. Next session will use it.",
             ephemeral=False,

--- a/claude_discord/cogs/event_processor.py
+++ b/claude_discord/cogs/event_processor.py
@@ -48,12 +48,18 @@ logger = logging.getLogger(__name__)
 
 
 def _backend_name_from_runner(runner: object) -> str:
-    """Best-effort mapping from runner class name to embed backend tag."""
+    """Best-effort mapping from runner class to embed backend tag."""
     cls = type(runner).__name__
     if cls == "AnonymizingBackend":
         inner = getattr(runner, "inner", None)
         if inner is not None and inner is not runner:
             return _backend_name_from_runner(inner)
+    # Prefer the runner's declared ``backend_name`` (ClaudeRunner and ZaiRunner
+    # set it as a class attribute) over class-name matching, so a subclass is
+    # identified by which endpoint it targets rather than by its class name.
+    declared = getattr(runner, "backend_name", None)
+    if declared in {"claude", "codex", "local", "agui", "zai"}:
+        return declared
     # LocalCodexRunner subclasses CodexRunner, so it has to be matched first.
     if cls == "LocalCodexRunner":
         return "local"
@@ -1120,7 +1126,7 @@ async def _post_engine_status_footer(
     # Render the Claude statusLine on Claude turns, or whenever the Codex line
     # is being shown (so both engines appear together). On non-Claude turns the
     # session model id is not a Claude model, so suppress the model label.
-    render_claude_sl = backend == "claude" or codex_line is not None
+    render_claude_sl = backend in {"claude", "zai"} or codex_line is not None
     statusline_text: str | None = None
     if render_claude_sl:
         statusline_text = await _render_claude_statusline_text(

--- a/claude_discord/discord_ui/embeds.py
+++ b/claude_discord/discord_ui/embeds.py
@@ -24,11 +24,13 @@ _BACKEND_TITLE: dict[str, str] = {
     "claude": "\U0001f916 Claude Code",  # robot face 🤖
     "codex": "\U0001f300 OpenAI Codex",  # cyclone 🌀
     "local": "\U0001f3e0 Local model",  # house 🏠
+    "zai": "\U0001f7e3 Z.ai GLM",  # purple circle 🟣
 }
 _BACKEND_COLOR_START: dict[str, int] = {
     "claude": COLOR_INFO,  # Discord blurple
     "codex": 0x10A37F,  # OpenAI teal-green
     "local": 0x6B8E23,  # olive — "stays on your hardware"
+    "zai": 0x6D5DFB,  # Z.ai purple
 }
 
 

--- a/claude_discord/discord_ui/thread_renamer.py
+++ b/claude_discord/discord_ui/thread_renamer.py
@@ -97,12 +97,19 @@ async def suggest_title(
 
     prompt = _PROMPT_TEMPLATE.format(text=user_message[:2000])
 
+    # The default ``haiku`` is an Anthropic alias the Z.ai endpoint does not
+    # serve, so a title call against a Z.ai-configured env would 404. Detect
+    # the endpoint the same way api_provider does and pick a model it serves.
+    title_model = "haiku"
+    if env and "api.z.ai" in (env.get("ANTHROPIC_BASE_URL") or ""):
+        title_model = "glm-4.7"
+
     try:
         proc = await asyncio.create_subprocess_exec(
             claude_command,
             "-p",
             "--model",
-            "haiku",
+            title_model,
             prompt,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,

--- a/claude_discord/main.py
+++ b/claude_discord/main.py
@@ -48,8 +48,12 @@ def load_config() -> dict[str, str]:
     frontends = parse_frontends(os.getenv("CCDB_FRONTENDS", ""))
     # Default model is backend-specific: Claude needs an explicit alias
     # ("sonnet"), but Codex defers to its own config.toml default when left
-    # empty (so we never pin a stale Codex model version).
-    default_model = "sonnet" if backend == "claude" else ""
+    # empty (so we never pin a stale Codex model version). Z.ai uses its own
+    # model setting and must never inherit CLAUDE_MODEL.
+    if backend == "zai":
+        default_model = os.getenv("CCDB_MODEL") or os.getenv("CCDB_ZAI_MODEL", "glm-5.2[1m]")
+    else:
+        default_model = "sonnet" if backend == "claude" else ""
 
     return {
         "token": token,
@@ -63,6 +67,8 @@ def load_config() -> dict[str, str]:
         "codex_command": os.getenv("CCDB_CODEX_COMMAND", ""),
         "agui_url": os.getenv("CCDB_AGUI_URL", ""),
         "agui_token": os.getenv("CCDB_AGUI_TOKEN", ""),
+        "zai_env_file": os.getenv("CCDB_ZAI_ENV_FILE", ""),
+        "zai_model": os.getenv("CCDB_ZAI_MODEL", "glm-5.2[1m]"),
         "model": _env("CCDB_MODEL", "CLAUDE_MODEL", default_model),
         "permission_mode": _env("CCDB_PERMISSION_MODE", "CLAUDE_PERMISSION_MODE", "acceptEdits"),
         "working_dir": _env("CCDB_WORKING_DIR", "CLAUDE_WORKING_DIR", ""),
@@ -107,15 +113,15 @@ async def main() -> None:
     if config["allowed_tools"]:
         allowed_tools = [t.strip() for t in config["allowed_tools"].split(",") if t.strip()] or None
 
-    # Create runner via backend factory (CCDB_BACKEND=claude|codex)
+    # Create runner via backend factory (CCDB_BACKEND=claude|codex|zai)
     backend_name = config["backend"]
-    # BackendFactory is the runtime authority for building Claude/Codex
+    # BackendFactory is the runtime authority for building Claude/Codex/Z.ai
     # runners on demand (e.g. when the user switches via /backend).
     from .backend_factory import BackendFactory
 
     factory = BackendFactory(
         claude_command=config["claude_command"]
-        or (config["command"] if backend_name == "claude" else "")
+        or (config["command"] if backend_name in {"claude", "zai"} else "")
         or "claude",
         codex_command=config["codex_command"]
         or (config["command"] if backend_name == "codex" else "")
@@ -130,6 +136,8 @@ async def main() -> None:
         effort=config["effort"] or None,
         agui_url=config["agui_url"] or None,
         agui_token=config["agui_token"] or None,
+        zai_env_file=config["zai_env_file"] or None,
+        zai_model=config["zai_model"] or None,
     )
 
     runner = factory.build(backend=backend_name, model=config["model"] or None)

--- a/claude_discord/setup.py
+++ b/claude_discord/setup.py
@@ -366,12 +366,17 @@ async def setup_bridge(
     if backend_factory is not None:
         from .backend_settings import BackendSettings
 
-        _runner_class = runner.__class__.__name__
+        _runner_backend = getattr(
+            runner,
+            "backend_name",
+            runner.__class__.__name__.replace("Runner", "").lower(),
+        )
         backend_settings = BackendSettings(
             settings_repo,
-            env_backend=_runner_class.replace("Runner", "").lower(),
-            env_model_for_claude=(runner.model if _runner_class == "ClaudeRunner" else ""),
-            env_model_for_codex=(runner.model if _runner_class == "CodexRunner" else ""),
+            env_backend=_runner_backend,
+            env_model_for_claude=(runner.model if _runner_backend == "claude" else ""),
+            env_model_for_codex=(runner.model if _runner_backend == "codex" else ""),
+            env_model_for_zai=(runner.model if _runner_backend == "zai" else ""),
         )
 
     chat_cog = ClaudeChatCog(

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -116,12 +116,21 @@ Extraction never destroys the upload it came from. The original is deleted only 
 ### Stripped Environment Variables (runner.py)
 
 ```python
-_STRIPPED_ENV_KEYS = frozenset({
-    "CLAUDECODE",           # Nesting detection
-    "DISCORD_BOT_TOKEN",    # Bot authentication
-    "DISCORD_TOKEN",        # Alternative token var
-    "API_SECRET_KEY",       # API authentication
-})
+_STRIPPED_ENV_KEYS = frozenset(
+    {
+        "CLAUDECODE",  # Nesting detection
+        "DISCORD_BOT_TOKEN",  # Bot authentication
+        "DISCORD_TOKEN",  # Alternative token var
+        "API_SECRET_KEY",  # API authentication
+        "CCDB_AGUI_URL",  # AG-UI run endpoint
+        "CCDB_AGUI_TOKEN",  # AG-UI bearer token
+        "CCDB_TEAMS_APP_PASSWORD",  # Teams bot credential
+        "CCDB_TEAMS_QUEUE_URL",  # Teams relay queue connection string
+        "CCDB_API_URL",  # Re-added per session, scoped to this subprocess's own API port
+        "CCDB_API_SECRET",  # Re-added per session alongside CCDB_API_URL
+        "CCDB_ZAI_ENV_FILE",  # Path to the Z.ai credential file; consumed, never forwarded
+    }
+)
 ```
 
 These variables are removed from the subprocess environment before spawning Claude Code:
@@ -129,10 +138,24 @@ These variables are removed from the subprocess environment before spawning Clau
 1. **DISCORD_BOT_TOKEN / DISCORD_TOKEN**: Prevents Claude Code from reading the Discord token via its Bash tool
 2. **CLAUDECODE**: Claude Code uses this to detect nesting. Stripping it ensures the subprocess runs as a fresh top-level instance
 3. **API_SECRET_KEY**: If the host bot exposes a REST API, this key shouldn't leak to Claude
+4. **CCDB_AGUI_URL / CCDB_AGUI_TOKEN**: The remote AG-UI endpoint and its bearer token are ccdb's own routing config, not something a Claude/Codex session's Bash tool should be able to read or reuse
+5. **CCDB_TEAMS_APP_PASSWORD / CCDB_TEAMS_QUEUE_URL**: Same reasoning for the Teams frontend's bot credential and relay queue connection string
+6. **CCDB_API_URL / CCDB_API_SECRET**: Stripped from the inherited environment, then set explicitly per session scoped to that session's own local API port — a session never receives another session's API credential
+7. **CCDB_ZAI_ENV_FILE**: The *path* to the Z.ai credential file must not reach the CLI's Bash tool; `ZaiRunner` reads the file, merges its contents into the subprocess environment, then pops the path itself before spawning
+
+### Z.ai credential isolation (zai_runner.py)
+
+A Z.ai thread runs the same Claude Code CLI as the `claude` backend, so `ZaiRunner` cannot rely on
+a different binary to keep the two credential sets apart. Instead, before applying the Z.ai
+credential file it pops `ANTHROPIC_API_KEY` and `ANTHROPIC_AUTH_TOKEN` from the subprocess
+environment — the two variables the direct-Anthropic backend passes through (see below) — so a
+Z.ai session can never inherit, or silently fall back to, direct Anthropic credentials. Losing the
+Z.ai credential file therefore fails as an auth error against Z.ai, not as a quiet switch to
+Anthropic billing.
 
 ### What's NOT Stripped
 
-General environment variables (PATH, HOME, ANTHROPIC_API_KEY, etc.) are passed through because Claude Code needs them to function. The `ANTHROPIC_API_KEY` is intentionally available — Claude Code uses it for API calls. If you need to restrict which API key Claude Code uses, configure it via Claude Code's own settings, not this bridge.
+General environment variables (PATH, HOME, ANTHROPIC_API_KEY, etc.) are passed through because Claude Code needs them to function. The `ANTHROPIC_API_KEY` is intentionally available — Claude Code uses it for API calls. If you need to restrict which API key Claude Code uses, configure it via Claude Code's own settings, not this bridge. The Z.ai backend is the one exception: it strips `ANTHROPIC_API_KEY` / `ANTHROPIC_AUTH_TOKEN` for its own threads only (see above).
 
 ## Authorization Model
 

--- a/docs/backends.md
+++ b/docs/backends.md
@@ -11,10 +11,11 @@ Teams app.
 |---|---|---|---|
 | Claude Code | local `claude` CLI | the CLI's existing login | Claude-native coding workflows |
 | OpenAI Codex | local `codex` CLI | the CLI's existing login | Codex coding and review workflows |
+| Z.ai | local `claude` CLI, pointed at Z.ai's Anthropic-compatible endpoint | a dedicated Z.ai credential file | GLM models through the same CLI, without touching direct Anthropic credentials |
 | Local | local `codex` CLI to an OpenAI-compatible `/v1/responses` endpoint | none by default | data that should stay on a controlled network |
 | AG-UI | HTTP request plus JSON server-sent events | optional bearer token | custom and hosted agents that implement AG-UI |
 
-All four work from both Discord and Microsoft Teams. The frontend controls message rendering,
+All five work from both Discord and Microsoft Teams. The frontend controls message rendering,
 buttons, files, and rate limits; the backend controls model execution and streamed events.
 
 ## Select a backend
@@ -30,6 +31,7 @@ On Discord, switch an individual conversation without restarting:
 ```text
 /backend claude
 /backend codex
+/backend zai
 /backend local
 /backend agui
 ```
@@ -56,6 +58,25 @@ ccdb start
 
 The default backend remains `claude`, so upgrading an existing deployment does not change which
 agent receives the next turn.
+
+## Z.ai
+
+Z.ai serves the Anthropic Messages API, so the same Claude Code CLI runs against it unchanged once
+the subprocess environment points at Z.ai — no separate CLI, no code changes.
+
+```dotenv
+CCDB_ZAI_ENV_FILE=/home/you/.ccdb/zai.env
+CCDB_ZAI_MODEL=glm-5.2
+```
+
+`CCDB_ZAI_ENV_FILE` is a dedicated `KEY=VALUE` file holding the Z.ai credentials
+(`ANTHROPIC_AUTH_TOKEN` and, if your account needs it, a regional `ANTHROPIC_BASE_URL`). Keep it
+separate from any file used by `CCDB_CLI_ENV_FILE`: before applying it, ccdb pops
+`ANTHROPIC_API_KEY` and `ANTHROPIC_AUTH_TOKEN` from the subprocess environment, so a Z.ai thread
+never inherits — or silently falls back to — direct Anthropic credentials. Title-suggestion calls
+pick a GLM model rather than an Anthropic alias, since Z.ai does not serve `haiku`.
+
+Then set `CCDB_BACKEND=zai`, or enter `/backend zai` in Discord.
 
 ## Local
 
@@ -99,7 +120,8 @@ Discord can set per-conversation overrides; Teams consumes the configured/global
 deployment can therefore run, for example:
 
 - a Discord thread on Claude Code;
-- another Discord thread on a local model;
+- another Discord thread on Z.ai's GLM models;
+- a third Discord thread on a local model;
 - Teams conversations on the configured Codex default; or
 - Teams conversations on an internal AG-UI agent when AG-UI is the configured/global backend.
 
@@ -110,7 +132,7 @@ posted into a Discord thread with a numerically similar key.
 ## Security boundary
 
 Every selected backend receives that conversation's prompts and attachments. Treat a remote AG-UI
-endpoint or local model host as part of the data-processing path. A customer-tenant Teams app does
+endpoint, Z.ai, or local model host as part of the data-processing path. A customer-tenant Teams app does
 not by itself keep data inside that tenant: messages still travel through Bot Framework, the public
 receiver, the queue, the private session host, and the selected backend. Deploy the complete stack
 inside the required boundary when the contract requires that literal property.

--- a/tests/test_api_provider.py
+++ b/tests/test_api_provider.py
@@ -76,3 +76,8 @@ def test_truthy_variations() -> None:
 def test_falsy_flag_is_direct() -> None:
     for val in ("0", "false", "", "no"):
         assert detect_api_provider({"CLAUDE_CODE_USE_BEDROCK": val}) == ("Anthropic API (direct)")
+
+
+def test_zai_base_url_has_provider_label() -> None:
+    env = {"ANTHROPIC_BASE_URL": "https://api.z.ai/api/anthropic"}
+    assert detect_api_provider(env) == "Z.ai"

--- a/tests/test_backend_factory_api_port.py
+++ b/tests/test_backend_factory_api_port.py
@@ -69,3 +69,41 @@ class TestFactoryApiPort:
         assert runner.api_port == 8099
         env = runner._build_env()
         assert env["CCDB_API_URL"] == "http://127.0.0.1:8099"
+
+
+class TestZaiBackendFactory:
+    """Z.ai runs the Claude Code CLI against the Z.ai endpoint."""
+
+    def test_zai_backend_uses_claude_command_and_dedicated_env(self, tmp_path) -> None:
+        from claude_code_core.zai_runner import ZaiRunner
+
+        env_file = tmp_path / "zai.env"
+        factory = _factory(
+            zai_env_file=str(env_file),
+            zai_model="glm-5.2[1m]",
+        )
+        runner = factory.build(backend="zai")
+        assert isinstance(runner, ZaiRunner)
+        assert runner.model == "glm-5.2[1m]"
+        assert runner.env_file == str(env_file)
+        assert runner.command == "claude"  # reuses the Claude CLI binary
+
+    def test_zai_default_model_when_none_configured(self) -> None:
+        from claude_code_core.zai_runner import ZaiRunner
+
+        factory = _factory()
+        runner = factory.build(backend="zai")
+        assert isinstance(runner, ZaiRunner)
+        # The factory ships a sensible GLM default.
+        assert runner.model == "glm-5.2[1m]"
+
+    def test_zai_clone_preserves_env_file(self, tmp_path) -> None:
+        from claude_code_core.zai_runner import ZaiRunner
+
+        env_file = tmp_path / "zai.env"
+        factory = _factory(zai_env_file=str(env_file), zai_model="glm-5.2[1m]")
+        runner = factory.build(backend="zai", thread_id=1)
+        cloned = runner.clone(thread_id=2)
+        assert isinstance(cloned, ZaiRunner)
+        assert cloned.env_file == str(env_file)
+        assert cloned.thread_id == 2

--- a/tests/test_backend_protocol.py
+++ b/tests/test_backend_protocol.py
@@ -64,6 +64,12 @@ class TestCreateBackend:
         )
         assert isinstance(backend, AgUiBackend)
 
+    def test_zai_backend(self) -> None:
+        from claude_code_core.zai_runner import ZaiRunner
+
+        backend = create_backend(backend="zai", model="glm-5.2[1m]")
+        assert isinstance(backend, ZaiRunner)
+
     def test_unknown_backend_raises(self) -> None:
         with pytest.raises(ValueError, match="Unknown backend"):
             create_backend(backend="unknown", model="sonnet")

--- a/tests/test_backend_settings.py
+++ b/tests/test_backend_settings.py
@@ -9,9 +9,11 @@ import aiosqlite
 import pytest
 
 from claude_discord.backend_settings import (
+    ALL_BACKENDS,
     BACKEND_GLOBAL,
     CODEX_STATUS_GLOBAL,
     BackendSettings,
+    session_is_resumable,
 )
 from claude_discord.database.settings_repo import SettingsRepository
 
@@ -227,3 +229,47 @@ class TestEffort:
         s = await self._settings()
         with pytest.raises(ValueError):
             await s.set_effort("gpt4", "high")  # type: ignore[arg-type]
+
+
+class TestZaiBackend:
+    """Z.ai is a first-class backend alongside claude/codex/local/agui."""
+
+    async def _settings(self) -> BackendSettings:
+        repo, _ = await _new_repo()
+        return BackendSettings(
+            repo,
+            env_backend="claude",
+            env_model_for_claude="sonnet",
+            env_model_for_codex="",
+            env_model_for_zai="glm-5.2[1m]",
+        )
+
+    def test_zai_is_a_supported_backend(self) -> None:
+        assert "zai" in ALL_BACKENDS
+
+    def test_zai_and_claude_sessions_are_not_interchangeable(self) -> None:
+        # Z.ai keeps its own Claude Code session store under separate
+        # credentials, so a claude session id cannot resume on zai (or vice versa).
+        assert session_is_resumable("claude", "zai") is False
+        assert session_is_resumable("zai", "claude") is False
+        assert session_is_resumable("zai", "zai") is True
+
+    async def test_zai_backend_and_model_are_independent(self) -> None:
+        s = await self._settings()
+        await s.set_backend("zai")
+        await s.set_model("zai", "glm-4.7")
+        assert await s.current_backend() == "zai"
+        assert await s.current_model("zai") == "glm-4.7"
+        # Switching backend must not leak the Z.ai model into claude.
+        assert await s.current_model("claude") == "sonnet"
+
+    async def test_env_model_for_zai_is_optional(self) -> None:
+        """Old call sites that omit env_model_for_zai still construct cleanly."""
+        repo, _ = await _new_repo()
+        s = BackendSettings(
+            repo,
+            env_backend="claude",
+            env_model_for_claude="sonnet",
+            env_model_for_codex="",
+        )
+        assert await s.current_model("zai") is None

--- a/tests/test_build_runner_for_thread.py
+++ b/tests/test_build_runner_for_thread.py
@@ -365,3 +365,60 @@ class TestBuildRunnerPerBackendEffort:
         )
         assert isinstance(runner, ClaudeRunner)
         assert runner.effort == "high"
+
+
+class TestBuildRunnerZaiBackend:
+    """Z.ai is selectable per-thread and yields an isolated ZaiRunner."""
+
+    async def test_thread_override_zai_returns_isolated_zai_runner(self, tmp_path: Path) -> None:
+        from claude_code_core.zai_runner import ZaiRunner
+
+        repo = await _new_settings_repo()
+        settings = BackendSettings(
+            repo,
+            env_backend="claude",
+            env_model_for_claude="sonnet",
+            env_model_for_codex="",
+            env_model_for_zai="glm-5.2[1m]",
+        )
+        await settings.set_backend("zai", thread_id=100)
+        env_file = tmp_path / "zai.env"
+        factory = _factory()
+        factory.zai_env_file = str(env_file)
+        cog = _cog(factory=factory, settings=settings)
+        runner = await cog._build_runner_for_thread(
+            thread_id=100,
+            model_override=None,
+            tools_override=None,
+            fork_session=False,
+            working_dir_override=None,
+            effort_override=None,
+        )
+        assert isinstance(runner, ZaiRunner)
+        assert runner.model == "glm-5.2[1m]"
+        assert runner.env_file == str(env_file)
+
+    async def test_legacy_model_override_does_not_leak_to_zai(self) -> None:
+        """A Claude /model-set leftover must not leak into a Z.ai spawn."""
+        from claude_code_core.zai_runner import ZaiRunner
+
+        repo = await _new_settings_repo()
+        settings = BackendSettings(
+            repo,
+            env_backend="claude",
+            env_model_for_claude="sonnet",
+            env_model_for_codex="",
+            env_model_for_zai="glm-5.2[1m]",
+        )
+        await settings.set_backend("zai", thread_id=8)
+        cog = _cog(factory=_factory(), settings=settings)
+        runner = await cog._build_runner_for_thread(
+            thread_id=8,
+            model_override="opus",  # Claude leftover — must be ignored
+            tools_override=None,
+            fork_session=False,
+            working_dir_override=None,
+            effort_override=None,
+        )
+        assert isinstance(runner, ZaiRunner)
+        assert runner.model == "glm-5.2[1m]"

--- a/tests/test_describe_api.py
+++ b/tests/test_describe_api.py
@@ -83,3 +83,17 @@ class TestCodexDescribeApi:
             assert label.startswith("Custom endpoint")
         finally:
             _restore(saved)
+
+
+class TestZaiDescribeApi:
+    def test_identifies_zai_from_cli_env_overlay(self, tmp_path: Path) -> None:
+        saved = _clear()
+        overlay = tmp_path / "zai.env"
+        overlay.write_text(
+            "ANTHROPIC_AUTH_TOKEN=test-key\nANTHROPIC_BASE_URL=https://api.z.ai/api/anthropic\n"
+        )
+        os.environ["CCDB_CLI_ENV_FILE"] = str(overlay)
+        try:
+            assert ClaudeRunner().describe_api() == "Z.ai"
+        finally:
+            _restore(saved)

--- a/tests/test_embeds.py
+++ b/tests/test_embeds.py
@@ -406,3 +406,23 @@ class TestToolResultPreviewEmbed:
         embed = tool_result_preview_embed("🔧 Running: cat...", "output")
         assert embed.title is not None
         assert not embed.title.endswith(".")
+
+
+class TestSessionStartEmbedBackend:
+    """The session-start embed reflects which backend a turn runs on."""
+
+    def test_zai_uses_distinct_title_and_color(self) -> None:
+        from claude_discord.discord_ui.embeds import session_start_embed
+
+        embed = session_start_embed(backend="zai", model="glm-5.2[1m]")
+        assert embed.title is not None
+        assert "Z.ai" in embed.title
+        assert embed.colour.value == 0x6D5DFB  # Z.ai purple
+
+    def test_zai_distinct_from_claude(self) -> None:
+        from claude_discord.discord_ui.embeds import session_start_embed
+
+        zai = session_start_embed(backend="zai", model="glm-5.2[1m]")
+        claude = session_start_embed(backend="claude", model="sonnet")
+        assert zai.colour.value != claude.colour.value
+        assert zai.title != claude.title

--- a/tests/test_engine_status_footer.py
+++ b/tests/test_engine_status_footer.py
@@ -115,3 +115,13 @@ class TestGating:
                 thread_id=1,
             )
         assert thread.send.await_count == 0
+
+
+class TestZaiStatusLine:
+    """Z.ai runs the Claude Code CLI, so it shares Claude's statusline rendering."""
+
+    async def test_zai_turn_renders_claude_statusline(self) -> None:
+        """Z.ai gets the claude statusline (render_claude_sl is True for zai)."""
+        body = await _run(backend="zai", mode="off", codex_line=None, statusline="Ctx 1%")
+        assert body is not None
+        assert "Ctx 1%" in body

--- a/tests/test_event_processor.py
+++ b/tests/test_event_processor.py
@@ -98,6 +98,17 @@ def test_backend_name_does_not_unwrap_arbitrary_mock_attributes() -> None:
     assert _backend_name_from_runner(MagicMock()) == "claude"
 
 
+def test_backend_name_prefers_declared_zai_backend_name() -> None:
+    """A runner that declares backend_name='zai' is identified as zai, not claude."""
+    from claude_code_core.zai_runner import ZaiRunner
+
+    class ZaiLikeRunner:
+        backend_name = "zai"
+
+    assert _backend_name_from_runner(ZaiLikeRunner()) == "zai"
+    assert _backend_name_from_runner(ZaiRunner(model="glm-5.2[1m]")) == "zai"
+
+
 class TestEventProcessorProperties:
     """Initial state and property behaviour."""
 

--- a/tests/test_main_backend.py
+++ b/tests/test_main_backend.py
@@ -51,7 +51,15 @@ class TestEnvVarRename:
         from claude_discord.main import load_config
 
         merged = {**self._REQUIRED, **env}
-        with patch.dict("os.environ", merged, clear=True):
+        # load_config() calls load_dotenv(find_dotenv(usecwd=True)) internally,
+        # which walks up from the real cwd and would silently repopulate
+        # os.environ from an actual .env file (e.g. a live deployment's own
+        # config) even though clear=True just wiped it — patch.dict only
+        # controls the *starting* snapshot, not writes made during the block.
+        with (
+            patch.dict("os.environ", merged, clear=True),
+            patch("claude_discord.main.load_dotenv"),
+        ):
             return load_config()
 
     def test_ccdb_model_takes_precedence(self) -> None:

--- a/tests/test_main_backend.py
+++ b/tests/test_main_backend.py
@@ -34,6 +34,13 @@ class TestCreateBackendFromEnv:
         assert isinstance(backend, ClaudeRunner)
         assert backend.working_dir == "/tmp"
 
+    def test_zai_backend(self) -> None:
+        from claude_code_core.zai_runner import ZaiRunner
+
+        backend = create_backend(backend="zai", model="glm-5.2[1m]")
+        assert isinstance(backend, ZaiRunner)
+        assert backend.model == "glm-5.2[1m]"
+
 
 class TestEnvVarRename:
     """Verify CCDB_* env vars with CLAUDE_* fallbacks in load_config()."""
@@ -82,3 +89,20 @@ class TestEnvVarRename:
     def test_ccdb_backend_env(self) -> None:
         config = self._load({"CCDB_BACKEND": "codex"})
         assert config["backend"] == "codex"
+
+    def test_zai_backend_env_and_model(self) -> None:
+        config = self._load({"CCDB_BACKEND": "zai"})
+        assert config["backend"] == "zai"
+        # Z.ai has its own model setting, decoupled from CLAUDE_MODEL.
+        assert config["zai_model"] == "glm-5.2[1m]"
+        assert config["zai_env_file"] == ""
+
+    def test_zai_model_env_override(self) -> None:
+        config = self._load({"CCDB_BACKEND": "zai", "CCDB_ZAI_MODEL": "glm-4.7"})
+        assert config["zai_model"] == "glm-4.7"
+        # The default_model resolution for zai reads CCDB_ZAI_MODEL.
+        assert config["model"] == "glm-4.7"
+
+    def test_zai_env_file_configured(self) -> None:
+        config = self._load({"CCDB_ZAI_ENV_FILE": "/etc/ccdb/zai.env"})
+        assert config["zai_env_file"] == "/etc/ccdb/zai.env"

--- a/tests/test_thread_renamer.py
+++ b/tests/test_thread_renamer.py
@@ -323,3 +323,36 @@ class TestSuggestTitleErrors:
             result = await suggest_title("some request")
         assert result is None
         proc.kill.assert_called_once()
+
+
+class TestSuggestTitleZaiEnv:
+    """When the env points at Z.ai, the title call uses a Z.ai-served model.
+
+    The default ``haiku`` is an Anthropic alias the Z.ai endpoint does not
+    serve, so a title call would 404. suggest_title detects Z.ai from the env
+    and switches to a GLM model for the one-shot title generation.
+    """
+
+    @pytest.mark.asyncio
+    async def test_zai_env_uses_glm_model(self):
+        proc = _make_proc(b"Z.ai title\n")
+        zai_env = {
+            "ANTHROPIC_BASE_URL": "https://api.z.ai/api/anthropic",
+            "PATH": "/usr/bin",
+        }
+        with patch("asyncio.create_subprocess_exec", return_value=proc) as mock_exec:
+            await suggest_title("some request", env=zai_env)
+        args = mock_exec.call_args[0]
+        assert "--model" in args
+        model_idx = args.index("--model")
+        assert args[model_idx + 1] == "glm-4.7"
+
+    @pytest.mark.asyncio
+    async def test_non_zai_env_still_uses_haiku(self):
+        proc = _make_proc(b"Anthropic title\n")
+        anthropic_env = {"ANTHROPIC_BASE_URL": "https://api.anthropic.com", "PATH": "/usr/bin"}
+        with patch("asyncio.create_subprocess_exec", return_value=proc) as mock_exec:
+            await suggest_title("some request", env=anthropic_env)
+        args = mock_exec.call_args[0]
+        model_idx = args.index("--model")
+        assert args[model_idx + 1] == "haiku"

--- a/tests/test_zai_runner.py
+++ b/tests/test_zai_runner.py
@@ -1,0 +1,83 @@
+"""Tests for the Z.ai backend's provider-specific Claude Code environment."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from claude_code_core.runner import ClaudeRunner
+from claude_code_core.zai_runner import ZAI_ANTHROPIC_BASE_URL, ZaiRunner
+
+
+def test_zai_env_file_does_not_affect_claude(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    env_file = tmp_path / "zai.env"
+    env_file.write_text(
+        "ANTHROPIC_AUTH_TOKEN=zai-secret\nANTHROPIC_BASE_URL=https://api.z.ai/api/anthropic\n"
+    )
+    monkeypatch.setenv("CCDB_ZAI_ENV_FILE", str(env_file))
+    monkeypatch.delenv("ANTHROPIC_AUTH_TOKEN", raising=False)
+    monkeypatch.delenv("ANTHROPIC_BASE_URL", raising=False)
+
+    zai_env = ZaiRunner(model="glm-5.2[1m]")._build_env()
+    claude_env = ClaudeRunner(model="sonnet")._build_env()
+
+    assert zai_env["ANTHROPIC_AUTH_TOKEN"] == "zai-secret"
+    assert zai_env["ANTHROPIC_BASE_URL"] == ZAI_ANTHROPIC_BASE_URL
+    assert "ANTHROPIC_AUTH_TOKEN" not in claude_env
+    assert "ANTHROPIC_BASE_URL" not in claude_env
+    assert "CCDB_ZAI_ENV_FILE" not in zai_env
+    assert "CCDB_ZAI_ENV_FILE" not in claude_env
+
+
+def test_zai_never_reuses_inherited_anthropic_credentials(monkeypatch) -> None:
+    monkeypatch.delenv("CCDB_ZAI_ENV_FILE", raising=False)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "anthropic-api-key")
+    monkeypatch.setenv("ANTHROPIC_AUTH_TOKEN", "anthropic-auth-token")
+
+    env = ZaiRunner(model="glm-5.2[1m]")._build_env()
+
+    assert env["ANTHROPIC_BASE_URL"] == ZAI_ANTHROPIC_BASE_URL
+    assert "ANTHROPIC_API_KEY" not in env
+    assert "ANTHROPIC_AUTH_TOKEN" not in env
+
+
+def test_explicit_env_file_overrides_process_setting(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    process_file = tmp_path / "process.env"
+    process_file.write_text("ANTHROPIC_AUTH_TOKEN=wrong\n")
+    explicit_file = tmp_path / "explicit.env"
+    explicit_file.write_text("ANTHROPIC_AUTH_TOKEN=right\n")
+    monkeypatch.setenv("CCDB_ZAI_ENV_FILE", str(process_file))
+
+    env = ZaiRunner(model="glm-5.2[1m]", env_file=str(explicit_file))._build_env()
+
+    assert env["ANTHROPIC_AUTH_TOKEN"] == "right"
+
+
+def test_clone_preserves_zai_backend_and_env_file(tmp_path: Path) -> None:
+    env_file = tmp_path / "zai.env"
+    runner = ZaiRunner(model="glm-5.2[1m]", env_file=str(env_file), thread_id=1)
+
+    cloned = runner.clone(thread_id=2, model="glm-4.7")
+
+    assert isinstance(cloned, ZaiRunner)
+    assert cloned.env_file == str(env_file)
+    assert cloned.thread_id == 2
+    assert cloned.model == "glm-4.7"
+
+
+def test_describe_api_is_zai_without_env_file(monkeypatch) -> None:
+    monkeypatch.delenv("CCDB_ZAI_ENV_FILE", raising=False)
+
+    assert ZaiRunner(model="glm-5.2[1m]").describe_api() == "Z.ai"
+
+
+def test_zai_runner_declares_zai_backend_name() -> None:
+    """ZaiRunner must identify itself as 'zai' so settings/embeds route it correctly."""
+    assert ZaiRunner(model="glm-5.2[1m]").backend_name == "zai"
+    # The base runner stays 'claude' — the override is opt-in per subclass.
+    assert ClaudeRunner(model="sonnet").backend_name == "claude"


### PR DESCRIPTION
## What

Adds **Z.ai** as a first-class CLI backend — the fifth, alongside `claude` / `codex` / `local` / `agui`. Select it with `/backend zai` or `CCDB_BACKEND=zai`.

## Why

Z.ai serves the Anthropic Messages API, so the same Claude Code CLI works against it once the subprocess env points at Z.ai. A deployment can run GLM models from Discord with no code changes — `/backend zai`, and the next session uses Z.ai.

## How

- **`ZaiRunner`** subclasses `ClaudeRunner` with one job: isolation. A Z.ai thread never inherits (or falls back to) direct-Anthropic credentials — `ANTHROPIC_API_KEY` / `ANTHROPIC_AUTH_TOKEN` are popped before the Z.ai endpoint and a dedicated credential file (`CCDB_ZAI_ENV_FILE`) are applied.
- **Base runner hooks** (so the subclass needs no copy-paste): a `backend_name` class attribute, `_clone_extra_kwargs()` so `clone()` preserves subclass state, and `_merge_env_file()` factored out of the `CCDB_CLI_ENV_FILE` overlay so the Z.ai credential file reuses the same parse-once-never-log-values path.
- **Detection**: `describe_api()` recognises `api.z.ai` as `"Z.ai"`; the session embed, status line and `/backend` emoji surface the Z.ai backend distinctly.
- **Title renamer**: picks a GLM model for Z.ai-configured envs (`haiku` is an Anthropic alias Z.ai does not serve, so a title call would 404).

## Zero-config

Existing deployments change nothing. `env_model_for_zai` defaults to `""`; `zai_env_file` / `zai_model` default to `None`; `ALL_BACKENDS` grows by one entry. No consumer wiring required.

## Compatibility

Based on **v4.0.0** (`01e3f6b`). The v3.4→v4.0 Teams frontend work is untouched — Teams env passthrough (`CCDB_TEAMS_APP_PASSWORD`, `CCDB_TEAMS_QUEUE_URL`) coexists with `CCDB_ZAI_ENV_FILE` in `runner._build_env`.

## Security

No change to subprocess spawning (still `create_subprocess_exec`, no shell), session-id validation, or the `--` separator. `CCDB_ZAI_ENV_FILE` is added to the stripped-env keys so the credential-file path does not reach the CLI's Bash tool. Env-file values are still never logged.

## Verification

- `uv run pytest` → **2564 passed** (baseline incl. Teams + 12 new/extended Z.ai test files)
- `uv run ruff check` / `ruff format --check` → clean
- `uv run pyright` → 0 errors

## Docs

README, `docs/backends.md`, and `docs/SECURITY.md` had no mention of the Z.ai backend at all.
Added: the fifth backend in the frontend×backend table and `/backend`/env-var references, a
`## Z.ai` section in `docs/backends.md` mirroring the existing Local/AG-UI sections, and brought
`docs/SECURITY.md`'s `_STRIPPED_ENV_KEYS` snippet back in sync with `runner.py` (it was also
missing the AG-UI, Teams, and per-session API keys, unrelated to Z.ai but stale regardless).
