### PR TITLE
docs: document THREAD_COMPLETION_PROMPT_FILE

### DIFF
--- a/examples/ebibot/.env.example
+++ b/examples/ebibot/.env.example
@@ -53,3 +53,4 @@ SESSION_TIMEOUT_SECONDS=300
 # Thread Completion: a deleted thread means that work is finished — file a record of it
 # THREAD_COMPLETION_CHANNEL_ID=YOUR_CHANNEL_ID      # required — Cog is disabled if not set
 # THREAD_COMPLETION_DEBOUNCE=180                    # seconds of quiet before the batch is filed
+# THREAD_COMPLETION_PROMPT_FILE=/path/to/prompt.md  # where the record goes; {count} + {manifest}

--- a/examples/ebibot/README.md
+++ b/examples/ebibot/README.md
@@ -87,9 +87,24 @@ Two consequences worth knowing before enabling it:
   watches) have no session row, and filing "work completed" for them would be a lie. The Cog's own
   record threads are ignored too, so deleting a record does not file a record about it.
 
+**Where the record goes is not decided by the Cog.** Note-taking conventions — which file, which
+folder, which headings — are personal, and this repository is public, so the Cog resolves the
+deleted threads and hands over a manifest while the instructions live in an external template at
+`THREAD_COMPLETION_PROMPT_FILE`. The template takes two placeholders:
+
+| Placeholder | Expands to |
+|-------------|------------|
+| `{count}` | How many threads were deleted in this batch |
+| `{manifest}` | Path to the JSON listing them, each with `summary` and `transcript_path` |
+
+Leave it unset and a generic prompt is used, which says to record the work following the
+workspace's own conventions without naming any. An unreadable path falls back to that same generic
+prompt rather than dropping the batch — losing the wording is recoverable, losing the batch is not.
+
 Configuration (the Cog is disabled unless the channel is set):
 
 | Variable | Default | Purpose |
 |----------|---------|---------|
 | `THREAD_COMPLETION_CHANNEL_ID` | — (required) | Channel the record thread is created in |
 | `THREAD_COMPLETION_DEBOUNCE` | `180` | Seconds of quiet before the batch is filed |
+| `THREAD_COMPLETION_PROMPT_FILE` | — (generic prompt) | Template saying what to record and where |


### PR DESCRIPTION
## Why

#627 moved `ThreadCompletionCog`'s instructions out of the source and into an external template, but the docs written by #626 predate that change. They list `THREAD_COMPLETION_CHANNEL_ID` and `THREAD_COMPLETION_DEBOUNCE` only — so the one variable that decides *what actually gets written* was undiscoverable, and the reason it lives outside the repository was unexplained.

## Change

- `examples/ebibot/.env.example` — the variable, with its two placeholders noted inline
- `examples/ebibot/README.md` — a short section explaining that note-taking conventions are personal and this repository is public, the `{count}` / `{manifest}` contract, and the fallback behaviour when the path is unset or unreadable

## Test plan

Documentation only; no source changed. `tests/test_no_personal_identifiers.py` and `tests/test_thread_completion.py` pass, and the diff was checked for personal identifiers and instance-specific paths before committing.