### PR TITLE
feat: /ask — explicit escalation with verified isolation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,8 @@ Discord frontend for Claude Code CLI. **This is a framework (OSS library), not a
 
 13. **A local backend is a measured claim, not a configured one** (`claude_code_core/local_backend.py`): `/backend local` runs the Codex CLI against a model on the user's own hardware. Pointing the CLI at a local endpoint is not sufficient — measured on codex-cli 0.145.0, a fully local, logged-out run still contacts `chatgpt.com` for the startup update check and analytics. ccdb therefore generates and owns a separate `CODEX_HOME` with both disabled, re-verifies those settings on every spawn, and refuses to start rather than run a "local" thread that phones home. The check is structural (works on Windows too), not an OS egress rule; re-measure after a CLI upgrade. See `docs/local-backend.md`.
 
+14. **Escalation is isolated by verified argv, not by procedure** (`claude_code_core/escalation.py`): `/ask` sends one anonymized, self-contained question to an external model. The CLI runs with `--setting-sources ""`, an empty temp cwd, every tool disallowed, and `--` before the prompt; `verify_isolation()` checks the argv immediately before spawning and refuses otherwise. The first flag is load-bearing — measured with cwd=/home/ebi and all tools already off, the CLI reports a CLAUDE.md-only term as present in its context without it and absent with it, so a naive escalation ships the whole file regardless of how well the question was anonymized. See `docs/escalation.md`.
+
 ### Why REST API over stdout markers for Claude→ccdb communication
 
 Alternative considered: Claude embeds `<!-- ccdb:schedule {...} -->` in response text; ccdb parses stdout.

--- a/README.md
+++ b/README.md
@@ -508,6 +508,7 @@ Behind the scenes:
 - **Log injection prevention** — User-provided API values are sanitized (newlines stripped) before writing to logs
 - **Local-model backend** (optional) — `/backend local` runs a thread against a model on your own hardware. ccdb owns a separate CLI home with the update check and analytics disabled, because a "local" run otherwise still contacts the vendor; it refuses to start if those settings are missing — see [docs/local-backend.md](docs/local-backend.md)
 - **Remote AG-UI backend** (optional) — `/backend agui` connects the existing Discord/Teams session machinery to any HTTP/SSE AG-UI agent while preserving ccdb's session ledger, rendering, cancellation, and operational controls — see [docs/agui-backend.md](docs/agui-backend.md)
+- **`/ask` — explicit escalation** (optional) — sends one anonymized, self-contained question to a strong external model with no project context, no files and no tools, then restores your real names in the answer; the isolation is verified before every spawn — see [docs/escalation.md](docs/escalation.md)
 - **Anonymization gateway** (optional) — Replaces organisation-identifying terms with stable aliases before the prompt reaches Claude or Codex, and restores them in the answer. A local model checks the result for replacement misses and, by default, blocks the send when it finds one. Off until you write a rules file — see [docs/anonymization.md](docs/anonymization.md)
 
 ---

