### PR TITLE
feat: make thread-completion recording opt-in, off by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Thread-completion recording is opt-in, off by default** — deleting a thread is an everyday,
+  destructive act, and having it silently start a Claude session is a surprise. `/thread-completion
+  on|off` throws the switch and the answer is stored, so it survives a restart; the environment
+  variables now decide only whether the switch exists. The state is re-checked after the debounce
+  window, so turning it off during the wait drops the pending batch. Anything other than a stored
+  "on" — no settings repo, no value, a failed read — is off, because the absence of an answer is
+  not permission.
+
+### Changed
+
 - **`ThreadCompletionCog`'s prompt is external** (`THREAD_COMPLETION_PROMPT_FILE`) — where a
   completion record goes is one person's note-taking convention, and this repository is public. The
   Cog keeps the generic half (batching, session/transcript resolution, the manifest) and reads the

--- a/examples/ebibot/.env.example
+++ b/examples/ebibot/.env.example
@@ -51,6 +51,7 @@ SESSION_TIMEOUT_SECONDS=300
 # JOB_TRIAGE_CHANNEL_ID=YOUR_CHANNEL_ID             # required — Cog is disabled if not set
 
 # Thread Completion: a deleted thread means that work is finished — file a record of it
+# Recording stays OFF until you run /thread-completion on; these only build the switch.
 # THREAD_COMPLETION_CHANNEL_ID=YOUR_CHANNEL_ID      # required — Cog is disabled if not set
 # THREAD_COMPLETION_PROMPT_FILE=/path/to/prompt.md  # your own instructions; {count} and {manifest}
 # THREAD_COMPLETION_DEBOUNCE=180                    # seconds of quiet before the batch is filed

--- a/examples/ebibot/README.md
+++ b/examples/ebibot/README.md
@@ -78,7 +78,21 @@ already held — the session row, and the transcript at
 `~/.claude/projects/<project>/<session_id>.jsonl`, which contains every user turn, reply, and tool
 call. That transcript is the primary source, so there is no need to mirror Discord separately.
 
-Three consequences worth knowing before enabling it:
+**Recording is off until you turn it on.** Deleting a thread is an everyday, destructive act, and
+having it silently start a Claude session is a surprise — so consent is explicit:
+
+```
+/thread-completion on      # deletions start being recorded
+/thread-completion off     # deletions do nothing again
+/thread-completion         # show the current state
+```
+
+The environment variables below decide only whether the switch *exists*, never whether it is
+thrown. The answer is stored in the settings repo, so it survives a restart. It is also re-checked
+after the quiet period: turning it off during the wait drops the pending batch, because "stop" said
+before anything ran should be honoured.
+
+Three consequences worth knowing before turning it on:
 
 - **Deletions are batched.** Threads are usually cleaned up in bursts, so the Cog waits for a quiet
   period and then starts *one* session for the whole batch. Filing one session per deleted thread
@@ -101,7 +115,8 @@ The prompt template takes two placeholders:
 | `{count}` | How many threads were deleted in this batch |
 | `{manifest}` | Path to the JSON listing them. Each entry carries `summary` and `transcript_path`, the latter `null` when no transcript survives |
 
-Configuration (the Cog is disabled unless the channel is set):
+Configuration (the Cog is not loaded at all unless the channel is set, and recording
+stays off until `/thread-completion on`):
 
 | Variable | Default | Purpose |
 |----------|---------|---------|

--- a/examples/ebibot/cogs/thread_completion.py
+++ b/examples/ebibot/cogs/thread_completion.py
@@ -19,6 +19,12 @@ threads and hands a manifest to Claude; the instructions for what to write and
 where live in an external prompt file, because that part is specific to one
 person's notes and this repository is public.
 
+**Recording is off until the user turns it on** with ``/thread-completion on``.
+Deleting a thread is an everyday, destructive act, and having it silently spawn a
+Claude session is a surprise; the environment variables below only decide whether
+the switch exists, never whether it is thrown. The answer is stored so it survives
+a restart.
+
 Configuration (environment variables):
     THREAD_COMPLETION_CHANNEL_ID  (required) Channel to open the record thread in.
                                   The Cog is disabled when unset.
@@ -41,6 +47,7 @@ from pathlib import Path
 from typing import Any
 
 import discord
+from discord import app_commands
 from discord.ext import commands
 
 from claude_code_core.transcript_search import default_transcripts_root, find_transcript
