### PR TITLE
fix: keep SQLite reads available during writes (#483)

### DIFF
--- a/claude_discord/database/models.py
+++ b/claude_discord/database/models.py
@@ -190,6 +190,9 @@ async def init_db(db_path: str) -> None:
     the migration statements add any missing columns idempotently.
     """
     async with aiosqlite.connect(db_path) as db:
+        # WAL lets readers continue using the last committed snapshot while a
+        # different connection holds a write transaction.
+        await db.execute("PRAGMA journal_mode=WAL")
         await db.executescript(SCHEMA)
         for stmt in _MIGRATIONS:
             with contextlib.suppress(Exception):

--- a/tests/test_settings_repo.py
+++ b/tests/test_settings_repo.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import asyncio
+
+import aiosqlite
 import pytest
 
 from claude_discord.database.models import init_db
@@ -16,6 +19,28 @@ async def repo(tmp_path):
 
 
 class TestSettingsRepository:
+    async def test_get_remains_available_during_an_exclusive_write(self, tmp_path):
+        """Readers should see the last commit while another connection writes."""
+        db_path = str(tmp_path / "concurrent.db")
+        await init_db(db_path)
+        repo = SettingsRepository(db_path)
+        await repo.set("claude_model", "committed-model")
+
+        writer = await aiosqlite.connect(db_path)
+        try:
+            await writer.execute("BEGIN EXCLUSIVE")
+            await writer.execute(
+                "UPDATE settings SET value = ? WHERE key = ?",
+                ("uncommitted-model", "claude_model"),
+            )
+
+            value = await asyncio.wait_for(repo.get("claude_model"), timeout=0.5)
+        finally:
+            await writer.rollback()
+            await writer.close()
+
+        assert value == "committed-model"
+
     async def test_get_returns_none_for_missing_key(self, repo):
         result = await repo.get("nonexistent")
         assert result is None


### PR DESCRIPTION
## Summary

- enable SQLite WAL mode during database initialization
- keep settings reads available while another connection holds a write transaction
- add a regression test that reads the last committed setting during an exclusive write

## Test plan

- [x] `uv run pytest tests/test_settings_repo.py tests/test_repository.py -q`
- [x] `uv run ruff check claude_discord/ tests/`
- [x] `uv run ruff format --check claude_discord/ tests/`
- [x] `uv run pyright claude_discord/`
- [x] `uv run pytest tests/ -q` (2621 passed)

Closes #483