### PR TITLE
[docs-sync] De-duplicate the THREAD_COMPLETION_PROMPT_FILE documentation

### DIFF
--- a/examples/ebibot/.env.example
+++ b/examples/ebibot/.env.example
@@ -54,4 +54,3 @@ SESSION_TIMEOUT_SECONDS=300
 # THREAD_COMPLETION_CHANNEL_ID=YOUR_CHANNEL_ID      # required — Cog is disabled if not set
 # THREAD_COMPLETION_PROMPT_FILE=/path/to/prompt.md  # your own instructions; {count} and {manifest}
 # THREAD_COMPLETION_DEBOUNCE=180                    # seconds of quiet before the batch is filed
-# THREAD_COMPLETION_PROMPT_FILE=/path/to/prompt.md  # where the record goes; {count} + {manifest}

--- a/examples/ebibot/README.md
+++ b/examples/ebibot/README.md
@@ -94,19 +94,12 @@ Three consequences worth knowing before enabling it:
   than dropping the batch, since losing the record's wording is recoverable and losing the batch is
   not.
 
-**Where the record goes is not decided by the Cog.** Note-taking conventions — which file, which
-folder, which headings — are personal, and this repository is public, so the Cog resolves the
-deleted threads and hands over a manifest while the instructions live in an external template at
-`THREAD_COMPLETION_PROMPT_FILE`. The template takes two placeholders:
+The prompt template takes two placeholders:
 
 | Placeholder | Expands to |
 |-------------|------------|
 | `{count}` | How many threads were deleted in this batch |
-| `{manifest}` | Path to the JSON listing them, each with `summary` and `transcript_path` |
-
-Leave it unset and a generic prompt is used, which says to record the work following the
-workspace's own conventions without naming any. An unreadable path falls back to that same generic
-prompt rather than dropping the batch — losing the wording is recoverable, losing the batch is not.
+| `{manifest}` | Path to the JSON listing them. Each entry carries `summary` and `transcript_path`, the latter `null` when no transcript survives |
 
 Configuration (the Cog is disabled unless the channel is set):
 
@@ -115,4 +108,3 @@ Configuration (the Cog is disabled unless the channel is set):
 | `THREAD_COMPLETION_CHANNEL_ID` | — (required) | Channel the record thread is created in |
 | `THREAD_COMPLETION_PROMPT_FILE` | — (generic prompt) | Prompt template holding the instance's own instructions, with `{count}` and `{manifest}` placeholders |
 | `THREAD_COMPLETION_DEBOUNCE` | `180` | Seconds of quiet before the batch is filed |
-| `THREAD_COMPLETION_PROMPT_FILE` | — (generic prompt) | Template saying what to record and where |


### PR DESCRIPTION
## Summary

`#629` re-documented `THREAD_COMPLETION_PROMPT_FILE`, which `#628` had already documented. The two
landed on top of each other, so `examples/ebibot/` shipped the same facts three times over. This PR
removes the duplication and keeps the one piece of information `#629` genuinely added.

What was duplicated:

| File | Duplication |
|------|-------------|
| `.env.example` | `THREAD_COMPLETION_PROMPT_FILE` listed twice, the second copy after `THREAD_COMPLETION_DEBOUNCE` and outside its own group |
| `README.md` | A prose block restating the third bullet of "Three consequences" |
| `README.md` | A second `THREAD_COMPLETION_PROMPT_FILE` row in the configuration table |

What was kept: the placeholder table. The bullet list says *why* the prompt file exists and how an
unreadable path falls back; it never said what `{count}` and `{manifest}` expand to. That table now
follows the bullets without repeating them.

One correction while verifying against the source: `write_manifest()` serialises `CompletionRecord`,
whose `transcript_path` is whatever `find_transcript()` returned — `None` when no transcript
survives. The table says so rather than implying every entry has a path.

## Verification

- Read `examples/ebibot/cogs/thread_completion.py` — `build_prompt()` formats `{count}` and
  `{manifest}`; `write_manifest()` writes `{"deleted_at": ..., "threads": [...]}`
- Root `README.md` / `CONTRIBUTING.md` and their `docs/ja/` translations already describe this
  feature and are structurally in sync (104 headings each) — no translation drift to correct
- Documentation only; no source, no tests touched

## 日本語

`#629` が `#628` と同じ内容を再度追記したため、`examples/ebibot/` に同じ説明が重複していました。
本 PR はその重複を解消し、`#629` が実際に追加した情報（プレースホルダ表）だけを残します。

- `.env.example`: `THREAD_COMPLETION_PROMPT_FILE` の重複行を削除
- `README.md`: 箇条書きを言い換えただけの散文ブロックを削除し、プレースホルダ表のみ残置
- `README.md`: 設定表の重複行を削除
- 表の記述をソースに合わせて修正 — `transcript_path` は transcript が残っていない場合 `null`

ルートの `README.md` / `CONTRIBUTING.md` と `docs/ja/` の翻訳は既に同期済みのため変更なし。
