### PR TITLE
fix: ignore shutdown errors from webhook reactions (#478)

### DIFF
--- a/claude_discord/cogs/webhook_trigger.py
+++ b/claude_discord/cogs/webhook_trigger.py
@@ -17,6 +17,7 @@ import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+import aiohttp
 import discord
 from discord.ext import commands
 
@@ -179,9 +180,14 @@ class WebhookTriggerCog(commands.Cog):
                 )
             )
 
-            if session_id:
-                await message.add_reaction("✅")
-            else:
-                await message.add_reaction("❌")
+            reaction = "✅" if session_id else "❌"
+            try:
+                await message.add_reaction(reaction)
+            except (discord.HTTPException, aiohttp.ClientError):
+                logger.debug("Discord client closed before completion reaction", exc_info=True)
+            except RuntimeError as exc:
+                if str(exc) != "Session is closed":
+                    raise
+                logger.debug("Discord session closed before completion reaction", exc_info=True)
         finally:
             self._active_count -= 1

--- a/tests/test_webhook_trigger.py
+++ b/tests/test_webhook_trigger.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import aiohttp
 import discord
 import pytest
 from discord.ext import commands
@@ -254,6 +255,48 @@ class TestTriggerExecution:
             mock_run.return_value = None
             await cog.on_message(msg)
             msg.add_reaction.assert_called_with("❌")
+
+    @pytest.mark.asyncio
+    async def test_completion_reaction_ignores_shutdown_client_error(
+        self,
+        cog: WebhookTriggerCog,
+    ) -> None:
+        """A closing Discord HTTP client must not hide a completed trigger."""
+        msg = _make_message(content="🔄 docs-sync")
+        msg.add_reaction.side_effect = aiohttp.ClientError("transport closing")
+
+        with patch(_PATCH_RUN, new_callable=AsyncMock) as mock_run:
+            mock_run.return_value = "session-abc"
+            await cog.on_message(msg)
+
+    @pytest.mark.asyncio
+    async def test_completion_reaction_ignores_closed_session_runtime_error(
+        self,
+        cog: WebhookTriggerCog,
+    ) -> None:
+        """discord.py can report its closing client as a RuntimeError."""
+        msg = _make_message(content="🔄 docs-sync")
+        msg.add_reaction.side_effect = RuntimeError("Session is closed")
+
+        with patch(_PATCH_RUN, new_callable=AsyncMock) as mock_run:
+            mock_run.return_value = "session-abc"
+            await cog.on_message(msg)
+
+    @pytest.mark.asyncio
+    async def test_completion_reaction_propagates_unexpected_runtime_error(
+        self,
+        cog: WebhookTriggerCog,
+    ) -> None:
+        """Only the known shutdown RuntimeError is best-effort cleanup."""
+        msg = _make_message(content="🔄 docs-sync")
+        msg.add_reaction.side_effect = RuntimeError("unexpected bug")
+
+        with (
+            patch(_PATCH_RUN, new_callable=AsyncMock) as mock_run,
+            pytest.raises(RuntimeError, match="unexpected bug"),
+        ):
+            mock_run.return_value = "session-abc"
+            await cog.on_message(msg)
 
     @pytest.mark.asyncio
     async def test_runner_clone_overrides(


### PR DESCRIPTION
## Summary

- treat webhook completion reactions as best-effort when Discord is shutting down
- suppress Discord HTTP, aiohttp client, and the known closed-session transport errors
- continue propagating unexpected runtime failures
- retain the existing StopView shutdown protection

## Test plan

- [x] `uv run pytest tests/test_webhook_trigger.py -q`
- [x] `uv run ruff check claude_discord/cogs/webhook_trigger.py tests/test_webhook_trigger.py`
- [x] `uv run ruff format --check claude_discord/cogs/webhook_trigger.py tests/test_webhook_trigger.py`
- [x] `uv run pyright claude_discord/cogs/webhook_trigger.py`
- [x] `uv run pytest tests/ -q` (2623 passed)

Closes #478