### PR TITLE
fix: finalize Teams session cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Teams session cards now leave the running state when a turn ends** — teardown removes and
+  unregisters the Stop action, then flushes the final card repaint so the completed or error status
+  is visible immediately instead of leaving a stale working card behind.
+
 ## [4.0.0] - 2026-08-11
 
 ### Added

--- a/claude_discord/cogs/event_processor.py
+++ b/claude_discord/cogs/event_processor.py
@@ -330,12 +330,16 @@ class EventProcessor:
             await asyncio.gather(*tasks, return_exceptions=True)
 
     async def finalize(self) -> None:
-        """Cancel unfinished frontend activities and legacy timers.
+        """Disable the interrupt affordance and cancel unfinished activities.
 
         Prompt tasks are left running on purpose: each owns a timeout that
         fails closed, and an approval the user is mid-way through answering
         should still reach the CLI.
         """
+        if self._interrupt is not None:
+            with contextlib.suppress(Exception):
+                await self._interrupt.disable()
+            self._interrupt = None
         for activity in self._state.active_tools.values():
             with contextlib.suppress(Exception):
                 await activity.cancel()

--- a/claude_teams/surface.py
+++ b/claude_teams/surface.py
@@ -515,6 +515,10 @@ class TeamsInterruptHandle:
         if self._surface._stop_action_id == self._action_id:
             self._surface._stop_action_id = None
             await self._surface._repaint()
+            # Session teardown must leave the card visibly final before its
+            # short-lived surface goes out of scope. This flush also coalesces
+            # the preceding Done/Error status repaint into the same update.
+            await self._surface._pacer.flush()
 
 
 async def _await_answer(future: asyncio.Future[Any], timeout: float | None) -> Any:

--- a/tests/test_event_processor_surface.py
+++ b/tests/test_event_processor_surface.py
@@ -36,6 +36,7 @@ async def test_surface_only_config_drives_session_text_and_notices() -> None:
     await processor.process(
         StreamEvent(message_type=MessageType.RESULT, is_complete=True, session_id="session-1")
     )
+    await processor.finalize()
 
     assert surface.conformance_sent_text == ["Hello from core"]
     assert [notice.level for notice in surface.notices] == [
@@ -43,6 +44,8 @@ async def test_surface_only_config_drives_session_text_and_notices() -> None:
         NoticeLevel.SUCCESS,
     ]
     assert surface.statuses[-1] is StatusKind.DONE
+    assert len(surface.interrupts) == 1
+    assert surface.interrupts[0].disabled is True
 
 
 async def test_tool_lifecycle_is_expressed_as_surface_activity() -> None:

--- a/tests/test_teams_surface.py
+++ b/tests/test_teams_surface.py
@@ -375,6 +375,22 @@ class TestInterrupt:
         await s.close()
         assert not connector.updated[-1][1]["attachments"][0]["content"].get("actions")
 
+    async def test_disabling_flushes_the_final_status_and_removes_stop(self) -> None:
+        async def on_stop() -> None:
+            return None
+
+        connector = RecordingConnector()
+        s = build(connector)
+        handle = await s.offer_interrupt(on_stop)
+
+        await s.set_status(StatusKind.DONE)
+        await handle.disable()
+
+        final_card = connector.updated[-1][1]["attachments"][0]["content"]
+        assert final_card["body"][1]["text"] == "Done"
+        assert not final_card.get("actions")
+        await s.close()
+
     async def test_disabling_twice_is_harmless_and_stops_honouring_the_id(self) -> None:
         # The session-end path and the user pressing Stop both reach disable().
         # A Stop that still worked afterwards would interrupt whatever ran next.


### PR DESCRIPTION
## Summary

- finalize the original Teams session card when a run completes
- replace the running status with a terminal status
- remove the Stop action after completion while keeping it available during processing

## Validation

- 2,537 tests passed
- coverage: 85.10%
- Ruff and Pyright passed
- Bandit: no findings

Closes #619
