### PR TITLE
feat: file a work record when a thread is deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`find_transcript(session_id, root)`** in `claude_code_core.transcript_search` — resolves one
+  session's transcript without knowing its working directory. A thread can be deleted; its
+  transcript can't, so anything that wants to say something about a finished conversation after the
+  thread is gone needs this. The id is validated before it reaches a filesystem glob.
+- **`ThreadCompletionCog`** (EbiBot example) — treats "the user deleted the thread" as "that work is
+  finished". Deletions are batched over a quiet period, resolved against the session rows and
+  on-disk transcripts, written to a manifest, and handed to one Claude session that files the
+  records. Threads that never held a session (notification threads) are dropped, and the Cog's own
+  record threads don't re-trigger it. Disabled unless `THREAD_COMPLETION_CHANNEL_ID` is set.
+
 ### Fixed
+
+- **EbiBot's own Cogs kept the 24-hour thread window** — `alert_responder` and `job_failure_triage`
+  passed `auto_archive_duration=1440` literally. They now use the shared constant, and the
+  architecture test scans `examples/ebibot/cogs` too.
 
 - **Threads stay in the channel's thread list for a week instead of an hour** — every
   `create_thread()` call site now asks for Discord's maximum auto-archive window (7 days) via the

--- a/claude_code_core/transcript_search.py
+++ b/claude_code_core/transcript_search.py
@@ -46,6 +46,27 @@ def default_transcripts_root() -> str | None:
     return str(root) if root.is_dir() else None
 
 
+def find_transcript(session_id: str, root: str | None) -> str | None:
+    """Path to one session's transcript, or None if it isn't on this machine.
+
+    The project directory is derived from the session's working directory, which
+    callers generally don't have, so this searches every project directory rather
+    than reconstructing the path. The id is validated first because it reaches a
+    filesystem glob: anything that isn't exactly a session filename is refused
+    rather than allowed to escape ``root``.
+    """
+    if not root or not _SESSION_FILE_RE.match(f"{session_id}.jsonl"):
+        return None
+    root_path = Path(root)
+    if not root_path.is_dir():
+        return None
+    for project_dir in sorted(root_path.iterdir()):
+        candidate = project_dir / f"{session_id}.jsonl"
+        if candidate.is_file():
+            return str(candidate)
+    return None
+
+
 def make_snippet(text: str, query: str, width: int = _SNIPPET_WIDTH) -> str:
     """Return a one-line snippet of ``text`` centred on the first ``query`` hit."""
     flat = " ".join(text.split())

--- a/examples/ebibot/cogs/alert_responder.py
+++ b/examples/ebibot/cogs/alert_responder.py
@@ -38,6 +38,7 @@ from claude_discord.cogs.headless_backend import (
     build_headless_runner,
 )
 from claude_discord.cogs.run_config import RunConfig
+from claude_discord.thread_policy import THREAD_AUTO_ARCHIVE_MINUTES
 
 logger = logging.getLogger(__name__)
 
@@ -131,7 +132,7 @@ class AlertResponderCog(commands.Cog):
         # Create a thread on the alert message
         thread = await alert_message.create_thread(
             name=f"🔍 Investigation: {alert_message.content[:50]}",
-            auto_archive_duration=1440,  # 24 hours
+            auto_archive_duration=THREAD_AUTO_ARCHIVE_MINUTES,
         )
 
         owner_id = os.environ.get("DISCORD_OWNER_ID", "")

--- a/examples/ebibot/cogs/job_failure_triage.py
+++ b/examples/ebibot/cogs/job_failure_triage.py
@@ -32,6 +32,7 @@ from claude_discord.cogs.headless_backend import (
     build_headless_runner,
 )
 from claude_discord.cogs.run_config import RunConfig
+from claude_discord.thread_policy import THREAD_AUTO_ARCHIVE_MINUTES
 
 logger = logging.getLogger(__name__)
 
@@ -179,7 +180,7 @@ class JobFailureTriageCog(commands.Cog):
 
         thread = await alert_message.create_thread(
             name=f"{title_emoji} Triage: {job_name}"[:100],
-            auto_archive_duration=1440,
+            auto_archive_duration=THREAD_AUTO_ARCHIVE_MINUTES,
         )
 
         owner_id = os.environ.get("DISCORD_OWNER_ID", "")

