### PR TITLE
fix: keep threads visible for a week, not an hour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Threads stay in the channel's thread list for a week instead of an hour** — every
+  `create_thread()` call site now asks for Discord's maximum auto-archive window (7 days) via the
+  shared `THREAD_AUTO_ARCHIVE_MINUTES` constant. Chat threads had been created with a 60-minute
+  window, so a conversation dropped out of the sidebar an hour after the last reply and looked
+  deleted; the other call sites silently inherited discord.py's 24-hour default. An architecture
+  test fails when a new call site forgets the keyword.
+
 - **Teams session cards now leave the running state when a turn ends** — teardown removes and
   unregisters the Stop action, then flushes the final card repaint so the completed or error status
   is visible immediately instead of leaving a stale working card behind.

--- a/claude_discord/cogs/auto_upgrade.py
+++ b/claude_discord/cogs/auto_upgrade.py
@@ -23,6 +23,7 @@ from discord import app_commands
 from discord.ext import commands
 
 from ..protocols import DrainAware
+from ..thread_policy import THREAD_AUTO_ARCHIVE_MINUTES
 
 logger = logging.getLogger(__name__)
 
@@ -258,12 +259,16 @@ class AutoUpgradeCog(commands.Cog):
         async with self._lock:
             thread = await text_channel.create_thread(
                 name=self.config.trigger_prefix[:100],
+                auto_archive_duration=THREAD_AUTO_ARCHIVE_MINUTES,
             )
             await self._run_pipeline(thread, status_target=None)
 
     async def _run_upgrade(self, trigger_message: discord.Message) -> None:
         """Execute the upgrade pipeline triggered by a webhook message."""
-        thread = await trigger_message.create_thread(name=self.config.trigger_prefix[:100])
+        thread = await trigger_message.create_thread(
+            name=self.config.trigger_prefix[:100],
+            auto_archive_duration=THREAD_AUTO_ARCHIVE_MINUTES,
+        )
         await self._run_pipeline(thread, status_target=trigger_message)
 
     async def _run_pipeline(

--- a/claude_discord/cogs/claude_chat.py
+++ b/claude_discord/cogs/claude_chat.py
@@ -43,6 +43,7 @@ from ..discord_ui.thread_context import DEFAULT_DAYS, build_recent_transcript
 from ..discord_ui.thread_dashboard import ThreadState, ThreadStatusDashboard
 from ..discord_ui.thread_renamer import suggest_title
 from ..discord_ui.views import RewindSelectView, StopView
+from ..thread_policy import THREAD_AUTO_ARCHIVE_MINUTES
 from ._run_helper import run_claude_with_config
 from .prompt_builder import build_prompt_and_images, wants_file_attachment
 from .run_config import RunConfig
@@ -748,7 +749,10 @@ class ClaudeChatCog(commands.Cog):
             )
         else:
             thread_name = message.content[:100] if message.content else "Claude Chat"