--- a/claude_code_core/escalation.py
+++ b/claude_code_core/escalation.py
@@ -1,0 +1,226 @@
+"""Explicit escalation: ask a strong external model one self-contained question.
+
+This is the other half of the local-first design. A thread does its work on a
+model you control; when it needs research, a second opinion or a plan, exactly
+one anonymized question goes out and exactly one answer comes back.
+
+What makes the claim checkable is that the external CLI runs with **no context
+of its own**. That is not a documented procedure — it is verified immediately
+before every spawn, because a procedure that can be skipped when someone is in
+a hurry always eventually is:
+
+1. ``--setting-sources ""`` — no CLAUDE.md, skills or memory.
+2. An **empty** temporary directory as cwd — nothing local to read.
+3. Every tool disallowed — no shell to escape the directory with.
+4. ``--`` before the prompt — without it the variadic tool list eats the
+   prompt and the CLI dies with "Input must be provided...".
+
+Point 1 is not paranoia. Measured with cwd=/home/ebi and every tool already
+disabled, changing *only* ``--setting-sources``: with it, the model reported
+that a term unique to the project's CLAUDE.md was absent from its context;
+without it, present. A naive escalation ships the whole file — customer names
+included — no matter how carefully the question was anonymized.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import shutil
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from .privacy.gateway import PrivacyGateway
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "ConsultChannel",
+    "ConsultOutcome",
+    "Escalation",
+    "IsolationError",
+    "CONSULT_DISALLOWED_TOOLS",
+    "verify_isolation",
+]
+
+
+class IsolationError(RuntimeError):
+    """Raised when a consult would run without its isolation intact."""
+
+
+# Every tool the CLI ships. A consult is text-in, text-out; anything that can
+# touch the filesystem or the network defeats the point of the empty cwd.
+CONSULT_DISALLOWED_TOOLS: tuple[str, ...] = (
+    "Bash",
+    "BashOutput",
+    "Edit",
+    "Glob",
+    "Grep",
+    "KillShell",
+    "NotebookEdit",
+    "Read",
+    "SlashCommand",
+    "Task",
+    "TodoWrite",
+    "WebFetch",
+    "WebSearch",
+    "Write",
+)
+
+# Secrets and control-plane handles that have no business in a consult.
+_STRIPPED_ENV_KEYS = frozenset(
+    {
+        "CLAUDECODE",
+        "DISCORD_BOT_TOKEN",
+        "DISCORD_TOKEN",
+        "API_SECRET_KEY",
+        "CCDB_API_URL",
+        "CCDB_API_SECRET",
+        "CCDB_CLI_ENV_FILE",
+    }
+)
+
+
+def verify_isolation(args: list[str], cwd: str | Path) -> list[str]:
+    """Return the isolation guarantees that are NOT in place.
+
+    An empty list means the four properties in the module docstring all hold
+    for this exact spawn. Checking the argv we are about to use — rather than
+    trusting the code that built it — is what makes this a route and not a
+    procedure.
+    """
+    problems: list[str] = []
+
+    if "--setting-sources" in args:
+        index = args.index("--setting-sources")
+        if index + 1 >= len(args) or args[index + 1] != "":
+            problems.append("--setting-sources is set to something other than empty")
+    else:
+        problems.append("--setting-sources is missing (CLAUDE.md and skills would be sent)")
+
+    if "--" not in args:
+        problems.append("-- separator is missing (the tool list would swallow the prompt)")
+
+    if "--disallowedTools" in args:
+        # Without the separator the tool list runs to the end of argv; report
+        # every finding rather than crashing on the first broken assumption.
+        separator = args.index("--") if "--" in args else len(args)
+        listed = set(args[args.index("--disallowedTools") + 1 : separator])
+        missing = [tool for tool in CONSULT_DISALLOWED_TOOLS if tool not in listed]
+        if missing:
+            problems.append(f"tools not disallowed: {', '.join(missing)}")
+    else:
+        problems.append("--disallowedTools is missing")
+
+    path = Path(cwd)
+    if not path.is_dir():
+        problems.append(f"working directory {path} does not exist")
+    elif any(path.iterdir()):
+        problems.append(f"working directory {path} is not empty")
+
+    return problems
+
+
+@dataclass(frozen=True)
+class ConsultOutcome:
+    """The result of one escalation."""
+
+    allowed: bool
+    question_sent: str = ""
+    answer: str = ""
+    reason: str | None = None
+    warning: str | None = None
+    substitutions: int = 0
+
+    @property
+    def blocked(self) -> bool:
+        return not self.allowed
+
+
+@dataclass
+class ConsultChannel:
+    """Runs one hardened, single-shot, text-only CLI call."""
+
+    command: str = "claude"
+    model: str = "sonnet"
+    timeout_seconds: int = 300
+
+    def build_args(self, prompt: str) -> list[str]:
+        return [
+            self.command,
+            "-p",
+            "--model",
+            self.model,
+            "--setting-sources",
+            "",
+            "--disallowedTools",
+            *CONSULT_DISALLOWED_TOOLS,
+            "--",
+            prompt,
+        ]
+
+    async def ask(self, prompt: str) -> str:
+        """Ask once and return the plain-text answer."""
+        workdir = tempfile.mkdtemp(prefix="ccdb-consult-")
+        try:
+            args = self.build_args(prompt)
+            problems = verify_isolation(args, workdir)
+            if problems:
+                raise IsolationError(
+                    "Refusing to escalate: " + "; ".join(problems) + ". Nothing was sent."
+                )
+            env = {k: v for k, v in os.environ.items() if k not in _STRIPPED_ENV_KEYS}
+            process = await asyncio.create_subprocess_exec(
+                *args,
+                stdin=asyncio.subprocess.DEVNULL,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                cwd=workdir,
+                env=env,
+            )
+            try:
+                stdout, stderr = await asyncio.wait_for(
+                    process.communicate(), timeout=self.timeout_seconds
+                )
+            except TimeoutError:
+                process.kill()
+                await process.wait()
+                raise
+            if process.returncode:
+                detail = stderr.decode("utf-8", errors="replace").strip()[:200]
+                raise RuntimeError(f"Consult CLI exited with {process.returncode}: {detail}")
+            return stdout.decode("utf-8", errors="replace").strip()
+        finally:
+            shutil.rmtree(workdir, ignore_errors=True)
+
+
+@dataclass
+class Escalation:
+    """Anonymize a question, ask an external model, restore the answer."""
+
+    gateway: PrivacyGateway
+    channel: ConsultChannel = field(default_factory=ConsultChannel)
+
+    async def consult(self, question: str, **context: object) -> ConsultOutcome:
+        """Send one question out, under the gateway's policy."""
+        outcome = await self.gateway.guard(question, kind="consult", **context)
+        if not outcome.allowed:
+            return ConsultOutcome(allowed=False, reason=outcome.reason)
+
+        answer = await self.channel.ask(outcome.text)
+        restored = self.gateway.restore(answer)
+        self.gateway.audit.record(
+            "consult_answer",
+            model=self.channel.model,
+            answer_chars=len(answer),
+            **context,
+        )
+        return ConsultOutcome(
+            allowed=True,
+            question_sent=outcome.text,
+            answer=restored,
+            warning=outcome.warning,
+            substitutions=outcome.result.total_substitutions,
+        )