--- a/examples/ebibot/cogs/thread_completion.py
+++ b/examples/ebibot/cogs/thread_completion.py
@@ -1,0 +1,284 @@
+"""thread_completion.py — deleting a thread files the work as done (custom Cog)
+
+胡田さんはDiscordのスレッドをTodoリストとして使っている。終わったものは自分で
+削除する。つまり **削除イベントは「この作業は完了した」という、人手ゼロで発生する
+高品質なラベル** である。ここではそれを拾って、Obsidianへの記録につなげる。
+
+重要な制約: 削除イベントが届いた時点で、そのスレッドのメッセージはもう取得できない
+（チャンネルごと消えている）。だから記録の材料は「ccdbが手元に持っていたもの」——
+セッション行と、`~/.claude/projects/<project>/<session_id>.jsonl` のtranscript——
+に限られる。transcriptにはユーザー発言もClaudeの返答もツール実行も全部入っている
+ので、Discordを別途ミラーする必要はない。
+
+まとめて消されることが多いので、削除を一定時間ためてから1回だけ記録セッションを
+起こす。1件ごとにセッションを立てると、掃除のたびにスレッドが増えて本末転倒になる。
+
+Configuration (environment variables):
+    THREAD_COMPLETION_CHANNEL_ID  (required) 記録スレッドを作るチャンネル。
+                                  未設定ならCogは無効。
+    THREAD_COMPLETION_DEBOUNCE    (optional) 静かになってから起動するまでの秒数。
+                                  既定180秒。連続削除を1バッチにまとめるため。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+from dataclasses import asdict, dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import discord
+from discord.ext import commands
+
+from claude_code_core.transcript_search import default_transcripts_root, find_transcript
+from claude_discord.cogs._run_helper import run_claude_with_config
+from claude_discord.cogs.headless_backend import (
+    backend_factory_from_components,
+    backend_settings_from_components,
+    build_headless_runner,
+)
+from claude_discord.cogs.run_config import RunConfig
+from claude_discord.thread_policy import THREAD_AUTO_ARCHIVE_MINUTES
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+_raw_channel_id = os.environ.get("THREAD_COMPLETION_CHANNEL_ID", "")
+THREAD_COMPLETION_CHANNEL_ID: int | None = int(_raw_channel_id) if _raw_channel_id else None
+
+DEBOUNCE_SECONDS = float(os.environ.get("THREAD_COMPLETION_DEBOUNCE", "180"))
+
+MANIFEST_DIR = str(Path.home() / "ccdb-completions")
+
+_PROMPT = """\
+Discordのスレッドが {count} 件削除されました。
+
+このワークスペースでは **スレッドの削除＝その作業が完了した** という意味です
+（終わったものを自分で消すTodo運用）。削除された分の作業記録をObsidianに残してください。
+
+## 材料
+
+`{manifest}` に削除されたスレッドの一覧が入っています。各要素:
+
+- `thread_id` / `thread_name` — Discord側の識別子（スレッド自体はもう存在しません）
+- `summary` — そのセッションの最初のプロンプト
+- `working_dir` — 作業ディレクトリ
+- `last_used_at` — 最後にやりとりした時刻
+- `transcript_path` — 会話の全文（`~/.claude/projects/.../<session_id>.jsonl`）。
+  ユーザー発言・返答・ツール実行が全部入っています。**ここが一次情報です**
+
+## やること
+
+1. マニフェストを読み、各スレッドの transcript を確認して「実際に何をやったか」を掴む
+   （transcriptは大きいことがあるので、全文をコンテキストに載せず必要な範囲を読むこと）
+2. `transcript_path` が null のものは `summary` だけで判断する。無理に推測しない
+3. CLAUDE.md の記録ルールに従って書く:
+   - プロジェクトに紐づく作業 → 該当プロジェクトの `log.md` に詳細、`status.md` を更新
+     （完了したタスクは `[ ]` → `[x]` に必ず変える）
+   - デイリーノート `obsidian/01_Daily/YYYY-MM-DD.md` には wikilink + 1行サマリーだけ
+4. 知識が生まれていたら 3点セット（wiki / KB / ADR）に入れる。無理に作らない
+5. 雑談・確認だけで終わったもの、記録する価値がないものは **書かない**。
+   「全部書く」より「後で読む価値があるものだけ書く」を優先する
+
+## 報告
+
+このスレッドに、何を記録したか（と、記録しなかったものと理由）を簡潔に報告してください。
+報告が終わったらこのスレッドも消して構いません。
+"""
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CompletionRecord:
+    """One finished conversation, as much of it as survived the deletion."""
+
+    thread_id: int
+    session_id: str | None
+    summary: str | None
+    working_dir: str | None
+    last_used_at: str | None
+    transcript_path: str | None
+    thread_name: str | None = None
+
+
+async def collect_records(
+    thread_ids: list[int],
+    session_repo: Any,
+    transcripts_root: str | None,
+) -> list[CompletionRecord]:
+    """Turn deleted thread ids into what we still know about them.
+
+    Threads with no session row are dropped: those are notification threads
+    (おはよう, scheduler alerts, PR watches) that never held a conversation, and
+    filing "work completed" for them would be a lie.
+    """
+    records: list[CompletionRecord] = []
+    seen: set[int] = set()
+    for thread_id in thread_ids:
+        if thread_id in seen:
+            continue
+        seen.add(thread_id)
+        try:
+            row = await session_repo.get(thread_id)
+        except Exception:
+            logger.exception("thread_completion: session lookup failed for %d", thread_id)
+            continue
+        if row is None:
+            logger.debug("thread_completion: %d had no session; not a conversation", thread_id)
+            continue
+        records.append(
+            CompletionRecord(
+                thread_id=thread_id,
+                session_id=row.session_id,
+                summary=row.summary,
+                working_dir=row.working_dir,
+                last_used_at=row.last_used_at,
+                transcript_path=find_transcript(row.session_id, transcripts_root),
+            )
+        )
+    return records
+
+
+def write_manifest(records: list[CompletionRecord], directory: str, stamp: str) -> str:
+    """Write the batch to disk and return its path.
+
+    The content goes in a file rather than the prompt so a large cleanup can't
+    blow up the prompt, and so customer names in a summary don't end up in
+    process logs.
+    """
+    Path(directory).mkdir(parents=True, exist_ok=True)
+    path = Path(directory) / f"completed-{stamp}.json"
+    payload = {"deleted_at": stamp, "threads": [asdict(r) for r in records]}
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    return str(path)
+
+
+def build_prompt(manifest_path: str, records: list[CompletionRecord]) -> str:
+    return _PROMPT.format(count=len(records), manifest=manifest_path)
+
+
+# ---------------------------------------------------------------------------
+# Cog
+# ---------------------------------------------------------------------------
+
+
+class ThreadCompletionCog(commands.Cog):
+    """Batches thread deletions and files the finished work in Obsidian."""
+
+    def __init__(self, bot: commands.Bot, runner: object, components: object) -> None:
+        self.bot = bot
+        # The Cog loader hands these over as ``object``; discord.py's unions and
+        # the backend protocol don't survive that, so keep them loose here.
+        self.runner: Any = runner
+        self.components: Any = components
+        self._pending: list[int] = []
+        self._flush_task: asyncio.Task[None] | None = None
+        # Threads this Cog created. Deleting a record thread must not file a
+        # record about filing a record.
+        self._own_threads: set[int] = set()
+
+    @commands.Cog.listener()
+    async def on_raw_thread_delete(self, payload: discord.RawThreadDeleteEvent) -> None:
+        if payload.thread_id in self._own_threads:
+            self._own_threads.discard(payload.thread_id)
+            return
+        self._pending.append(payload.thread_id)
+        self._schedule_flush()
+
+    def _schedule_flush(self) -> None:
+        """Restart the quiet timer — a burst of deletions becomes one batch."""
+        if self._flush_task is not None and not self._flush_task.done():
+            self._flush_task.cancel()
+        self._flush_task = asyncio.create_task(self._flush_after_quiet())
+
+    async def _flush_after_quiet(self) -> None:
+        try:
+            await asyncio.sleep(DEBOUNCE_SECONDS)
+        except asyncio.CancelledError:
+            return
+        batch, self._pending = self._pending, []
+        if not batch:
+            return
+        try:
+            await self._file_records(batch)
+        except Exception:
+            logger.exception("thread_completion: failed to file %d deletions", len(batch))
+
+    async def _file_records(self, thread_ids: list[int]) -> None:
+        session_repo = getattr(self.components, "session_repo", None)
+        if session_repo is None:
+            logger.warning("thread_completion: no session_repo; nothing to file")
+            return
+
+        records = await collect_records(thread_ids, session_repo, default_transcripts_root())
+        if not records:
+            logger.info(
+                "thread_completion: %d threads deleted, none held a conversation", len(thread_ids)
+            )
+            return
+
+        stamp = datetime.now().strftime("%Y-%m-%dT%H-%M-%S")
+        manifest = write_manifest(records, MANIFEST_DIR, stamp)
+
+        channel = self.bot.get_channel(THREAD_COMPLETION_CHANNEL_ID or 0)
+        if not isinstance(channel, discord.TextChannel):
+            logger.warning(
+                "thread_completion: channel %s is not a text channel; manifest left at %s",
+                THREAD_COMPLETION_CHANNEL_ID,
+                manifest,
+            )
+            return
+
+        thread = await channel.create_thread(
+            name=f"🗂 完了記録 {datetime.now():%m/%d %H:%M}（{len(records)}件）",
+            type=discord.ChannelType.public_thread,
+            auto_archive_duration=THREAD_AUTO_ARCHIVE_MINUTES,
+        )
+        self._own_threads.add(thread.id)
+
+        registry = getattr(self.components, "registry", None)
+        lounge_repo = getattr(self.components, "lounge_repo", None)
+        cloned_runner = await build_headless_runner(
+            self.runner,
+            factory=backend_factory_from_components(self.components),
+            settings=backend_settings_from_components(self.components),
+            thread_id=thread.id,
+        )
+        await run_claude_with_config(
+            RunConfig(
+                thread=thread,
+                runner=cloned_runner,
+                prompt=build_prompt(manifest, records),
+                session_id=None,
+                repo=session_repo,
+                registry=registry,
+                lounge_repo=lounge_repo,
+                backend_settings=backend_settings_from_components(self.components),
+            )
+        )
+
+
+async def setup(bot: commands.Bot, runner: object, components: object) -> None:
+    """Entry point called by the custom Cog loader."""
+    if THREAD_COMPLETION_CHANNEL_ID is None:
+        logger.warning(
+            "ThreadCompletionCog: THREAD_COMPLETION_CHANNEL_ID is not set — Cog disabled."
+        )
+        return
+
+    await bot.add_cog(ThreadCompletionCog(bot, runner, components))
+    logger.info(
+        "ThreadCompletionCog loaded — deleted threads are filed as completed work in channel %d",
+        THREAD_COMPLETION_CHANNEL_ID,
+    )

--- a/tests/test_thread_completion.py
+++ b/tests/test_thread_completion.py
@@ -1,0 +1,139 @@
+"""tests/test_thread_completion.py
+
+Unit tests for ThreadCompletionCog — the Cog that treats "the user deleted the
+thread" as "that work is finished" and files a record for it.
+
+The interesting constraint is that by the time the delete event arrives, the
+thread's messages are already unreachable. Everything the record says has to
+come from what ccdb kept: the session row, and the transcript on disk.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+# Set required env vars before the module under test is imported.
+os.environ.setdefault("THREAD_COMPLETION_CHANNEL_ID", "333333333333333333")
+
+from unittest.mock import AsyncMock, MagicMock  # noqa: E402
+
+import pytest  # noqa: E402
+
+from examples.ebibot.cogs.thread_completion import (  # noqa: E402
+    CompletionRecord,
+    build_prompt,
+    collect_records,
+    write_manifest,
+)
+
+
+def _session(thread_id: int, session_id: str, summary: str | None = "やったこと") -> MagicMock:
+    rec = MagicMock()
+    rec.thread_id = thread_id
+    rec.session_id = session_id
+    rec.summary = summary
+    rec.working_dir = "/home/ebi"
+    rec.last_used_at = "2026-08-16 10:00:00"
+    return rec
+
+
+def _repo(records: dict[int, MagicMock]) -> MagicMock:
+    repo = MagicMock()
+    repo.get = AsyncMock(side_effect=lambda tid: records.get(tid))
+    return repo
+
+
+class TestCollectRecords:
+    @pytest.mark.asyncio
+    async def test_builds_a_record_from_the_session_row(self, tmp_path) -> None:
+        sid = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+        proj = tmp_path / "-home-ebi"
+        proj.mkdir()
+        (proj / f"{sid}.jsonl").write_text("{}\n", encoding="utf-8")
+
+        got = await collect_records([111], _repo({111: _session(111, sid)}), str(tmp_path))
+
+        assert len(got) == 1
+        assert got[0].thread_id == 111
+        assert got[0].session_id == sid
+        assert got[0].transcript_path is not None
+        assert got[0].transcript_path.endswith(f"{sid}.jsonl")
+
+    @pytest.mark.asyncio
+    async def test_threads_with_no_session_are_dropped(self, tmp_path) -> None:
+        """Notification threads (おはよう, scheduler alerts) never held a session."""
+        got = await collect_records([111, 222], _repo({111: _session(111, "a" * 8)}), str(tmp_path))
+        assert [r.thread_id for r in got] == [111]
+
+    @pytest.mark.asyncio
+    async def test_a_missing_transcript_still_yields_a_record(self, tmp_path) -> None:
+        """The session summary alone is worth filing; don't drop the whole record."""
+        sid = "cccccccc-cccc-cccc-cccc-cccccccccccc"
+        got = await collect_records([111], _repo({111: _session(111, sid)}), str(tmp_path))
+        assert len(got) == 1
+        assert got[0].transcript_path is None
+
+    @pytest.mark.asyncio
+    async def test_a_broken_repo_lookup_does_not_lose_the_other_threads(self, tmp_path) -> None:
+        repo = MagicMock()
+
+        async def flaky(tid: int):
+            if tid == 111:
+                raise RuntimeError("db is locked")
+            return _session(tid, "dddddddd-dddd-dddd-dddd-dddddddddddd")
+
+        repo.get = AsyncMock(side_effect=flaky)
+        got = await collect_records([111, 222], repo, str(tmp_path))
+        assert [r.thread_id for r in got] == [222]
+
+    @pytest.mark.asyncio
+    async def test_duplicate_ids_are_recorded_once(self, tmp_path) -> None:
+        sid = "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee"
+        got = await collect_records([111, 111], _repo({111: _session(111, sid)}), str(tmp_path))
+        assert len(got) == 1
+
+
+class TestWriteManifest:
+    def test_manifest_is_readable_json(self, tmp_path) -> None:
+        rec = CompletionRecord(
+            thread_id=111,
+            session_id="s",
+            summary="要約",
+            working_dir="/home/ebi",
+            last_used_at="2026-08-16 10:00:00",
+            transcript_path="/t.jsonl",
+        )
+        path = write_manifest([rec], str(tmp_path), "2026-08-16T12-00-00")
+        data = json.loads(Path(path).read_text(encoding="utf-8"))
+        assert data["deleted_at"] == "2026-08-16T12-00-00"
+        assert data["threads"][0]["thread_id"] == 111
+        assert data["threads"][0]["transcript_path"] == "/t.jsonl"
+
+    def test_manifest_filename_is_unique_per_flush(self, tmp_path) -> None:
+        rec = CompletionRecord(111, "s", None, None, None, None)
+        a = write_manifest([rec], str(tmp_path), "2026-08-16T12-00-00")
+        b = write_manifest([rec], str(tmp_path), "2026-08-16T12-00-01")
+        assert a != b
+
+
+class TestBuildPrompt:
+    def test_prompt_points_at_the_manifest_and_never_inlines_the_body(self) -> None:
+        rec = CompletionRecord(
+            thread_id=111,
+            session_id="s",
+            summary="秘密の顧客名がここに入る",
+            working_dir="/home/ebi",
+            last_used_at="2026-08-16 10:00:00",
+            transcript_path="/t.jsonl",
+        )
+        prompt = build_prompt("/tmp/m.json", [rec])
+        assert "/tmp/m.json" in prompt
+        # The prompt is an instruction, not a data dump: the manifest carries the
+        # content so a long batch can't blow up the prompt or leak into logs.
+        assert "秘密の顧客名がここに入る" not in prompt
+
+    def test_prompt_states_the_count(self) -> None:
+        recs = [CompletionRecord(i, "s", None, None, None, None) for i in range(3)]
+        assert "3" in build_prompt("/tmp/m.json", recs)

