### PR TITLE
fix: deliver the scheduled notifications the REST API accepts

### DIFF
--- a/claude_discord/__init__.py
+++ b/claude_discord/__init__.py
@@ -18,6 +18,7 @@ from .cogs.claude_chat import ClaudeChatCog
 from .cogs.collision_watch import CollisionWatchCog
 from .cogs.context_links import ContextLinksCog
 from .cogs.event_processor import EventProcessor
+from .cogs.notification_dispatch import NotificationDispatchCog
 from .cogs.run_config import RunConfig
 from .cogs.scheduler import SchedulerCog
 from .cogs.session_manage import SessionManageCog
@@ -69,6 +70,7 @@ __all__ = [
     "AutoUpgradeCog",
     "UpgradeConfig",
     # Scheduling
+    "NotificationDispatchCog",
     "SchedulerCog",
     "ScheduledTaskRepository",
     "DrainAware",

--- a/claude_discord/cogs/__init__.py
+++ b/claude_discord/cogs/__init__.py
@@ -6,6 +6,7 @@ from .claude_chat import ClaudeChatCog
 from .collision_watch import CollisionWatchCog
 from .context_links import ContextLinksCog
 from .event_processor import EventProcessor
+from .notification_dispatch import NotificationDispatchCog
 from .run_config import RunConfig
 from .scheduler import SchedulerCog
 from .session_manage import SessionManageCog
@@ -19,6 +20,7 @@ __all__ = [
     "ContextLinksCog",
     "EventProcessor",
     "RunConfig",
+    "NotificationDispatchCog",
     "SchedulerCog",
     "SessionManageCog",
     "AskCommandCog",

--- a/claude_discord/cogs/notification_dispatch.py
+++ b/claude_discord/cogs/notification_dispatch.py
@@ -1,0 +1,160 @@
+"""NotificationDispatchCog — delivers the notifications the REST API accepts.
+
+``POST /api/schedule`` stores a row and answers ``{"status": "scheduled"}``.
+Something has to read that row back at its due time and post it, and that
+something belongs here rather than in a consumer's custom Cog: the endpoint is
+part of ccdb, so its delivery has to ship with ccdb (CLAUDE.md, Zero-Config).
+
+The Cog is constructed with the *repository object* the API server writes
+through — never with a path of its own.  A scheduled notification that is
+accepted but never delivered is indistinguishable from a delivered one at the
+API surface (it is listed by ``GET /api/scheduled`` either way), so the only
+safe design is one where a second database cannot come into existence.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+
+import discord
+from discord.ext import commands, tasks
+
+if TYPE_CHECKING:
+    from ..database.notification_repo import NotificationRepository
+
+logger = logging.getLogger(__name__)
+
+# Matches SchedulerCog's cadence: the worst-case lateness a user can observe.
+DISPATCH_INTERVAL_SECONDS = 30
+
+DEFAULT_COLOR = 0x00BFFF
+
+# How late a notification may be and still be worth sending.  A restart or a
+# maintenance window costs minutes and those reminders should still arrive; a
+# notification whose day has passed has lost its context, and firing a backlog
+# of them the moment delivery is restored is its own kind of failure.
+DEFAULT_STALE_AFTER_SECONDS = 24 * 60 * 60
+
+
+class NotificationDispatchCog(commands.Cog):
+    """Post scheduled notifications once they come due.
+
+    Args:
+        bot: The Discord bot instance.
+        repo: The same NotificationRepository the API server writes through.
+        default_channel_id: Where to post rows stored without a channel.
+        stale_after_seconds: Lateness past which a notification is dropped
+            rather than delivered.
+    """
+
+    def __init__(
+        self,
+        bot: commands.Bot,
+        *,
+        repo: NotificationRepository,
+        default_channel_id: int | None = None,
+        stale_after_seconds: int = DEFAULT_STALE_AFTER_SECONDS,
+    ) -> None:
+        self.bot = bot
+        self.repo = repo
+        self.default_channel_id = default_channel_id
+        self.stale_after_seconds = stale_after_seconds
+
+    async def cog_load(self) -> None:
+        self._dispatch_loop.start()
+        logger.info("NotificationDispatchCog loaded — dispatch loop started")
+
+    def cog_unload(self) -> None:
+        self._dispatch_loop.cancel()
+        logger.info("NotificationDispatchCog unloaded — dispatch loop stopped")
+
+    @tasks.loop(seconds=DISPATCH_INTERVAL_SECONDS)
+    async def _dispatch_loop(self) -> None:
+        await self.dispatch_due()
+
+    @_dispatch_loop.before_loop
+    async def _before_dispatch_loop(self) -> None:
+        await self.bot.wait_until_ready()
+
+    async def dispatch_due(self) -> None:
+        """Send every pending notification whose time has passed.
+
+        ``scheduled_at`` is stored as a local-time ISO string without an
+        offset, so the comparison is made in the same form the writer used.
+        """
+        now = datetime.now().strftime("%Y-%m-%dT%H:%M:%S")
+        due = await self.repo.get_pending(before=now)
+        if not due:
+            return
+
+        logger.info("NotificationDispatchCog: %d notification(s) due", len(due))
+        for notification in due:
+            # One bad row (deleted channel, revoked access) must not hold back
+            # the queue behind it, so each is marked and stepped over.
+            await self._deliver(notification)
+
+    async def _deliver(self, notification: dict[str, Any]) -> None:
+        notification_id: int = notification["id"]
+        try:
+            lateness = self._lateness_seconds(notification["scheduled_at"])
+            if lateness is not None and lateness > self.stale_after_seconds:
+                logger.warning(
+                    "Notification %d is stale (%.0f h late) — not delivering",
+                    notification_id,
+                    lateness / 3600,
+                )
+                await self.repo.mark_failed(
+                    notification_id,
+                    f"stale: {lateness / 3600:.0f}h past its scheduled time",
+                )
+                return
+
+            channel = await self._resolve_channel(notification.get("channel_id"))
+            if channel is None:
+                logger.warning("No channel for notification %d", notification_id)
+                await self.repo.mark_failed(notification_id, "No channel ID")
+                return
+
+            await channel.send(embed=self._build_embed(notification))
+            await self.repo.mark_sent(notification_id)
+            logger.info("Notification sent: id=%d", notification_id)
+        except Exception as exc:
+            logger.exception("Failed to send notification %d", notification_id)
+            await self.repo.mark_failed(notification_id, str(exc))
+
+    @staticmethod
+    def _lateness_seconds(scheduled_at: str) -> float | None:
+        """Seconds between the due time and now, or None if it cannot be read.
+
+        Returning None means "do not judge": the due-time comparison is done on
+        strings, so a malformed value can reach here, and being unable to
+        measure a row's age is not evidence that it is too old to send.
+        """
+        try:
+            return (datetime.now() - datetime.fromisoformat(scheduled_at)).total_seconds()
+        except (ValueError, TypeError):
+            logger.warning(
+                "Unparseable scheduled_at %r — skipping the staleness check", scheduled_at
+            )
+            return None
+
+    async def _resolve_channel(self, channel_id: object) -> Any:
+        target = channel_id or self.default_channel_id
+        if not target:
+            return None
+        channel: Any = self.bot.get_channel(int(target))  # type: ignore[arg-type]
+        if channel is None:
+            channel = await self.bot.fetch_channel(int(target))  # type: ignore[arg-type]
+        return channel
+
+    @staticmethod
+    def _build_embed(notification: dict[str, Any]) -> discord.Embed:
+        """Render the row the API stored, matching the REST API's embed."""
+        return discord.Embed(
+            title=notification.get("title") or "⏰ Reminder",
+            description=notification["message"],
+            color=notification.get("color") or DEFAULT_COLOR,
+            timestamp=datetime.now(),
+        )

--- a/claude_discord/ext/api_server.py
+++ b/claude_discord/ext/api_server.py
@@ -445,10 +445,26 @@ class ApiServer:
             await self._ext_runner.cleanup()
 
     async def health(self, request: web.Request) -> web.Response:
-        """GET /api/health — health check."""
+        """GET /api/health — health check, including delivery backlog.
+
+        A scheduled notification that is stored but never sent used to be
+        undetectable from outside: create returned 201, the list endpoint
+        showed it, and only the human waiting for it ever found out.  The
+        backlog is therefore part of "healthy" — a row whose time has passed
+        and is still pending means the dispatcher is not draining the queue.
+        """
+        overdue = 0
+        try:
+            now = datetime.now().strftime("%Y-%m-%dT%H:%M:%S")
+            overdue = len(await self.repo.get_pending(before=now))
+        except Exception:
+            # A liveness probe must answer even when the store is unreadable.
+            logger.exception("Health check could not read the notification backlog")
+
         return web.json_response(
             {
-                "status": "ok",
+                "status": "degraded" if overdue else "ok",
+                "overdue_notifications": overdue,
                 "timestamp": datetime.now().isoformat(),
             }
         )

--- a/claude_discord/setup.py
+++ b/claude_discord/setup.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
     from .database.frontend_thread_repo import FrontendThreadRepository
     from .database.ingest_repo import IngestResultRepository
     from .database.lounge_repo import LoungeRepository
+    from .database.notification_repo import NotificationRepository
     from .database.repository import SessionRepository, UsageStatsRepository
     from .database.resume_repo import PendingResumeRepository
     from .database.settings_repo import SettingsRepository
@@ -68,6 +69,10 @@ class BridgeComponents:
     settings_repo: SettingsRepository | None = None
     ask_repo: PendingAskRepository | None = None
     usage_repo: UsageStatsRepository | None = None
+    #: The scheduled-notification store the API server writes through, exposed
+    #: so a custom Cog scheduling a reminder lands in the same database the
+    #: dispatcher reads.  A Cog that opens its own file writes into a void.
+    notification_repo: NotificationRepository | None = None
 
     def apply_to_api_server(self, api_server: ApiServer) -> None:
         """Wire all optional repos to an ApiServer instance.
@@ -521,6 +526,25 @@ async def setup_bridge(
 
     # Auto-wire repos to ApiServer and set runner.api_port if provided
     if api_server is not None:
+        # An API that accepts POST /api/schedule has to deliver it, so the
+        # dispatcher ships with the endpoint rather than with the consumer.
+        # It is handed the API's own repository object: matching two paths is
+        # a convention that drifts, sharing one object is a structure.
+        from .cogs.notification_dispatch import NotificationDispatchCog
+
+        await bot.add_cog(
+            NotificationDispatchCog(
+                bot,
+                repo=api_server.repo,
+                default_channel_id=claude_channel_id,
+            )
+        )
+        logger.info("Registered NotificationDispatchCog")
+
+        # Custom Cogs schedule reminders through this rather than opening a
+        # database of their own.
+        components.notification_repo = api_server.repo
+
         components.apply_to_api_server(api_server)
         if runner.api_port is None:
             runner.api_port = api_server.port

--- a/examples/ebibot/cogs/reminder.py
+++ b/examples/ebibot/cogs/reminder.py
@@ -1,7 +1,14 @@
-"""/remind slash command & 30-second notification send loop.
+"""/remind slash command — schedules through ccdb's notification store.
 
-Self-contained custom Cog: includes DB schema, repository, embed builders,
-and the ReminderCog itself.  No external dependencies beyond discord.py.
+This Cog used to carry its own SQLite wrapper, its own repository and its own
+30-second send loop against a hardcoded ``data/bot.db``.  That made it the only
+thing in the tree that delivered scheduled notifications, while the REST API
+wrote to the deployment's ``notifications.db`` — so anything scheduled through
+``POST /api/schedule`` was stored, listed, and never sent.
+
+Delivery now belongs to ccdb's ``NotificationDispatchCog``, which reads the
+same repository the API writes through.  What is left here is the part that is
+genuinely EbiBot's: the ``/remind`` command.
 
 Usage:
     CUSTOM_COGS_DIR=examples/ebibot/cogs ccdb start
@@ -11,166 +18,29 @@ from __future__ import annotations
 
 import logging
 import re
-import sqlite3
 from datetime import datetime, timedelta
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 import discord
 from discord import app_commands
-from discord.ext import commands, tasks
+from discord.ext import commands
+
+if TYPE_CHECKING:
+    from claude_discord.database.notification_repo import NotificationRepository
 
 logger = logging.getLogger(__name__)
-
-# ---------------------------------------------------------------------------
-# Database
-# ---------------------------------------------------------------------------
-
-_SCHEMA = """
-CREATE TABLE IF NOT EXISTS scheduled_notifications (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    message TEXT NOT NULL,
-    title TEXT,
-    color INTEGER DEFAULT 49151,
-    scheduled_at TEXT NOT NULL,
-    source TEXT NOT NULL DEFAULT 'api',
-    channel_id INTEGER,
-    status TEXT NOT NULL DEFAULT 'pending',
-    sent_at TEXT,
-    error_message TEXT,
-    created_at TEXT DEFAULT (datetime('now', 'localtime'))
-);
-
-CREATE INDEX IF NOT EXISTS idx_notif_status_scheduled
-    ON scheduled_notifications(status, scheduled_at);
-"""
-
-
-class _Database:
-    """Minimal synchronous SQLite wrapper for notifications."""
-
-    def __init__(self, db_path: str = "data/bot.db") -> None:
-        self.db_path = db_path
-        self._connection: sqlite3.Connection | None = None
-
-    def connect(self) -> sqlite3.Connection:
-        if self._connection is not None:
-            return self._connection
-        Path(self.db_path).parent.mkdir(parents=True, exist_ok=True)
-        self._connection = sqlite3.connect(self.db_path, check_same_thread=False)
-        self._connection.row_factory = sqlite3.Row
-        return self._connection
-
-    def initialize(self) -> None:
-        conn = self.connect()
-        conn.executescript(_SCHEMA)
-        conn.commit()
-
-    def close(self) -> None:
-        if self._connection:
-            self._connection.close()
-            self._connection = None
-
-    @property
-    def connection(self) -> sqlite3.Connection:
-        return self.connect()
-
-
-class _NotificationRepository:
-    """CRUD for scheduled_notifications table."""
-
-    def __init__(self, db: _Database) -> None:
-        self.db = db
-
-    def create(
-        self,
-        message: str,
-        scheduled_at: str,
-        *,
-        title: str | None = None,
-        color: int = 0x00BFFF,
-        source: str = "api",
-        channel_id: int | None = None,
-    ) -> int:
-        conn = self.db.connection
-        cursor = conn.execute(
-            """
-            INSERT INTO scheduled_notifications
-                (message, title, color, scheduled_at, source, channel_id)
-            VALUES (?, ?, ?, ?, ?, ?)
-            """,
-            (message, title, color, scheduled_at, source, channel_id),
-        )
-        conn.commit()
-        return cursor.lastrowid  # type: ignore[return-value]
-
-    def get_pending(self, before: str | None = None) -> list[dict]:
-        conn = self.db.connection
-        if before:
-            rows = conn.execute(
-                """
-                SELECT * FROM scheduled_notifications
-                WHERE status = 'pending' AND scheduled_at <= ?
-                ORDER BY scheduled_at
-                """,
-                (before,),
-            ).fetchall()
-        else:
-            rows = conn.execute(
-                """
-                SELECT * FROM scheduled_notifications
-                WHERE status = 'pending'
-                ORDER BY scheduled_at
-                """,
-            ).fetchall()
-        return [dict(row) for row in rows]
-
-    def mark_sent(self, notification_id: int) -> None:
-        conn = self.db.connection
-        conn.execute(
-            """
-            UPDATE scheduled_notifications
-            SET status = 'sent', sent_at = datetime('now', 'localtime')
-            WHERE id = ?
-            """,
-            (notification_id,),
-        )
-        conn.commit()
-
-    def mark_failed(self, notification_id: int, error: str) -> None:
-        conn = self.db.connection
-        conn.execute(
-            """
-            UPDATE scheduled_notifications
-            SET status = 'failed', error_message = ?
-            WHERE id = ?
-            """,
-            (error, notification_id),
-        )
-        conn.commit()
-
-
-# ---------------------------------------------------------------------------
-# Embeds
-# ---------------------------------------------------------------------------
 
 _COLOR_REMINDER = 0x00BFFF
 _COLOR_SUCCESS = 0x00FF00
 
-
-def _build_reminder_embed(message: str, title: str | None = None) -> discord.Embed:
-    embed = discord.Embed(
-        title=title or "\u23f0 Remind!",
-        description=message,
-        color=_COLOR_REMINDER,
-        timestamp=datetime.now(),
-    )
-    embed.set_footer(text="EbiBot Reminder")
-    return embed
+_TIME_PATTERN = re.compile(r"^(\d{1,2}):(\d{2})$")
+_MAX_HOUR = 23
+_MAX_MINUTE = 59
 
 
 def _build_schedule_confirm_embed(message: str, scheduled_at: str) -> discord.Embed:
     embed = discord.Embed(
-        title="\u2705 Reminder scheduled!",
+        title="✅ Reminder scheduled!",
         description=f"**{scheduled_at}** — notification set.\n\n> {message}",
         color=_COLOR_SUCCESS,
         timestamp=datetime.now(),
@@ -179,24 +49,12 @@ def _build_schedule_confirm_embed(message: str, scheduled_at: str) -> discord.Em
     return embed
 
 
-# ---------------------------------------------------------------------------
-# Cog
-# ---------------------------------------------------------------------------
-
-
 class ReminderCog(commands.Cog):
-    """Reminder: /remind slash command + periodic send loop."""
+    """The /remind slash command.  Delivery is ccdb's job, not this Cog's."""
 
-    def __init__(self, bot: commands.Bot, repo: _NotificationRepository) -> None:
+    def __init__(self, bot: commands.Bot, repo: NotificationRepository) -> None:
         self.bot = bot
         self.repo = repo
-
-    async def cog_load(self) -> None:
-        self.check_scheduled.start()
-        logger.info("ReminderCog loaded, check loop started")
-
-    async def cog_unload(self) -> None:
-        self.check_scheduled.cancel()
 
     @app_commands.command(
         name="remind",
@@ -212,7 +70,7 @@ class ReminderCog(commands.Cog):
         time: str,
         message: str,
     ) -> None:
-        match = re.match(r"^(\d{1,2}):(\d{2})$", time.strip())
+        match = _TIME_PATTERN.match(time.strip())
         if not match:
             await interaction.response.send_message(
                 "Please use HH:MM format (e.g. 14:30)",
@@ -221,7 +79,7 @@ class ReminderCog(commands.Cog):
             return
 
         hour, minute = int(match.group(1)), int(match.group(2))
-        if not (0 <= hour <= 23 and 0 <= minute <= 59):
+        if not (0 <= hour <= _MAX_HOUR and 0 <= minute <= _MAX_MINUTE):
             await interaction.response.send_message(
                 "Time out of range! Use 00:00-23:59.",
                 ephemeral=True,
@@ -233,11 +91,11 @@ class ReminderCog(commands.Cog):
         if scheduled <= now:
             scheduled += timedelta(days=1)
 
-        scheduled_str = scheduled.strftime("%Y-%m-%dT%H:%M:%S")
-
-        self.repo.create(
+        # Local-time ISO without an offset — the form the dispatcher compares.
+        await self.repo.create(
             message=message,
-            scheduled_at=scheduled_str,
+            scheduled_at=scheduled.strftime("%Y-%m-%dT%H:%M:%S"),
+            color=_COLOR_REMINDER,
             source="slash_command",
             channel_id=interaction.channel_id,
         )
@@ -248,54 +106,13 @@ class ReminderCog(commands.Cog):
         )
         await interaction.response.send_message(embed=embed)
 
-    @tasks.loop(seconds=30)
-    async def check_scheduled(self) -> None:
-        """Check pending notifications every 30 seconds and send them."""
-        now_str = datetime.now().strftime("%Y-%m-%dT%H:%M:%S")
-        pending = self.repo.get_pending(before=now_str)
-
-        for notif in pending:
-            try:
-                channel_id = notif.get("channel_id") or getattr(
-                    self.bot, "default_channel_id", None
-                )
-                if not channel_id:
-                    logger.warning("No channel ID for notification %d", notif["id"])
-                    self.repo.mark_failed(notif["id"], "No channel ID")
-                    continue
-
-                channel = self.bot.get_channel(int(channel_id))
-                if not channel:
-                    channel = await self.bot.fetch_channel(int(channel_id))
-
-                embed = _build_reminder_embed(
-                    message=notif["message"],
-                    title=notif.get("title"),
-                )
-                if notif.get("color"):
-                    embed.color = notif["color"]
-
-                await channel.send(embed=embed)
-                self.repo.mark_sent(notif["id"])
-                logger.info("Notification sent: id=%d", notif["id"])
-
-            except Exception as e:
-                logger.error("Failed to send notification %d: %s", notif["id"], e)
-                self.repo.mark_failed(notif["id"], str(e))
-
-    @check_scheduled.before_loop
-    async def before_check_scheduled(self) -> None:
-        await self.bot.wait_until_ready()
-
-
-# ---------------------------------------------------------------------------
-# setup() — called by load_custom_cogs
-# ---------------------------------------------------------------------------
-
 
 async def setup(bot: commands.Bot, runner: object, components: object) -> None:
     """Entry point for the custom Cog loader."""
-    db = _Database(db_path="data/bot.db")
-    db.initialize()
-    repo = _NotificationRepository(db)
+    repo = getattr(components, "notification_repo", None)
+    if repo is None:
+        # No API server means no notification store and no dispatcher, so a
+        # /remind that appeared to work would never fire.  Skip it loudly.
+        logger.warning("ReminderCog skipped: no notification_repo (API server disabled?)")
+        return
     await bot.add_cog(ReminderCog(bot, repo))

--- a/tests/test_api_server.py
+++ b/tests/test_api_server.py
@@ -73,6 +73,29 @@ class TestHealth:
         assert data["status"] == "ok"
         assert "timestamp" in data
 
+    @pytest.mark.asyncio
+    async def test_health_reports_no_overdue_when_clean(self, client: TestClient) -> None:
+        resp = await client.get("/api/health")
+        assert (await resp.json())["overdue_notifications"] == 0
+
+    @pytest.mark.asyncio
+    async def test_health_counts_overdue_notifications(
+        self, client: TestClient, repo: NotificationRepository
+    ) -> None:
+        """A notification long past its time is the symptom of a dead dispatcher.
+
+        The previous outage was invisible precisely because every endpoint kept
+        answering normally while nothing was delivered, so the health check now
+        reports the backlog instead of a bare "ok".
+        """
+        await repo.create(message="取り残された", scheduled_at="2020-01-01T09:00:00")
+        await repo.create(message="まだ先", scheduled_at="2099-01-01T09:00:00")
+
+        data = await (await client.get("/api/health")).json()
+
+        assert data["overdue_notifications"] == 1
+        assert data["status"] == "degraded"
+
 
 class TestNotify:
     @pytest.mark.asyncio

--- a/tests/test_notification_dispatch.py
+++ b/tests/test_notification_dispatch.py
@@ -1,0 +1,233 @@
+"""Tests for NotificationDispatchCog — the loop that actually delivers.
+
+Regression context: ``POST /api/schedule`` wrote to the deployment's
+``notifications.db`` while the only send loop in the tree (an example custom
+Cog) read a hardcoded ``data/bot.db``.  Every scheduled notification was
+accepted, listed and cancellable — and never delivered.  The tests below pin
+the properties that make that class of bug impossible:
+
+* the dispatcher reads through the *same repository object* the API writes to
+  (``test_dispatcher_shares_the_api_repository_object``), so the two can never
+  drift onto different files again,
+* a deployment with an API server always gets a dispatcher, with no wiring
+  from the consumer (``tests/test_setup.py``), and
+* restoring the loop does not replay a backlog of notifications whose moment
+  has passed (``TestStale``).
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from datetime import datetime, timedelta
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from claude_discord.cogs.notification_dispatch import NotificationDispatchCog
+from claude_discord.database.notification_repo import NotificationRepository
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+
+@pytest.fixture
+async def repo() -> AsyncIterator[NotificationRepository]:
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    repo = NotificationRepository(path)
+    await repo.init_db()
+    yield repo
+    os.unlink(path)
+
+
+def _ago(**delta: float) -> str:
+    """A due time in the past, in the local-time format the writer uses."""
+    return (datetime.now() - timedelta(**delta)).strftime("%Y-%m-%dT%H:%M:%S")
+
+
+def _ahead(**delta: float) -> str:
+    return (datetime.now() + timedelta(**delta)).strftime("%Y-%m-%dT%H:%M:%S")
+
+
+def _bot_with_channel(channel: MagicMock) -> MagicMock:
+    bot = MagicMock()
+    bot.get_channel.return_value = channel
+    bot.fetch_channel = AsyncMock(return_value=channel)
+    return bot
+
+
+def _messageable() -> MagicMock:
+    channel = MagicMock()
+    channel.send = AsyncMock()
+    return channel
+
+
+class TestDispatch:
+    async def test_sends_due_notification_and_marks_sent(
+        self, repo: NotificationRepository
+    ) -> None:
+        await repo.create(message="時間です", scheduled_at=_ago(minutes=1), channel_id=42)
+        channel = _messageable()
+        cog = NotificationDispatchCog(_bot_with_channel(channel), repo=repo)
+
+        await cog.dispatch_due()
+
+        channel.send.assert_awaited_once()
+        assert await repo.get_pending() == []
+
+    async def test_does_not_send_before_scheduled_time(self, repo: NotificationRepository) -> None:
+        await repo.create(message="まだ先", scheduled_at=_ahead(hours=1), channel_id=42)
+        channel = _messageable()
+        cog = NotificationDispatchCog(_bot_with_channel(channel), repo=repo)
+
+        await cog.dispatch_due()
+
+        channel.send.assert_not_awaited()
+        assert len(await repo.get_pending()) == 1
+
+    async def test_falls_back_to_default_channel(self, repo: NotificationRepository) -> None:
+        await repo.create(message="宛先なし", scheduled_at=_ago(minutes=1))
+        channel = _messageable()
+        bot = _bot_with_channel(channel)
+        cog = NotificationDispatchCog(bot, repo=repo, default_channel_id=777)
+
+        await cog.dispatch_due()
+
+        bot.get_channel.assert_called_once_with(777)
+        channel.send.assert_awaited_once()
+
+    async def test_marks_failed_when_no_channel_can_be_resolved(
+        self, repo: NotificationRepository
+    ) -> None:
+        await repo.create(message="宛先不明", scheduled_at=_ago(minutes=1))
+        cog = NotificationDispatchCog(MagicMock(), repo=repo, default_channel_id=None)
+
+        await cog.dispatch_due()
+
+        assert await repo.get_pending() == []
+        rows = await _all_rows(repo)
+        assert rows[0]["status"] == "failed"
+        assert rows[0]["error_message"]
+
+    async def test_marks_failed_when_send_raises(self, repo: NotificationRepository) -> None:
+        await repo.create(message="送信失敗", scheduled_at=_ago(minutes=1), channel_id=42)
+        channel = _messageable()
+        channel.send.side_effect = RuntimeError("Missing Access")
+        cog = NotificationDispatchCog(_bot_with_channel(channel), repo=repo)
+
+        await cog.dispatch_due()
+
+        rows = await _all_rows(repo)
+        assert rows[0]["status"] == "failed"
+        assert "Missing Access" in rows[0]["error_message"]
+
+    async def test_one_failure_does_not_block_the_rest(self, repo: NotificationRepository) -> None:
+        await repo.create(message="1本目", scheduled_at=_ago(minutes=2), channel_id=1)
+        await repo.create(message="2本目", scheduled_at=_ago(minutes=1), channel_id=2)
+        channel = _messageable()
+        channel.send.side_effect = [RuntimeError("boom"), None]
+        cog = NotificationDispatchCog(_bot_with_channel(channel), repo=repo)
+
+        await cog.dispatch_due()
+
+        statuses = [row["status"] for row in await _all_rows(repo)]
+        assert statuses == ["failed", "sent"]
+
+
+class TestStale:
+    """Restoring the loop must not replay a backlog whose moment has passed."""
+
+    async def test_does_not_deliver_a_notification_from_days_ago(
+        self, repo: NotificationRepository
+    ) -> None:
+        await repo.create(message="1ヶ月前の予定", scheduled_at=_ago(days=30), channel_id=42)
+        channel = _messageable()
+        cog = NotificationDispatchCog(_bot_with_channel(channel), repo=repo)
+
+        await cog.dispatch_due()
+
+        channel.send.assert_not_awaited()
+        rows = await _all_rows(repo)
+        assert rows[0]["status"] == "failed"
+        assert "stale" in rows[0]["error_message"]
+
+    async def test_still_delivers_after_a_short_outage(self, repo: NotificationRepository) -> None:
+        """A restart or a brief maintenance window must not drop reminders."""
+        await repo.create(message="再起動中に来た", scheduled_at=_ago(minutes=20), channel_id=42)
+        channel = _messageable()
+        cog = NotificationDispatchCog(_bot_with_channel(channel), repo=repo)
+
+        await cog.dispatch_due()
+
+        channel.send.assert_awaited_once()
+
+    async def test_stale_window_is_configurable(self, repo: NotificationRepository) -> None:
+        await repo.create(message="2時間前", scheduled_at=_ago(hours=2), channel_id=42)
+        channel = _messageable()
+        cog = NotificationDispatchCog(
+            _bot_with_channel(channel), repo=repo, stale_after_seconds=3600
+        )
+
+        await cog.dispatch_due()
+
+        channel.send.assert_not_awaited()
+
+    async def test_unparseable_due_time_is_delivered_not_dropped(
+        self, repo: NotificationRepository
+    ) -> None:
+        """A row we cannot age must not be silently discarded as stale.
+
+        The due-time comparison is a string one, so a malformed value can still
+        sort into the due set; being unable to measure its age is not evidence
+        that it is old.
+        """
+        await repo.create(message="壊れた日時", scheduled_at="2020-13-45T99:99:99", channel_id=42)
+        channel = _messageable()
+        cog = NotificationDispatchCog(_bot_with_channel(channel), repo=repo)
+
+        await cog.dispatch_due()
+
+        channel.send.assert_awaited_once()
+
+
+class TestNoDrift:
+    """The properties that keep write-side and read-side on one database."""
+
+    async def test_dispatcher_shares_the_api_repository_object(
+        self, repo: NotificationRepository
+    ) -> None:
+        """The Cog must hold the very object the API writes through.
+
+        Comparing paths would still allow two repositories to be constructed
+        from two different defaults; sharing the object cannot.
+        """
+        from claude_discord.ext.api_server import ApiServer
+
+        api = ApiServer(repo=repo, bot=MagicMock(), default_channel_id=1)
+        cog = NotificationDispatchCog(MagicMock(), repo=api.repo)
+
+        assert cog.repo is api.repo
+
+    async def test_a_notification_written_by_the_api_is_visible_to_the_dispatcher(
+        self, repo: NotificationRepository
+    ) -> None:
+        """End-to-end on one repo: what /api/schedule stores, dispatch sends."""
+        await repo.create(message="APIが書いた", scheduled_at=_ago(minutes=1), channel_id=42)
+        channel = _messageable()
+        cog = NotificationDispatchCog(_bot_with_channel(channel), repo=repo)
+
+        await cog.dispatch_due()
+
+        sent = channel.send.await_args.kwargs["embed"]
+        assert sent.description == "APIが書いた"
+
+
+async def _all_rows(repo: NotificationRepository) -> list[dict]:
+    import aiosqlite
+
+    async with aiosqlite.connect(repo.db_path) as db:
+        db.row_factory = aiosqlite.Row
+        cursor = await db.execute("SELECT * FROM scheduled_notifications ORDER BY id")
+        return [dict(row) for row in await cursor.fetchall()]

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -176,6 +176,54 @@ def _make_api_server() -> MagicMock:
     return server
 
 
+@pytest.mark.asyncio
+async def test_setup_bridge_registers_notification_dispatcher(tmp_path: object) -> None:
+    """An API server means scheduled notifications must have a delivery loop.
+
+    Regression: /api/schedule accepted and stored notifications that nothing
+    ever read back, because the only send loop lived in a consumer's custom
+    Cog and pointed at a different database file.
+    """
+    from claude_discord.database.notification_repo import NotificationRepository
+
+    bot = _make_bot()
+    api_server = _make_api_server()
+    api_server.repo = MagicMock(spec=NotificationRepository)
+
+    await setup_bridge(
+        bot,
+        _make_runner(),
+        api_server=api_server,
+        session_db_path=str(tmp_path / "sessions.db"),  # type: ignore[operator]
+        enable_scheduler=False,
+    )
+
+    dispatchers = [
+        call.args[0]
+        for call in bot.add_cog.call_args_list
+        if call.args[0].__class__.__name__ == "NotificationDispatchCog"
+    ]
+    assert len(dispatchers) == 1, "an API server must come with exactly one dispatcher"
+    # Sharing the object — not a matching path — is what prevents the drift.
+    assert dispatchers[0].repo is api_server.repo
+
+
+@pytest.mark.asyncio
+async def test_setup_bridge_skips_dispatcher_without_api_server(tmp_path: object) -> None:
+    """No API server means nothing writes notifications, so nothing polls."""
+    bot = _make_bot()
+
+    await setup_bridge(
+        bot,
+        _make_runner(),
+        session_db_path=str(tmp_path / "sessions.db"),  # type: ignore[operator]
+        enable_scheduler=False,
+    )
+
+    cog_names = [call.args[0].__class__.__name__ for call in bot.add_cog.call_args_list]
+    assert "NotificationDispatchCog" not in cog_names
+
+
 def test_apply_to_api_server_wires_task_and_lounge_repos(tmp_path: object) -> None:
     """apply_to_api_server should set task_repo and lounge_repo on the ApiServer."""
     from claude_discord.database.lounge_repo import LoungeRepository


### PR DESCRIPTION
## Problem

`POST /api/schedule` stored a row in the deployment's `notifications.db` and answered `{"status": "scheduled"}`. The only send loop in the tree lived in an example custom Cog (`examples/ebibot/cogs/reminder.py`) and read a hardcoded `data/bot.db`.

Every scheduled notification was therefore accepted, listed by `GET /api/scheduled`, and cancellable — and never delivered. Nothing at the API surface distinguished that from a working queue; the only observer was the person waiting for a reminder that did not come.

The write side moved to the deployment root in #566 (`DataLayout`); the hardcoded consumer Cog did not move with it.

## Fix

Delivery belongs to the endpoint, so it ships with ccdb:

- **`NotificationDispatchCog`** — polls every 30 s and posts due notifications. It is constructed with the API server's *repository object*, never a path of its own. Matching two paths is a convention that drifts; sharing one object is a structure.
- **`setup_bridge`** registers it whenever an API server is present — a consumer gets delivery by updating the package, no wiring (Zero-Config).
- **`BridgeComponents.notification_repo`** — so a custom Cog scheduling a reminder writes where the dispatcher reads.
- **`examples/ebibot` ReminderCog** drops its private SQLite wrapper, repository and send loop, keeping only `/remind`.

## Guards against the same outage hiding again

- **Stale backlog is not replayed.** Restoring a stopped loop would otherwise fire every missed notification at once. Rows more than 24 h late are recorded as `failed` with the lateness in `error_message`. A row whose age cannot be parsed is *delivered*, not dropped — being unable to measure age is not evidence of being old.
- **`GET /api/health` reports `overdue_notifications`** and returns `degraded` on a backlog, so a stalled dispatcher is visible without opening the database.

## Tests

- `tests/test_notification_dispatch.py` (new, 12 cases): due/not-due, default-channel fallback, failure isolation, the stale window, and the two no-drift properties.
- `tests/test_setup.py`: an API server always comes with exactly one dispatcher holding *that server's* repo object; no API server means no dispatcher.
- `tests/test_api_server.py`: health counts the backlog and degrades.

`2594 passed`, `ruff check` / `ruff format --check` clean, `pyright` 0 errors.

## Verification on a live deployment

| Check | Result |
|---|---|
| 671 h-old pending row | withheld, `failed` / `stale: 671h past its scheduled time` |
| notification due `09:24:04` | delivered `09:24:17` (30 s poll) |
| health during backlog | `{"status": "degraded", "overdue_notifications": 1}` |
| health after drain | `{"status": "ok", "overdue_notifications": 0}` |