--- a/claude_discord/__init__.py
+++ b/claude_discord/__init__.py
@@ -12,6 +12,7 @@ from .claude.parser import parse_line
 from .claude.runner import ClaudeRunner
 from .claude.types import MessageType, StreamEvent, ToolCategory, ToolUseEvent
 from .cog_loader import load_custom_cogs
+from .cogs.ask_command import AskCommandCog
 from .cogs.auto_upgrade import AutoUpgradeCog, UpgradeConfig
 from .cogs.claude_chat import ClaudeChatCog
 from .cogs.collision_watch import CollisionWatchCog
@@ -53,6 +54,7 @@ __all__ = [
     "SessionRegistry",
     "SessionManageCog",
     "CollisionWatchCog",
+    "AskCommandCog",
     "SkillCommandCog",
     "SessionRepository",
     "SettingsRepository",

--- a/claude_discord/cogs/__init__.py
+++ b/claude_discord/cogs/__init__.py
@@ -1,5 +1,6 @@
 """Cogs for claude-code-discord-bridge."""
 
+from .ask_command import AskCommandCog
 from .auto_upgrade import AutoUpgradeCog
 from .claude_chat import ClaudeChatCog
 from .collision_watch import CollisionWatchCog
@@ -20,6 +21,7 @@ __all__ = [
     "RunConfig",
     "SchedulerCog",
     "SessionManageCog",
+    "AskCommandCog",
     "SkillCommandCog",
     "WebhookTriggerCog",
 ]

--- a/claude_discord/cogs/ask_command.py
+++ b/claude_discord/cogs/ask_command.py
@@ -1,0 +1,101 @@
+"""`/ask` — send one anonymized question to a strong external model.
+
+The companion to the local-model backend: a thread does its work locally, and
+when it needs research, a second opinion or a plan, the human sends exactly one
+question out. The external model gets no tools, no files and no project
+context, so what left the machine is exactly the line recorded in the audit log.
+
+The command is only registered when a rules file exists. Without one there is
+nothing to anonymize, and a `/ask` that quietly forwards real names would be
+worse than no command at all.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import discord
+from discord import app_commands
+from discord.ext import commands
+
+from claude_code_core.escalation import ConsultChannel, Escalation, IsolationError
+from claude_code_core.privacy import get_gateway
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["AskCommandCog"]
+
+_MAX_ANSWER_CHARS = 1800
+
+
+class AskCommandCog(commands.Cog):
+    """Slash command for explicit, anonymized escalation to an external model."""
+
+    def __init__(self, bot: commands.Bot, *, model: str = "sonnet") -> None:
+        self.bot = bot
+        self.model = model
+
+    @app_commands.command(
+        name="ask",
+        description="Ask a strong external model one anonymized, self-contained question",
+    )
+    @app_commands.describe(
+        question="Self-contained question. Identifying terms are replaced before it is sent.",
+        show_sent="Also show the exact text that left this machine (default: yes)",
+    )
+    async def ask(
+        self,
+        interaction: discord.Interaction,
+        question: str,
+        show_sent: bool = True,
+    ) -> None:
+        gateway = get_gateway()
+        if gateway is None:
+            await interaction.response.send_message(
+                "`/ask` needs an anonymization rules file. Without one nothing would be "
+                "replaced, so the question is not sent. See docs/anonymization.md.",
+                ephemeral=True,
+            )
+            return
+
+        await interaction.response.defer(thinking=True)
+        escalation = Escalation(gateway=gateway, channel=ConsultChannel(model=self.model))
+
+        try:
+            outcome = await escalation.consult(
+                question,
+                thread_id=getattr(interaction.channel, "id", None),
+                user_id=interaction.user.id,
+            )
+        except IsolationError as exc:
+            logger.warning("Escalation refused: %s", exc)
+            await interaction.followup.send(f"🛑 {exc}")
+            return
+        except Exception:
+            logger.exception("Escalation failed")
+            await interaction.followup.send(
+                "🛑 The external model could not be reached. Nothing was retried automatically."
+            )
+            return
+
+        if outcome.blocked:
+            await interaction.followup.send(f"🛑 {outcome.reason}")
+            return
+
+        parts: list[str] = []
+        if outcome.warning:
+            parts.append(f"⚠️ {outcome.warning}")
+        if show_sent:
+            parts.append(
+                f"📤 **Sent** ({outcome.substitutions} replaced):\n> "
+                + outcome.question_sent.replace("\n", "\n> ")
+            )
+        answer = outcome.answer
+        if len(answer) > _MAX_ANSWER_CHARS:
+            answer = answer[:_MAX_ANSWER_CHARS] + "\n…(truncated)"
+        parts.append(answer)
+        await interaction.followup.send("\n\n".join(parts))
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(AskCommandCog(bot))

--- a/claude_discord/cogs/claude_chat.py
+++ b/claude_discord/cogs/claude_chat.py
@@ -80,6 +80,7 @@ _HELP_CATEGORY: dict[str, str | None] = {
     "model": "🤖 Model",
     "backend": "🤖 Model",
     "engine-status": "🤖 Model",
+    "ask": "🤖 Model",  # one anonymized question to an external model
     "effort": "⚡ Effort",
     "tools-show": "🔧 Advanced",
     "tools-set": "🔧 Advanced",

--- a/claude_discord/setup.py
+++ b/claude_discord/setup.py
@@ -486,6 +486,22 @@ async def setup_bridge(
         await bot.add_cog(backend_cmd_cog)
         logger.info("Registered BackendCommandCog")
 
+    # --- AskCommandCog (auto-discovered: only when anonymization rules exist) ---
+    # Zero-config by the same rule as the gateway itself — no rules file, no
+    # command, because a /ask that forwards real names is worse than none.
+    from claude_code_core.privacy import get_gateway
+
+    try:
+        if get_gateway() is not None:
+            from .cogs.ask_command import AskCommandCog
+
+            await bot.add_cog(AskCommandCog(bot))  # type: ignore[arg-type]
+            logger.info("Registered AskCommandCog (anonymized external escalation)")
+    except Exception:
+        # A broken rules file must not take the whole bot down; the gateway
+        # raises deliberately, and the chat path surfaces it on first use.
+        logger.exception("Could not register AskCommandCog")
+
     components = BridgeComponents(
         session_repo=session_repo,
         task_repo=task_repo,

--- a/docs/escalation.md
+++ b/docs/escalation.md
@@ -1,0 +1,73 @@
+# Explicit escalation — `/ask`
+
+The companion to the [local-model backend](local-backend.md). A thread does its
+work on a model you control; when it needs research, a second opinion or a
+plan, **one** anonymized question goes out and one answer comes back.
+
+```
+/ask <question>
+   │
+   ▼
+anonymization gateway ── identifying terms → stable aliases
+   │
+   ▼
+external CLI, isolated ── no project context, no files, no tools
+   │
+   ▼
+answer, restored to real names, in the thread
+```
+
+## Why this is stronger than anonymizing a normal chat turn
+
+An ordinary session gives the external model your repository and a shell. The
+[gateway](anonymization.md) can only anonymize the message text; everything the
+agent then *reads* goes to the API on its own.
+
+A consult has none of that. The external model receives one string and nothing
+else, so **the audit log is a complete record of what left the machine** — which
+is the property that makes the claim checkable rather than reassuring.
+
+## The isolation, and why it is verified rather than documented
+
+Every consult is checked immediately before the process starts. If any of these
+does not hold, nothing is sent:
+
+| | Why |
+|---|---|
+| `--setting-sources ""` | Otherwise CLAUDE.md, skills and memory are sent |
+| Empty temporary directory as cwd | Nothing local to read |
+| Every tool disallowed | No shell to escape the directory with |
+| `--` before the prompt | Without it the variadic tool list eats the prompt |
+
+The first row is the one that surprises people. Measured with `cwd=/home/ebi`
+and every tool already disabled, changing **only** `--setting-sources`: asked
+whether a term unique to the project's CLAUDE.md was present in its context,
+the model answered "not present" with the flag and "present" without it. A
+naive escalation ships the whole file — customer names included — no matter how
+carefully the question itself was anonymized.
+
+This is a *route*, not a procedure. `verify_isolation()` inspects the argv about
+to be used, so a future refactor that drops a flag fails loudly instead of
+quietly sending more than intended.
+
+## Using it
+
+`/ask` appears only when an anonymization rules file exists. Without rules
+nothing would be replaced, and a command that silently forwards real names is
+worse than no command.
+
+```
+/ask question: How do I debug a conditional access policy that blocks one host?
+```
+
+The reply shows the exact text that was sent (`show_sent`, on by default), then
+the answer with your real names restored. Both are in the audit log.
+
+## Limits
+
+- **One question, no memory.** A consult does not resume; each one starts clean.
+  That is deliberate — a growing conversation would accumulate context nobody
+  audited.
+- **Nothing is retried.** If the external CLI fails, you get the error.
+- **The body still goes out.** Identifiers are replaced; the sentences are not.
+  If the text itself is the secret, do not escalate it.

--- a/tests/test_escalation.py
+++ b/tests/test_escalation.py
@@ -1,0 +1,164 @@
+"""Tests for the explicit escalation channel.
+
+The interesting assertions are all about refusal: the value of this module is
+that it will not send anything when its isolation is not intact.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from claude_code_core.escalation import (
+    CONSULT_DISALLOWED_TOOLS,
+    ConsultChannel,
+    Escalation,
+    IsolationError,
+    verify_isolation,
+)
+from claude_code_core.privacy import (
+    AnonymizationRules,
+    Anonymizer,
+    AuditLog,
+    InspectionPolicy,
+    InspectionResult,
+    MappingStore,
+    PrivacyGateway,
+    Suspect,
+)
+
+RULES = {"terms": [{"value": "Contoso", "category": "org"}], "builtins": []}
+
+
+def make_gateway(policy=InspectionPolicy.OFF, inspection=None, audit_path=None):
+    class _FakeInspector:
+        model = "fake"
+
+        async def inspect(self, text: str) -> InspectionResult:
+            assert inspection is not None
+            return inspection
+
+    return PrivacyGateway(
+        anonymizer=Anonymizer(rules=AnonymizationRules.from_dict(RULES), store=MappingStore()),
+        inspector=_FakeInspector() if inspection is not None else None,  # type: ignore[arg-type]
+        policy=policy,
+        audit=AuditLog(audit_path),
+    )
+
+
+class TestIsolationContract:
+    def test_a_correct_spawn_has_no_problems(self, tmp_path):
+        args = ConsultChannel().build_args("hello")
+        assert verify_isolation(args, tmp_path) == []
+
+    def test_missing_setting_sources_is_caught(self, tmp_path):
+        args = [a for a in ConsultChannel().build_args("hi") if a != "--setting-sources"]
+        problems = verify_isolation(args, tmp_path)
+        assert any("setting-sources" in p for p in problems)
+
+    def test_non_empty_setting_sources_is_caught(self, tmp_path):
+        args = ConsultChannel().build_args("hi")
+        args[args.index("--setting-sources") + 1] = "user"
+        assert any("setting-sources" in p for p in verify_isolation(args, tmp_path))
+
+    def test_missing_separator_is_caught(self, tmp_path):
+        args = [a for a in ConsultChannel().build_args("hi") if a != "--"]
+        assert any("separator" in p for p in verify_isolation(args, tmp_path))
+
+    def test_a_tool_left_enabled_is_caught(self, tmp_path):
+        args = [a for a in ConsultChannel().build_args("hi") if a != "Bash"]
+        problems = verify_isolation(args, tmp_path)
+        assert any("Bash" in p for p in problems)
+
+    def test_a_non_empty_working_directory_is_caught(self, tmp_path):
+        (tmp_path / "CLAUDE.md").write_text("customer notes", encoding="utf-8")
+        assert any(
+            "not empty" in p for p in verify_isolation(ConsultChannel().build_args("hi"), tmp_path)
+        )
+
+    def test_a_missing_working_directory_is_caught(self, tmp_path):
+        problems = verify_isolation(ConsultChannel().build_args("hi"), tmp_path / "absent")
+        assert any("does not exist" in p for p in problems)
+
+    def test_every_known_tool_is_disallowed(self):
+        args = ConsultChannel().build_args("hi")
+        listed = args[args.index("--disallowedTools") + 1 : args.index("--")]
+        assert set(listed) == set(CONSULT_DISALLOWED_TOOLS)
+        # The ones that can reach the filesystem or the network matter most.
+        for tool in ("Bash", "Read", "WebFetch", "Task"):
+            assert tool in listed
+
+    def test_prompt_is_the_last_argument(self):
+        args = ConsultChannel().build_args("the question")
+        assert args[-1] == "the question"
+        assert args[-2] == "--"
+
+
+class TestChannelRefusal:
+    async def test_broken_isolation_sends_nothing(self, monkeypatch):
+        channel = ConsultChannel()
+        monkeypatch.setattr(channel, "build_args", lambda prompt: ["claude", "-p", "--", prompt])
+
+        spawned: list[object] = []
+
+        async def _no_spawn(*args: object, **kwargs: object):
+            spawned.append(args)
+
+        monkeypatch.setattr("asyncio.create_subprocess_exec", _no_spawn)
+
+        with pytest.raises(IsolationError, match="Nothing was sent"):
+            await channel.ask("a question")
+        assert spawned == []
+
+
+class _FakeChannel(ConsultChannel):
+    def __init__(self, answer: str) -> None:
+        super().__init__()
+        self.answer = answer
+        self.received: list[str] = []
+
+    async def ask(self, prompt: str) -> str:
+        self.received.append(prompt)
+        return self.answer
+
+
+class TestEscalation:
+    async def test_question_goes_out_anonymized_and_answer_comes_back_restored(self):
+        gateway = make_gateway()
+        # Mint the alias first so the fake answer can use it.
+        alias = gateway.anonymizer.anonymize("Contoso").replacements[0].alias
+        channel = _FakeChannel(f"You should check {alias}'s tenant settings.")
+        result = await Escalation(gateway=gateway, channel=channel).consult(
+            "Contoso のテナント設定で困っています"
+        )
+
+        assert result.allowed
+        assert "Contoso" not in channel.received[0]
+        assert "Contoso" in result.answer
+        assert result.substitutions == 1
+
+    async def test_a_blocked_question_never_reaches_the_channel(self):
+        gateway = make_gateway(
+            policy=InspectionPolicy.BLOCK,
+            inspection=InspectionResult(suspects=(Suspect(value="Fabrikam"),)),
+        )
+        channel = _FakeChannel("should not happen")
+        result = await Escalation(gateway=gateway, channel=channel).consult("Fabrikam の件")
+
+        assert result.blocked
+        assert channel.received == []
+        assert "Fabrikam" in (result.reason or "")
+
+    async def test_the_audit_records_the_question_and_the_answer(self, tmp_path):
+        import json
+
+        path = tmp_path / "audit.jsonl"
+        gateway = make_gateway(audit_path=path)
+        channel = _FakeChannel("an answer")
+        await Escalation(gateway=gateway, channel=channel).consult("Contoso", thread_id=7)
+
+        records = [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
+        events = [r["event"] for r in records]
+        assert events == ["outbound", "consult_answer"]
+        assert records[0]["kind"] == "consult"
+        assert records[0]["thread_id"] == 7
+        assert "Contoso" not in records[0]["text"]


### PR DESCRIPTION
## Summary

The companion to the local-model backend (#585). A thread works on a model you control; when it needs research, a second opinion or a plan, `/ask` sends **one** anonymized, self-contained question to a strong external model and restores your real names in the answer.

This is (a) of the local-first design — the human decides what escalates. Automatic routing ("plans always go external") builds on the same channel and is the next step.

## Why this is stronger than anonymizing an ordinary chat turn

A normal session hands the external model your repository and a shell. The gateway (#584) can only anonymize the message text; everything the agent then *reads* goes to the API on its own — so the guarantee was never enumerable.

A consult has none of that. The external model receives one string and nothing else, which makes **the audit log a complete record of what left the machine.**

## The finding that shaped it

Isolation is verified immediately before each spawn, and one of the four checks was not obvious:

| Check | Why |
|---|---|
| `--setting-sources ""` | Otherwise CLAUDE.md, skills and memory are sent |
| Empty temporary directory as cwd | Nothing local to read |
| Every tool disallowed | No shell to escape the directory with |
| `--` before the prompt | Without it the variadic tool list eats the prompt |

Measured with `cwd=/home/ebi` and every tool already disabled, changing **only** `--setting-sources`: asked whether a term unique to the project's CLAUDE.md was present in its context, the CLI answered *not present* with the flag and *present* without it.

So a naive escalation ships the entire CLAUDE.md — customer names, project notes, paths — regardless of how carefully the question was anonymized. The privacy gateway cannot prevent this on its own; the two have to be used together.

`verify_isolation()` inspects the argv about to be used rather than trusting the code that built it, so a future refactor that drops a flag fails loudly instead of quietly sending more than intended.

## Behaviour

- `/ask` registers **only** when an anonymization rules file exists — a command that silently forwards real names is worse than no command
- The reply shows the exact text that left the machine (default on), then the answer with real names restored
- One question, no memory, no retry — a resuming consult would accumulate context nobody audited

## Test plan

- [x] `pytest tests/` — 2553 passed (13 new)
- [x] `ruff check` + `ruff format --check` + `pyright` clean
- [x] End-to-end against the real external CLI: a question naming three identifiers went out as `org-001 / person-001 / host-001`, the answer came back with the real names restored, and the same run confirmed in-band that the CLAUDE.md term was **not** in the model's context
- [x] Isolation refusal covered per property — a broken argv raises before any spawn
- [ ] Live verification in Discord

Docs: `docs/escalation.md`, README, CLAUDE.md decision 14.