@@ -67,6 +74,9 @@ DEBOUNCE_SECONDS = float(os.environ.get("THREAD_COMPLETION_DEBOUNCE", "180"))
 PROMPT_FILE = os.environ.get("THREAD_COMPLETION_PROMPT_FILE", "")
 
 MANIFEST_DIR = str(Path.home() / "ccdb-completions")
+
+# Settings key holding the user's answer to "should a deletion record anything?".
+ENABLED_KEY = "thread_completion.enabled"
 
 _DEFAULT_PROMPT = """\
 {count} Discord thread(s) were deleted.
@@ -165,6 +175,27 @@ def write_manifest(records: list[CompletionRecord], directory: str, stamp: str) 
     return str(path)
 
 
+async def is_enabled(settings_repo: Any) -> bool:
+    """Whether the user has turned recording on. Off unless they said otherwise.
+
+    Deleting a thread is an everyday, destructive act; having it silently spawn a
+    Claude session is a surprise, so consent is explicit and opt-in. Anything
+    other than a stored "on" — no repo, no value, a failed read — is off, because
+    the absence of an answer is not permission.
+    """
+    if settings_repo is None:
+        return False
+    try:
+        return await settings_repo.get(ENABLED_KEY) == "1"
+    except Exception:
+        logger.exception("thread_completion: cannot read %s; treating as off", ENABLED_KEY)
+        return False
+
+
+async def set_enabled(settings_repo: Any, enabled: bool) -> None:
+    await settings_repo.set(ENABLED_KEY, "1" if enabled else "0")
+
+
 def load_template(prompt_file: str | None) -> str:
     """The instance's prompt, or the generic one.
 
@@ -206,10 +237,55 @@ class ThreadCompletionCog(commands.Cog):
         # record about filing a record.
         self._own_threads: set[int] = set()
 
+    @property
+    def _settings_repo(self) -> Any:
+        return getattr(self.components, "settings_repo", None)
+
+    @app_commands.command(
+        name="thread-completion",
+        description="Record finished work when a thread is deleted (off by default)",
+    )
+    @app_commands.describe(switch="on, off, or leave empty to see the current state")
+    @app_commands.choices(
+        switch=[
+            app_commands.Choice(name="on", value="on"),
+            app_commands.Choice(name="off", value="off"),
+        ]
+    )
+    async def thread_completion(
+        self, interaction: discord.Interaction, switch: str | None = None
+    ) -> None:
+        repo = self._settings_repo
+        if repo is None:
+            await interaction.response.send_message(
+                "⚠️ No settings store, so the switch can't be remembered — recording stays off.",
+                ephemeral=True,
+            )
+            return
+
+        if switch is None:
+            state = "on" if await is_enabled(repo) else "off"
+            await interaction.response.send_message(
+                f"Thread-completion recording is **{state}**.", ephemeral=True
+            )
+            return
+
+        await set_enabled(repo, switch == "on")
+        if switch == "on":
+            message = (
+                "✅ Thread-completion recording is **on**. Deleting a thread now files a record of "
+                f"the work in it, {int(DEBOUNCE_SECONDS)}s after the last deletion."
+            )
+        else:
+            message = "🛑 Thread-completion recording is **off**. Deleting a thread does nothing."
+        await interaction.response.send_message(message, ephemeral=True)
+
     @commands.Cog.listener()
     async def on_raw_thread_delete(self, payload: discord.RawThreadDeleteEvent) -> None:
         if payload.thread_id in self._own_threads:
             self._own_threads.discard(payload.thread_id)
+            return
+        if not await is_enabled(self._settings_repo):
             return
         self._pending.append(payload.thread_id)
         self._schedule_flush()
@@ -227,6 +303,11 @@ class ThreadCompletionCog(commands.Cog):
             return
         batch, self._pending = self._pending, []
         if not batch:
+            return
+        # Checked again: the switch may have been turned off during the wait, and
+        # "stop" given before anything ran should be honoured.
+        if not await is_enabled(self._settings_repo):
+            logger.info("thread_completion: switched off while waiting; dropping %d", len(batch))
             return
         try:
             await self._file_records(batch)