-            thread = await message.create_thread(name=thread_name)
+            thread = await message.create_thread(
+                name=thread_name,
+                auto_archive_duration=THREAD_AUTO_ARCHIVE_MINUTES,
+            )
             if self._auto_rename_threads and message.content:
                 asyncio.create_task(self._background_rename_thread(thread, message.content))
             await self._run_claude(
@@ -833,7 +837,7 @@ class ClaudeChatCog(commands.Cog):
         thread = await channel.create_thread(
             name=name,
             type=discord.ChannelType.public_thread,
-            auto_archive_duration=60,
+            auto_archive_duration=THREAD_AUTO_ARCHIVE_MINUTES,
         )
         # Post the prompt so StatusManager has a Message to add reactions to.
         # Long prompts (e.g. an ingested Teams thread) exceed Discord's

--- a/claude_discord/cogs/session_sync.py
+++ b/claude_discord/cogs/session_sync.py
@@ -16,6 +16,7 @@ import discord
 from ..database.repository import SessionRepository
 from ..discord_ui.embeds import COLOR_INFO
 from ..session_sync import CliSession, extract_recent_messages, scan_cli_sessions
+from ..thread_policy import THREAD_AUTO_ARCHIVE_MINUTES
 
 logger = logging.getLogger(__name__)
 
@@ -54,12 +55,16 @@ async def create_sync_thread(
         embed.set_footer(text=f"Session: {cli_session.session_id[:8]}...")
 
         summary_msg = await channel.send(embed=embed)
-        return await summary_msg.create_thread(name=f"\U0001f5a5 {thread_name}")
+        return await summary_msg.create_thread(
+            name=f"\U0001f5a5 {thread_name}",
+            auto_archive_duration=THREAD_AUTO_ARCHIVE_MINUTES,
+        )
 
     # Default: channel thread
     return await channel.create_thread(
         name=f"\U0001f5a5 {thread_name}",
         type=discord.ChannelType.public_thread,
+        auto_archive_duration=THREAD_AUTO_ARCHIVE_MINUTES,
     )
 
 

--- a/claude_discord/cogs/skill_command.py
+++ b/claude_discord/cogs/skill_command.py
@@ -29,6 +29,7 @@ from claude_code_core.backend import SessionBackend
 
 from ..concurrency import SessionRegistry
 from ..database.repository import SessionRepository
+from ..thread_policy import THREAD_AUTO_ARCHIVE_MINUTES
 from ._run_helper import run_claude_with_config
 from .run_config import RunConfig
 
@@ -294,6 +295,7 @@ class SkillCommandCog(commands.Cog):
         thread = await channel.create_thread(
             name=thread_name[:100],
             type=discord.ChannelType.public_thread,
+            auto_archive_duration=THREAD_AUTO_ARCHIVE_MINUTES,
         )
 
         display = f"`/{name} {args}`" if args else f"`/{name}`"

--- a/claude_discord/cogs/webhook_trigger.py
+++ b/claude_discord/cogs/webhook_trigger.py
@@ -24,6 +24,7 @@ from ..cogs._run_helper import run_claude_with_config
 from ..cogs.headless_backend import build_headless_runner
 from ..cogs.run_config import RunConfig
 from ..concurrency import SessionRegistry
+from ..thread_policy import THREAD_AUTO_ARCHIVE_MINUTES
 
 if TYPE_CHECKING:
     from claude_code_core.backend import SessionBackend
@@ -146,7 +147,10 @@ class WebhookTriggerCog(commands.Cog):
         trigger: WebhookTrigger,
     ) -> None:
         """Execute a matched trigger via Claude Code."""
-        thread = await message.create_thread(name=prefix[:100])
+        thread = await message.create_thread(
+            name=prefix[:100],
+            auto_archive_duration=THREAD_AUTO_ARCHIVE_MINUTES,
+        )
 
         runner = await build_headless_runner(
             self.runner,

--- a/claude_discord/ext/api_server.py
+++ b/claude_discord/ext/api_server.py
@@ -38,6 +38,7 @@ from claude_code_core.transcript_search import default_transcripts_root
 from ..discord_ui.file_sender import send_file_blobs
 from ..relay import MODE_INTERRUPT, MODE_QUEUE, VALID_MODES, RelayGuard, build_relay_prompt
 from ..session_view import STATE_HISTORY, STATE_RUNNING, build_session_views
+from ..thread_policy import THREAD_AUTO_ARCHIVE_MINUTES
 from . import ingest_manifest, teams_sync
 from .teams_store import TeamsVaultStore
 from .teams_sync import ThreadRef
@@ -510,7 +511,10 @@ class ApiServer:
         if thread_name:
             if not hasattr(raw_channel, "create_thread"):
                 return web.json_response({"error": "Channel does not support threads"}, status=400)
-            thread_result = await raw_channel.create_thread(name=thread_name)  # type: ignore[union-attr]
+            thread_result = await raw_channel.create_thread(  # type: ignore[union-attr]
+                name=thread_name,
+                auto_archive_duration=THREAD_AUTO_ARCHIVE_MINUTES,
+            )
             # create_thread may return Thread or ThreadWithMessage depending on discord.py version
             thread = thread_result.thread if hasattr(thread_result, "thread") else thread_result  # type: ignore[union-attr]
             target = thread

--- a/claude_discord/frontend.py
+++ b/claude_discord/frontend.py
@@ -36,6 +36,7 @@ from claude_code_core.frontend import ThreadKey
 
 from .database.frontend_thread_repo import FrontendThreadRepository
 from .surface import DiscordSurface
+from .thread_policy import THREAD_AUTO_ARCHIVE_MINUTES
 
 logger = logging.getLogger(__name__)
 
@@ -117,7 +118,10 @@ class DiscordFrontend:
         # A thread needs a starter message; the title doubles as its text so
         # the channel view shows what the conversation is for.
         starter = await channel.send(title[:2000])
-        thread = await starter.create_thread(name=title[:100])
+        thread = await starter.create_thread(
+            name=title[:100],
+            auto_archive_duration=THREAD_AUTO_ARCHIVE_MINUTES,
+        )
         await self._record(thread)
         return DiscordSurface(thread)
 

--- a/claude_discord/thread_policy.py
+++ b/claude_discord/thread_policy.py
@@ -1,0 +1,14 @@
+"""How long Discord keeps a conversation thread visible.
+
+Discord archives an inactive thread automatically, which removes it from the
+channel's thread list — the conversation still exists, but the user has to open
+"Show archived threads" to find it again. The window is chosen per thread at
+creation time and only accepts 60, 1440, 4320 or 10080 minutes.
+
+We always ask for the maximum. Threads here are conversations the user comes
+back to, and several are deliberately kept open as a to-do list; a thread that
+vanishes from the sidebar an hour after the last reply reads as lost work.
+"""
+
+# Discord's maximum auto-archive window (7 days, in minutes).
+THREAD_AUTO_ARCHIVE_MINUTES = 10080

--- a/tests/test_api_server.py
+++ b/tests/test_api_server.py
@@ -11,6 +11,7 @@ from aiohttp.test_utils import TestClient, TestServer
 
 from claude_discord.database.notification_repo import NotificationRepository
 from claude_discord.ext.api_server import ApiServer
+from claude_discord.thread_policy import THREAD_AUTO_ARCHIVE_MINUTES
 
 
 @pytest.fixture
@@ -302,7 +303,9 @@ class TestNotifyThread:
         data = await resp.json()
         assert data["status"] == "sent"
         assert data["thread_id"] == "111222333"
-        channel.create_thread.assert_called_once_with(name="PR Review")
+        channel.create_thread.assert_called_once_with(
+            name="PR Review", auto_archive_duration=THREAD_AUTO_ARCHIVE_MINUTES
+        )
         thread.send.assert_called_once_with("PR #42 needs review")
         # Channel.send should NOT be called — message goes to thread
         channel.send.assert_not_called()
@@ -323,7 +326,9 @@ class TestNotifyThread:
             },
         )
         assert resp.status == 200
