### PR TITLE
refactor: take the personal half of ThreadCompletionCog out of a public repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`ThreadCompletionCog`'s prompt is external** (`THREAD_COMPLETION_PROMPT_FILE`) — where a
+  completion record goes is one person's note-taking convention, and this repository is public. The
+  Cog keeps the generic half (batching, session/transcript resolution, the manifest) and reads the
+  instance-specific instructions from a file outside the repo. An unreadable path falls back to a
+  generic prompt rather than dropping the batch.
+
+### Added
+
+- **A test that fails when shipped source names a real person** — `examples/ebibot` is a real
+  instance's configuration, so a docstring explaining why a Cog exists is exactly where personal
+  detail leaks in. The check is narrow on purpose: names, not topics.
+
 ### Added
 
 - **`find_transcript(session_id, root)`** in `claude_code_core.transcript_search` — resolves one

--- a/examples/ebibot/cogs/thread_completion.py
+++ b/examples/ebibot/cogs/thread_completion.py
@@ -1,23 +1,32 @@
 """thread_completion.py — deleting a thread files the work as done (custom Cog)
 
-胡田さんはDiscordのスレッドをTodoリストとして使っている。終わったものは自分で
-削除する。つまり **削除イベントは「この作業は完了した」という、人手ゼロで発生する
-高品質なラベル** である。ここではそれを拾って、Obsidianへの記録につなげる。
+Some people keep Discord threads as a to-do list and delete a thread once the
+work in it is finished. Where that is the habit, the delete event is a
+zero-effort completion signal, and this Cog turns it into a written record.
 
-重要な制約: 削除イベントが届いた時点で、そのスレッドのメッセージはもう取得できない
-（チャンネルごと消えている）。だから記録の材料は「ccdbが手元に持っていたもの」——
-セッション行と、`~/.claude/projects/<project>/<session_id>.jsonl` のtranscript——
-に限られる。transcriptにはユーザー発言もClaudeの返答もツール実行も全部入っている
-ので、Discordを別途ミラーする必要はない。
+The constraint that shapes the design: by the time the delete event arrives the
+thread's messages are already unreachable. So the record is built from what ccdb
+still holds — the session row, and the transcript at
+``~/.claude/projects/<project>/<session_id>.jsonl``, which contains the user
+turns, the replies and the tool calls. Nothing needs to mirror Discord.
 
-まとめて消されることが多いので、削除を一定時間ためてから1回だけ記録セッションを
-起こす。1件ごとにセッションを立てると、掃除のたびにスレッドが増えて本末転倒になる。
+Deletions arrive in bursts (a cleanup, not one thread at a time), so they are
+batched over a quiet period and handed to a single session. One session per
+deleted thread would create more threads than the cleanup removed.
+
+**Where the record goes is not decided here.** This Cog resolves the deleted
+threads and hands a manifest to Claude; the instructions for what to write and
+where live in an external prompt file, because that part is specific to one
+person's notes and this repository is public.
 
 Configuration (environment variables):
-    THREAD_COMPLETION_CHANNEL_ID  (required) 記録スレッドを作るチャンネル。
-                                  未設定ならCogは無効。
-    THREAD_COMPLETION_DEBOUNCE    (optional) 静かになってから起動するまでの秒数。
-                                  既定180秒。連続削除を1バッチにまとめるため。
+    THREAD_COMPLETION_CHANNEL_ID  (required) Channel to open the record thread in.
+                                  The Cog is disabled when unset.
+    THREAD_COMPLETION_PROMPT_FILE (optional) Path to a prompt template with
+                                  ``{count}`` and ``{manifest}`` placeholders.
+                                  Falls back to a generic prompt.
+    THREAD_COMPLETION_DEBOUNCE    (optional) Seconds of quiet before the batch
+                                  runs. Default 180.
 """
 
 from __future__ import annotations
@@ -55,42 +64,34 @@ THREAD_COMPLETION_CHANNEL_ID: int | None = int(_raw_channel_id) if _raw_channel_
 
 DEBOUNCE_SECONDS = float(os.environ.get("THREAD_COMPLETION_DEBOUNCE", "180"))
 
+PROMPT_FILE = os.environ.get("THREAD_COMPLETION_PROMPT_FILE", "")
+
 MANIFEST_DIR = str(Path.home() / "ccdb-completions")
 
-_PROMPT = """\
-Discordのスレッドが {count} 件削除されました。
+_DEFAULT_PROMPT = """\
+{count} Discord thread(s) were deleted.
 
-このワークスペースでは **スレッドの削除＝その作業が完了した** という意味です
-（終わったものを自分で消すTodo運用）。削除された分の作業記録をObsidianに残してください。
+In this workspace a deleted thread means **the work in it is finished** — threads
+are kept as a to-do list and removed once done. Write a record of that work.
 
