### PR TITLE
fix: isolate owner auto-merge from CI runners (#637)

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -24,7 +24,9 @@ jobs:
       github.event.pull_request.user.login == 'ebibibi' &&
       github.event.pull_request.draft == false &&
       !contains(github.event.pull_request.labels.*.name, 'external-issue')
-    runs-on: [self-hosted, linux, x64]
+    # This control-plane job polls for required checks. Running it on the same
+    # single-capacity JIT pool as CI can starve the checks it is waiting for.
+    runs-on: ubuntu-latest
     permissions:
       pull-requests: write
       contents: write

--- a/tests/test_auto_approve_workflow.py
+++ b/tests/test_auto_approve_workflow.py
@@ -1,0 +1,23 @@
+"""Regression checks for the owner auto-merge control-plane workflow."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _job_block(workflow: str, job: str, next_job: str) -> str:
+    """Return one top-level job block without adding a YAML test dependency."""
+    start = workflow.index(f"  {job}:")
+    end = workflow.index(f"  {next_job}:", start)
+    return workflow[start:end]
+
+
+def test_owner_auto_merge_does_not_use_the_self_hosted_ci_pool() -> None:
+    """A merge-polling job must not occupy the only runner required by CI."""
+    workflow = (REPO_ROOT / ".github/workflows/auto-approve.yml").read_text()
+    owner_job = _job_block(workflow, "auto-approve-and-merge", "auto-merge-dependabot")
+
+    assert "runs-on: ubuntu-latest" in owner_job
+    assert "self-hosted" not in owner_job


### PR DESCRIPTION
## Summary

- run the owner auto-merge control-plane job on `ubuntu-latest`
- keep merge polling from occupying the self-hosted CI runner pool
- add a regression check for the workflow runner boundary

## Test plan

- [x] `uv run pytest tests/test_auto_approve_workflow.py -v`
- [x] `uv run ruff check tests/test_auto_approve_workflow.py`
- [x] `uv run ruff format --check tests/test_auto_approve_workflow.py`
- [x] `uv run pytest tests/ -q`

Closes #637