### PR TITLE
[docs-sync] State that thread-completion recording is off by default (English + Japanese)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   "on" — no settings repo, no value, a failed read — is off, because the absence of an answer is
   not permission.
 
-### Changed
-
 - **`ThreadCompletionCog`'s prompt is external** (`THREAD_COMPLETION_PROMPT_FILE`) — where a
   completion record goes is one person's note-taking convention, and this repository is public. The
   Cog keeps the generic half (batching, session/transcript resolution, the manifest) and reads the

--- a/README.md
+++ b/README.md
@@ -680,7 +680,7 @@ See [`examples/ebibot/`](examples/ebibot/) for a full real-world example with re
 | `DocsSyncCog` | Automated documentation sync on push |
 | `AlertResponderCog` | Generic alert monitoring — forwards alerts from monitoring systems to Discord and triggers a Claude Code investigation session |
 | `JobFailureTriageCog` | Auto-investigates scheduler job failures posted as webhook embeds |
-| `ThreadCompletionCog` | Treats "the user deleted the thread" as "that work is finished" — batches deletions and files a work record from the surviving transcripts |
+| `ThreadCompletionCog` | Treats "the user deleted the thread" as "that work is finished" — batches deletions and files a work record from the surviving transcripts. Off until `/thread-completion on` |
 
 ---
 
@@ -1363,7 +1363,7 @@ The project started on 2026-02-18 and continues to evolve through iterative conv
 - **DocsSyncCog** — Auto-translate documentation on push via webhook
 - **AlertResponderCog** — Generic alert-monitoring Cog; watches a configurable source and posts severity-annotated notifications to Discord
 - **JobFailureTriageCog** — Picks up scheduler job-failure embeds and starts a triage session
-- **ThreadCompletionCog** — Deleting a thread means the work is done; deletions are batched and filed as a written record built from the session transcript, since the thread's messages are already gone. What that record says and where it goes comes from an external prompt file (`THREAD_COMPLETION_PROMPT_FILE`), not from the Cog
+- **ThreadCompletionCog** — Deleting a thread means the work is done; deletions are batched and filed as a written record built from the session transcript, since the thread's messages are already gone. What that record says and where it goes comes from an external prompt file (`THREAD_COMPLETION_PROMPT_FILE`), not from the Cog. Recording is off until you run `/thread-completion on` — the environment variables decide only whether the switch exists
 
 Run it with: `ccdb start --cogs-dir examples/ebibot/cogs/`
 

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -681,7 +681,7 @@ async def setup(bot, runner, components):
 | `DocsSyncCog` | プッシュ時の自動ドキュメント同期 |
 | `AlertResponderCog` | 汎用アラート監視 — 監視システムからのアラートを Discord に転送し、Claude Code による調査セッションをトリガー |
 | `JobFailureTriageCog` | Webhook の embed として投稿されたスケジューラージョブの失敗を自動でトリアージ |
-| `ThreadCompletionCog` | 「スレッドを削除した」＝「その作業が完了した」とみなす — 削除をまとめて、残っている transcript から作業記録を書き起こす |
+| `ThreadCompletionCog` | 「スレッドを削除した」＝「その作業が完了した」とみなす — 削除をまとめて、残っている transcript から作業記録を書き起こす。`/thread-completion on` を実行するまでは無効 |
 
 ---
 
@@ -1361,7 +1361,7 @@ uv run pytest tests/ -v --cov=claude_discord
 - **DocsSyncCog** — push 時の Webhook 経由でドキュメントを自動翻訳
 - **AlertResponderCog** — 汎用アラート監視 Cog。設定可能なソースを監視し、重要度付き通知を Discord に投稿
 - **JobFailureTriageCog** — スケジューラージョブの失敗 embed を拾ってトリアージセッションを開始
-- **ThreadCompletionCog** — スレッドの削除は作業完了の合図。削除をまとめて 1 件の作業記録にする。スレッドのメッセージはすでに消えているため、記録はセッションの transcript から組み立てる。何をどこに記録するかは Cog ではなく外部のプロンプトファイル（`THREAD_COMPLETION_PROMPT_FILE`）が決める
+- **ThreadCompletionCog** — スレッドの削除は作業完了の合図。削除をまとめて 1 件の作業記録にする。スレッドのメッセージはすでに消えているため、記録はセッションの transcript から組み立てる。何をどこに記録するかは Cog ではなく外部のプロンプトファイル（`THREAD_COMPLETION_PROMPT_FILE`）が決める。記録は `/thread-completion on` を実行するまで無効 — 環境変数はスイッチを「用意する」だけで、入れるかどうかは決めない
 
 実行方法: `ccdb start --cogs-dir examples/ebibot/cogs/`
 


### PR DESCRIPTION
## Summary

Syncs the documentation with e8f6d85 (*make thread-completion recording opt-in, off by default*).
That commit updated `examples/ebibot/README.md` and `.env.example`, but the root `README.md` still
described `ThreadCompletionCog` as if setting the environment variables were enough to make it run.
It is not: recording stays off until `/thread-completion on`, so the previous wording would read as
"the feature is broken" to anyone who configured it and deleted a thread.

- `README.md` — both places that describe `ThreadCompletionCog` (the example-Cog table and the
  Real-World Example list) now state that recording is off until `/thread-completion on`, and that
  the environment variables decide only whether the switch exists.
- `docs/ja/README.md` — the same two entries, translated.
- `CHANGELOG.md` — removed a duplicated `### Changed` heading inside `[Unreleased]`, which left the
  two thread-completion entries split across two identical sections.

No source-code changes.

## 概要

e8f6d85（*thread-completion の記録を opt-in・既定 OFF にする*）にドキュメントを追従させます。
同コミットは `examples/ebibot/README.md` と `.env.example` を更新していましたが、ルートの
`README.md` は `ThreadCompletionCog` を「環境変数を設定すれば動く」と読める記述のままでした。
実際には `/thread-completion on` を実行するまで記録は行われないため、設定してスレッドを削除した
利用者には「壊れている」ように見えてしまいます。

- `README.md` — `ThreadCompletionCog` を説明している 2 箇所（Cog 一覧表と Real-World Example）に、
  記録は `/thread-completion on` まで無効であること、環境変数はスイッチを用意するだけであることを明記。
- `docs/ja/README.md` — 対応する 2 箇所を翻訳して同期。
- `CHANGELOG.md` — `[Unreleased]` 内で `### Changed` が重複し、thread-completion の 2 項目が
  同名セクションに分断されていたので統合。

ソースコードの変更はありません。

## Test plan

- [x] `git diff` limited to `README.md`, `docs/ja/README.md`, `CHANGELOG.md`
- [x] `[Unreleased]` now contains exactly one `### Changed` heading
- [x] Documented behaviour matches `is_enabled()` / the `/thread-completion` command in
      `examples/ebibot/cogs/thread_completion.py`