-## 材料
+`{manifest}` lists the deleted threads. Each entry has:
 
-`{manifest}` に削除されたスレッドの一覧が入っています。各要素:
+- `thread_id` / `thread_name` — the Discord identifiers (the thread itself is gone)
+- `summary` — the opening prompt of that session
+- `working_dir` — where the work happened
+- `last_used_at` — when it was last touched
+- `transcript_path` — the full conversation
+  (`~/.claude/projects/.../<session_id>.jsonl`), containing the user turns, the
+  replies and the tool calls. **This is the primary source.**
 
-- `thread_id` / `thread_name` — Discord側の識別子（スレッド自体はもう存在しません）
-- `summary` — そのセッションの最初のプロンプト
-- `working_dir` — 作業ディレクトリ
-- `last_used_at` — 最後にやりとりした時刻
-- `transcript_path` — 会話の全文（`~/.claude/projects/.../<session_id>.jsonl`）。
-  ユーザー発言・返答・ツール実行が全部入っています。**ここが一次情報です**
+Read the manifest, then read as much of each transcript as you need — they can be
+large, so don't load them whole. Where `transcript_path` is null, work from
+`summary` alone and don't guess beyond it.
 
-## やること
+Record the work following this workspace's own conventions. Skip anything not
+worth reading later: a short record of what mattered beats a complete one.
 
-1. マニフェストを読み、各スレッドの transcript を確認して「実際に何をやったか」を掴む
-   （transcriptは大きいことがあるので、全文をコンテキストに載せず必要な範囲を読むこと）
-2. `transcript_path` が null のものは `summary` だけで判断する。無理に推測しない
-3. CLAUDE.md の記録ルールに従って書く:
-   - プロジェクトに紐づく作業 → 該当プロジェクトの `log.md` に詳細、`status.md` を更新
-     （完了したタスクは `[ ]` → `[x]` に必ず変える）
-   - デイリーノート `obsidian/01_Daily/YYYY-MM-DD.md` には wikilink + 1行サマリーだけ
-4. 知識が生まれていたら 3点セット（wiki / KB / ADR）に入れる。無理に作らない
-5. 雑談・確認だけで終わったもの、記録する価値がないものは **書かない**。
-   「全部書く」より「後で読む価値があるものだけ書く」を優先する
-
-## 報告
-
-このスレッドに、何を記録したか（と、記録しなかったものと理由）を簡潔に報告してください。
-報告が終わったらこのスレッドも消して構いません。
+Report in this thread what you recorded, and what you skipped and why.
 """
 
 
@@ -164,8 +165,25 @@ def write_manifest(records: list[CompletionRecord], directory: str, stamp: str) 
     return str(path)
 
 
-def build_prompt(manifest_path: str, records: list[CompletionRecord]) -> str:
-    return _PROMPT.format(count=len(records), manifest=manifest_path)
+def load_template(prompt_file: str | None) -> str:
+    """The instance's prompt, or the generic one.
+
+    An unreadable path falls back rather than raising: losing the record's
+    wording is recoverable, losing the whole batch is not.
+    """
+    if not prompt_file:
+        return _DEFAULT_PROMPT
+    try:
+        return Path(prompt_file).read_text(encoding="utf-8")
+    except OSError:
+        logger.exception("thread_completion: cannot read %s; using default prompt", prompt_file)
+        return _DEFAULT_PROMPT
+
+
+def build_prompt(
+    manifest_path: str, records: list[CompletionRecord], template: str | None = None
+) -> str:
+    return (template or _DEFAULT_PROMPT).format(count=len(records), manifest=manifest_path)
 
 
 # ---------------------------------------------------------------------------
@@ -174,7 +192,7 @@ def build_prompt(manifest_path: str, records: list[CompletionRecord]) -> str:
 
 
 class ThreadCompletionCog(commands.Cog):
-    """Batches thread deletions and files the finished work in Obsidian."""
+    """Batches thread deletions and files the finished work as a record."""
 
     def __init__(self, bot: commands.Bot, runner: object, components: object) -> None:
         self.bot = bot
@@ -259,7 +277,7 @@ class ThreadCompletionCog(commands.Cog):
             RunConfig(
                 thread=thread,
                 runner=cloned_runner,
-                prompt=build_prompt(manifest, records),
+                prompt=build_prompt(manifest, records, load_template(PROMPT_FILE)),
                 session_id=None,
                 repo=session_repo,
                 registry=registry,

--- a/tests/test_no_personal_identifiers.py
+++ b/tests/test_no_personal_identifiers.py
@@ -1,0 +1,47 @@
+"""Source that ships in a public repository must not name a real person.
+
+``examples/ebibot`` is a real instance's configuration, so it is the place where
+personal detail leaks in: a docstring explaining *why* a Cog exists is the most
+natural thing in the world to write, and the natural way to write it is to name
+the person whose workflow it serves. This test makes that a build failure rather
+than something a reviewer has to notice.
+
+The check is deliberately narrow — names, not topics. A broad "no Japanese", or
+a list of tools someone might use, produces false positives that get suppressed,
+and a suppressed guard is not a guard.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_REPO = Path(__file__).parent.parent
+
+_SCANNED_ROOTS = (
+    _REPO / "claude_discord",
+    _REPO / "claude_code_core",
+    _REPO / "claude_teams",
+    _REPO / "examples",
+)
+
+# Real-person identifiers. The GitHub account name is excluded on purpose: it is
+# the repository owner and appears legitimately in clone URLs.
+_PERSONAL = re.compile(r"胡田|ebisuda", re.IGNORECASE)
+
+
+def test_no_personal_identifiers_in_shipped_source() -> None:
+    violations = []
+    for root in _SCANNED_ROOTS:
+        for path in sorted(root.rglob("*.py")):
+            if "__pycache__" in path.parts:
+                continue
+            for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+                if _PERSONAL.search(line):
+                    violations.append(f"  {path.relative_to(_REPO)}:{lineno}: {line.strip()[:80]}")
+
+    assert not violations, (
+        "This repository is public. Source must not name a real person — put the "
+        "personal half in an external file the instance points at (see "
+        "THREAD_COMPLETION_PROMPT_FILE for the pattern):\n" + "\n".join(violations)
+    )