-        channel.create_thread.assert_called_once_with(name="Summary Thread")
+        channel.create_thread.assert_called_once_with(
+            name="Summary Thread", auto_archive_duration=THREAD_AUTO_ARCHIVE_MINUTES
+        )
         call_kwargs = thread.send.call_args.kwargs
         assert "embed" in call_kwargs
         channel.send.assert_not_called()
@@ -398,7 +403,9 @@ class TestNotifyThread:
             json={"message": "Long title", "thread_name": raw_name},
         )
         assert resp.status == 200
-        channel.create_thread.assert_called_once_with(name="a" * 100)
+        channel.create_thread.assert_called_once_with(
+            name="a" * 100, auto_archive_duration=THREAD_AUTO_ARCHIVE_MINUTES
+        )
 
 
 class TestSchedule:

--- a/tests/test_thread_policy.py
+++ b/tests/test_thread_policy.py
@@ -1,0 +1,70 @@
+"""Every thread we create must ask Discord for the longest visibility window.
+
+A thread that Discord auto-archives drops out of the channel's thread list. The
+window is fixed at creation time, so a call site that forgets the keyword silently
+inherits discord.py's default and the conversation disappears from the sidebar
+while the user still considers it open. This is an architecture test: it fails
+when a *new* ``create_thread`` call site forgets, which is the way this
+regresses.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from claude_discord.thread_policy import THREAD_AUTO_ARCHIVE_MINUTES
+
+PACKAGE_DIR = Path(__file__).parent.parent / "claude_discord"
+
+# The only values Discord accepts, in minutes.
+_ALLOWED_WINDOWS = (60, 1440, 4320, 10080)
+
+
+def _create_thread_calls(tree: ast.AST) -> list[ast.Call]:
+    return [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "create_thread"
+    ]
+
+
+class TestThreadAutoArchiveWindow:
+    def test_constant_is_discords_maximum(self) -> None:
+        assert THREAD_AUTO_ARCHIVE_MINUTES in _ALLOWED_WINDOWS
+        assert max(_ALLOWED_WINDOWS) == THREAD_AUTO_ARCHIVE_MINUTES
+
+    def test_every_call_site_passes_the_constant(self) -> None:
+        violations = []
+        for path in sorted(PACKAGE_DIR.rglob("*.py")):
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+            for call in _create_thread_calls(tree):
+                kwarg = next((k for k in call.keywords if k.arg == "auto_archive_duration"), None)
+                rel = path.relative_to(PACKAGE_DIR.parent)
+                if kwarg is None:
+                    violations.append(f"  {rel}:{call.lineno}: no auto_archive_duration")
+                elif not (
+                    isinstance(kwarg.value, ast.Name)
+                    and kwarg.value.id == "THREAD_AUTO_ARCHIVE_MINUTES"
+                ):
+                    violations.append(
+                        f"  {rel}:{call.lineno}: auto_archive_duration is not the shared constant"
+                    )
+
+        assert not violations, (
+            "create_thread() call sites must pass "
+            "auto_archive_duration=THREAD_AUTO_ARCHIVE_MINUTES "
+            "(from claude_discord.thread_policy), or the thread vanishes from the "
+            "channel's thread list while the user still considers it open:\n"
+            + "\n".join(violations)
+        )
+
+    def test_the_scan_actually_finds_call_sites(self) -> None:
+        """Guard against the scan silently matching nothing and passing forever."""
+        found = sum(
+            len(_create_thread_calls(ast.parse(p.read_text(encoding="utf-8"))))
+            for p in PACKAGE_DIR.rglob("*.py")
+        )
+        assert found >= 8, f"expected the package to still create threads, found {found}"


### PR DESCRIPTION
## Problem

Discord archives an inactive thread automatically, which removes it from the channel's thread list. The conversation still exists, but you have to open "Show archived threads" to find it — so it reads as deleted.

`ClaudeChatCog` created threads with `auto_archive_duration=60`, i.e. **60 minutes**. A conversation dropped out of the sidebar an hour after the last reply. The other eight `create_thread()` call sites passed no window at all and silently inherited discord.py's 24-hour default, so the behaviour was also inconsistent across entry points (chat, `/skill`, webhook triggers, session sync, the REST API, auto-upgrade).

## Change

- New `claude_discord/thread_policy.py` exporting `THREAD_AUTO_ARCHIVE_MINUTES = 10080` (Discord's maximum, 7 days) with the reasoning in the module docstring.
- All nine `create_thread()` call sites pass it.

## Why the maximum

Threads here are conversations users come back to, and some are deliberately left open as a to-do list. Discord only accepts 60 / 1440 / 4320 / 10080 minutes, and the window is fixed at creation time — it cannot be widened later for threads that already exist.

## Test plan

- `tests/test_thread_policy.py` walks the package AST and fails when any `create_thread()` call site omits the constant — this is the regression that matters, since the failure mode is a *new* call site forgetting the keyword. Verified RED against `main` (10 violations) and GREEN on this branch.
- A guard test asserts the scan still finds call sites, so it can't silently pass by matching nothing.
- Existing `TestNotifyThread` assertions updated for the new keyword.
- `ruff check` / `ruff format --check` / `pyright` clean; full suite 2540 passed.

## Note for existing threads

This only affects threads created from now on. Threads that already exist keep the window they were created with.