@@ -297,6 +378,7 @@ async def setup(bot: commands.Bot, runner: object, components: object) -> None:
 
     await bot.add_cog(ThreadCompletionCog(bot, runner, components))
     logger.info(
-        "ThreadCompletionCog loaded — deleted threads are filed as completed work in channel %d",
+        "ThreadCompletionCog loaded — recording is OFF until /thread-completion on; "
+        "records would go to channel %d",
         THREAD_COMPLETION_CHANNEL_ID,
     )

--- a/tests/test_thread_completion.py
+++ b/tests/test_thread_completion.py
@@ -25,7 +25,9 @@ from examples.ebibot.cogs.thread_completion import (  # noqa: E402
     CompletionRecord,
     build_prompt,
     collect_records,
+    is_enabled,
     load_template,
+    set_enabled,
     write_manifest,
 )
 
@@ -164,3 +166,50 @@ class TestLoadTemplate:
 
     def test_an_unreadable_template_falls_back_instead_of_losing_the_batch(self) -> None:
         assert load_template("/nonexistent/prompt.md") == load_template("")
+
+
+class TestEnabledSwitch:
+    """The Cog does nothing until the user turns it on.
+
+    Deleting a thread is a destructive, everyday act; having it silently spawn a
+    session is a surprise. So the switch defaults to off and the state survives a
+    restart, which means it lives in the settings repo rather than in memory.
+    """
+
+    @pytest.mark.asyncio
+    async def test_default_is_off(self) -> None:
+        repo = MagicMock()
+        repo.get = AsyncMock(return_value=None)
+        assert await is_enabled(repo) is False
+
+    @pytest.mark.asyncio
+    async def test_on_after_being_set(self) -> None:
+        repo = MagicMock()
+        repo.get = AsyncMock(return_value="1")
+        assert await is_enabled(repo) is True
+
+    @pytest.mark.asyncio
+    async def test_explicit_off_is_off(self) -> None:
+        repo = MagicMock()
+        repo.get = AsyncMock(return_value="0")
+        assert await is_enabled(repo) is False
+
+    @pytest.mark.asyncio
+    async def test_no_settings_repo_is_off(self) -> None:
+        """Without somewhere to store consent, assume it wasn't given."""
+        assert await is_enabled(None) is False
+
+    @pytest.mark.asyncio
+    async def test_an_unreadable_setting_is_off(self) -> None:
+        """A broken read must not be read as permission."""
+        repo = MagicMock()
+        repo.get = AsyncMock(side_effect=RuntimeError("db is locked"))
+        assert await is_enabled(repo) is False
+
+    @pytest.mark.asyncio
+    async def test_set_enabled_persists_both_directions(self) -> None:
+        repo = MagicMock()
+        repo.set = AsyncMock()
+        await set_enabled(repo, True)
+        await set_enabled(repo, False)
+        assert [c.args[1] for c in repo.set.call_args_list] == ["1", "0"]


### PR DESCRIPTION
## Why

`ThreadCompletionCog` started recording as soon as the channel id was configured. Deleting a thread is an everyday, destructive act — having it silently start a Claude session is a surprise, and "I set an environment variable once" is weak evidence that the user wants it happening every time from now on.

## Change

Recording is **off unless the user turns it on**. The environment variables now decide only whether the switch *exists*.

```
/thread-completion on      # deletions start being recorded
/thread-completion off     # deletions do nothing again
/thread-completion         # show the current state
```

The answer is stored in `SettingsRepository` under `thread_completion.enabled`, so it survives a restart — an in-memory flag would silently re-arm itself on the next deploy, which is the same surprise in slower motion.

**Checked twice.** Once when the delete event arrives (nothing is even queued while off), and again after the debounce window — so turning it off during the wait drops the pending batch. "Stop" said before anything ran should be honoured.

**Every ambiguous state is off.** No settings repo, no stored value, or a read that raises all resolve to off, because the absence of an answer is not permission. A `/thread-completion` with no settings store says so rather than pretending the switch works.

## Also in this PR

`docs-sync` (#628) and #629 both documented `THREAD_COMPLETION_PROMPT_FILE` independently and both landed, leaving a duplicated paragraph, a duplicated table row and a duplicated `.env.example` line. Removed — keeping the docs-sync wording.

## Test plan

- 6 new tests on the switch: default off, on after being set, explicit off, no settings repo, an unreadable setting, and both directions persisting. Written first; confirmed RED on `ImportError`.
- `ruff check` / `ruff format --check` clean; `pyright claude_discord/` 0 errors; full suite **2578 passed**.
- Not yet exercised on a live bot — the running instance predates this branch.