--- a/tests/test_thread_completion.py
+++ b/tests/test_thread_completion.py
@@ -25,6 +25,7 @@ from examples.ebibot.cogs.thread_completion import (  # noqa: E402
     CompletionRecord,
     build_prompt,
     collect_records,
+    load_template,
     write_manifest,
 )
 
@@ -137,3 +138,29 @@ class TestBuildPrompt:
     def test_prompt_states_the_count(self) -> None:
         recs = [CompletionRecord(i, "s", None, None, None, None) for i in range(3)]
         assert "3" in build_prompt("/tmp/m.json", recs)
+
+
+class TestLoadTemplate:
+    """The instance's wording lives outside this repository, which is public."""
+
+    def test_no_file_configured_falls_back_to_the_generic_prompt(self) -> None:
+        template = load_template("")
+        assert "{count}" in template and "{manifest}" in template
+        rendered = build_prompt(
+            "/tmp/m.json", [CompletionRecord(1, "s", None, None, None, None)], template
+        )
+        assert "{" not in rendered  # every placeholder was filled
+        assert "deleted" in rendered.lower()
+
+    def test_an_external_template_is_used_verbatim(self, tmp_path) -> None:
+        path = tmp_path / "prompt.md"
+        path.write_text("{count}件を{manifest}から記録して", encoding="utf-8")
+        prompt = build_prompt(
+            "/tmp/m.json",
+            [CompletionRecord(1, "s", None, None, None, None)],
+            load_template(str(path)),
+        )
+        assert prompt == "1件を/tmp/m.jsonから記録して"
+
+    def test_an_unreadable_template_falls_back_instead_of_losing_the_batch(self) -> None:
+        assert load_template("/nonexistent/prompt.md") == load_template("")


### PR DESCRIPTION
## What was wrong

#624 added `ThreadCompletionCog` with a docstring that named a real person and a prompt that hardcoded one person's note structure and file paths. This repository is public.

No other Cog under `examples/ebibot` does this — every existing one is free of personal identifiers. The leak was introduced by that PR, not inherited.

## The split

The Cog does the generic half and nothing else:

- batch deletions over a quiet period
- resolve each deleted thread against its session row and on-disk transcript
- write a manifest
- open one thread and hand the manifest to a session

**Where the record goes** is an instance's own convention, so it comes from `THREAD_COMPLETION_PROMPT_FILE` — a template with `{count}` and `{manifest}` placeholders, living outside this repository. Unset falls back to a generic prompt that says "record it following this workspace's conventions" without naming any.

An unreadable path logs and falls back rather than raising: losing the record's wording is recoverable, losing the whole batch is not.

## The guard

`tests/test_no_personal_identifiers.py` fails when source under `claude_discord/`, `claude_code_core/`, `claude_teams/` or `examples/` names a real person. Confirmed RED against the merged state of #624.

It matches names, not topics. A broader rule — "no Japanese", or a list of tools someone might use — produces false positives, and a guard that gets suppressed is not a guard. The repository owner's GitHub account name is excluded deliberately: it appears in clone URLs.

## Test plan

- `TestLoadTemplate` — 3 tests: fallback when unconfigured (and every placeholder filled on render), an external template used verbatim, an unreadable path falling back instead of losing the batch.
- `ruff check` / `ruff format --check` clean; `pyright claude_discord/` 0 errors; full suite **2572 passed**.