--- a/tests/test_thread_policy.py
+++ b/tests/test_thread_policy.py
@@ -15,7 +15,11 @@ from pathlib import Path
 
 from claude_discord.thread_policy import THREAD_AUTO_ARCHIVE_MINUTES
 
-PACKAGE_DIR = Path(__file__).parent.parent / "claude_discord"
+_REPO = Path(__file__).parent.parent
+PACKAGE_DIR = _REPO / "claude_discord"
+# EbiBot's Cogs create threads too, and a thread that vanishes is just as wrong
+# there — the rule is about Discord's behaviour, not about which package we are in.
+_SCANNED_ROOTS = (PACKAGE_DIR, _REPO / "examples" / "ebibot" / "cogs")
 
 # The only values Discord accepts, in minutes.
 _ALLOWED_WINDOWS = (60, 1440, 4320, 10080)
@@ -38,11 +42,11 @@ class TestThreadAutoArchiveWindow:
 
     def test_every_call_site_passes_the_constant(self) -> None:
         violations = []
-        for path in sorted(PACKAGE_DIR.rglob("*.py")):
+        for path in sorted(p for root in _SCANNED_ROOTS for p in root.rglob("*.py")):
             tree = ast.parse(path.read_text(encoding="utf-8"))
             for call in _create_thread_calls(tree):
                 kwarg = next((k for k in call.keywords if k.arg == "auto_archive_duration"), None)
-                rel = path.relative_to(PACKAGE_DIR.parent)
+                rel = path.relative_to(_REPO)
                 if kwarg is None:
                     violations.append(f"  {rel}:{call.lineno}: no auto_archive_duration")
                 elif not (
@@ -65,6 +69,7 @@ class TestThreadAutoArchiveWindow:
         """Guard against the scan silently matching nothing and passing forever."""
         found = sum(
             len(_create_thread_calls(ast.parse(p.read_text(encoding="utf-8"))))
-            for p in PACKAGE_DIR.rglob("*.py")
+            for root in _SCANNED_ROOTS
+            for p in root.rglob("*.py")
         )
         assert found >= 8, f"expected the package to still create threads, found {found}"

--- a/tests/test_transcript_lookup.py
+++ b/tests/test_transcript_lookup.py
@@ -1,0 +1,65 @@
+"""Finding one session's transcript by id.
+
+A thread can be deleted; its transcript cannot. Everything that wants to say
+something about a finished conversation after the thread is gone has to get
+from ``session_id`` to a file on disk, and the project directory that file
+lives under is derived from the working directory, which the caller may not
+know. So the lookup searches, rather than reconstructing a path.
+"""
+
+from __future__ import annotations
+
+import json
+
+from claude_code_core.transcript_search import find_transcript
+
+_SID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+_OTHER = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+
+
+def _write(path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "type": "user",
+                "message": {"role": "user", "content": [{"type": "text", "text": text}]},
+            },
+            ensure_ascii=False,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_finds_transcript_in_a_project_subdirectory(tmp_path) -> None:
+    _write(tmp_path / "-home-ebi" / f"{_SID}.jsonl", "hello")
+    assert find_transcript(_SID, str(tmp_path)) == str(tmp_path / "-home-ebi" / f"{_SID}.jsonl")
+
+
+def test_searches_every_project_directory(tmp_path) -> None:
+    _write(tmp_path / "-home-ebi" / f"{_OTHER}.jsonl", "wrong one")
+    _write(tmp_path / "-home-ebi-scheduler" / f"{_SID}.jsonl", "right one")
+    found = find_transcript(_SID, str(tmp_path))
+    assert found is not None
+    assert found.endswith(f"-home-ebi-scheduler/{_SID}.jsonl")
+
+
+def test_unknown_session_is_none(tmp_path) -> None:
+    _write(tmp_path / "-home-ebi" / f"{_OTHER}.jsonl", "hello")
+    assert find_transcript(_SID, str(tmp_path)) is None
+
+
+def test_missing_root_is_none() -> None:
+    assert find_transcript(_SID, "/nonexistent/path/for/tests") is None
+
+
+def test_no_root_is_none() -> None:
+    assert find_transcript(_SID, None) is None
+
+
+def test_rejects_a_session_id_that_is_not_a_session_id(tmp_path) -> None:
+    """The id reaches a filesystem glob, so anything path-shaped must not."""
+    _write(tmp_path / "-home-ebi" / f"{_SID}.jsonl", "hello")
+    for hostile in ("../../etc/passwd", "*", "", "a" * 40, "../" + _SID):
+        assert find_transcript(hostile, str(tmp_path)) is None


### PR DESCRIPTION
## Why

This instance's user keeps Discord threads as a to-do list: finished work gets deleted. That makes the delete event a **zero-effort completion signal** — higher quality than anything a heuristic would produce, and it already happens.

## The constraint that shapes the design

By the time `on_raw_thread_delete` fires, the thread's messages are gone — you cannot fetch them. So the record has to be built from what ccdb already kept:

- the **session row** (`session_id`, `summary`, `working_dir`, `last_used_at`)
- the **transcript** at `~/.claude/projects/<project>/<session_id>.jsonl`, which holds the user turns, the replies and the tool calls

That is also why this needs no message mirroring: the transcript already contains the conversation.

## Added

**`claude_code_core.transcript_search.find_transcript(session_id, root)`** — the project directory is derived from the working directory, which callers generally don't have, so this searches the project directories rather than reconstructing a path. The id reaches a filesystem glob, so anything that isn't exactly a session filename is refused (`../../etc/passwd`, `*`, `""` are covered by tests).

**`examples/ebibot/cogs/thread_completion.py`** — `ThreadCompletionCog`:

- batches deletions over a quiet period (`THREAD_COMPLETION_DEBOUNCE`, default 180s). Cleanups are bursty; one session per deleted thread would create more threads than the cleanup removed
- drops threads with **no session row** — notification threads (おはよう, scheduler alerts, PR watches) never held a conversation, and filing "work completed" for them would be a lie
- writes the batch to a manifest file and passes the *path* in the prompt, so a large cleanup can't blow up the prompt and summaries containing customer names don't reach process logs
- ignores deletion of its own record threads, so filing a record can't file a record about filing a record
- disabled unless `THREAD_COMPLETION_CHANNEL_ID` is set

## Fixed

`alert_responder` and `job_failure_triage` still passed `auto_archive_duration=1440` literally, so EbiBot's own threads kept the 24-hour window that #622 removed elsewhere. The architecture test now scans `examples/ebibot/cogs` as well — that's how these two were found.

## Test plan

- `tests/test_transcript_lookup.py` — 6 tests including the path-traversal rejection. Written first; confirmed RED on `ImportError`.
- `tests/test_thread_completion.py` — 9 tests over the pure layer: record building, threads with no session dropped, a missing transcript still yielding a record, one failing repo lookup not losing the rest of the batch, duplicate ids collapsed, and an assertion that the prompt never inlines summary text.
- `ruff check` / `ruff format --check` clean; `pyright claude_discord/` 0 errors; full suite **2555 passed**.

## Security

No new subprocess, no new secret handling. The one new untrusted-input path is `session_id` reaching a glob, validated against the existing session-filename regex before use and covered by a test.