### PR TITLE
fix: stop delivery after a Discord thread disappears (#552)

### DIFF
--- a/claude_discord/surface.py
+++ b/claude_discord/surface.py
@@ -243,6 +243,7 @@ class DiscordSurface:
         self._interrupt_runner = interrupt_runner
         self._interrupt_view = interrupt_view
         self._status: StatusManager | None = status_manager
+        self._thread_missing = False
 
     # -- identity ----------------------------------------------------------
     @property
@@ -277,12 +278,14 @@ class DiscordSurface:
 
     # -- output ------------------------------------------------------------
     async def send_text(self, text: str) -> str | None:
+        if self._thread_missing:
+            return None
         last: discord.Message | None = None
         for chunk in render_for(text, DISCORD_CAPABILITIES):
             try:
                 last = await self._thread.send(chunk)
             except discord.NotFound:
-                logger.info("Thread %d disappeared mid-send", self._thread.id)
+                self._remember_missing_thread()
                 return None
             except discord.HTTPException:
                 logger.warning("Failed to send message chunk", exc_info=True)
@@ -290,6 +293,8 @@ class DiscordSurface:
         return str(last.id) if last else None
 
     async def send_notice(self, notice: Notice) -> str | None:
+        if self._thread_missing:
+            return None
         embed = discord.Embed(color=_NOTICE_COLOR.get(notice.level, COLOR_INFO))
         if notice.title:
             embed.title = notice.title[:256]
@@ -300,13 +305,16 @@ class DiscordSurface:
             embed.add_field(name=name[:256], value=value[:1024], inline=True)
         try:
             sent = await self._thread.send(embed=embed)
+        except discord.NotFound:
+            self._remember_missing_thread()
+            return None
         except discord.HTTPException:
             logger.warning("Failed to send notice", exc_info=True)
             return None
         return str(sent.id)
 
     async def deliver_files(self, files: Sequence[OutboundFile]) -> None:
-        if not files:
+        if self._thread_missing or not files:
             return
         paths = [f.path for f in files if f.path]
         blobs = [(f.display_name, f.blob) for f in files if f.blob is not None]
@@ -319,10 +327,21 @@ class DiscordSurface:
         return DiscordStream(StreamingMessageManager(self._thread))
 
     async def open_activity(self, spec: ActivitySpec) -> DiscordActivity:
+        if self._thread_missing:
+            return DiscordActivity(None, spec)
         message: discord.Message | None = None
-        with contextlib.suppress(discord.HTTPException):
+        try:
             message = await self._thread.send(embed=_activity_embed(spec, spec.detail))
+        except discord.NotFound:
+            self._remember_missing_thread()
+        except discord.HTTPException:
+            pass
         return DiscordActivity(message, spec)
+
+    def _remember_missing_thread(self) -> None:
+        if not self._thread_missing:
+            logger.info("Thread %d disappeared; disabling further delivery", self._thread.id)
+        self._thread_missing = True
 
     # -- state -------------------------------------------------------------
     async def set_status(self, status: StatusKind) -> None:

--- a/tests/test_discord_surface.py
+++ b/tests/test_discord_surface.py
@@ -19,7 +19,7 @@ Discord semantics is not a contract obligation and does not belong here.
 from __future__ import annotations
 
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import discord
 import pytest
@@ -150,6 +150,42 @@ class TestOutputGoesThroughDiscord:
         surface = _make_surface()
         surface.thread.send = AsyncMock(side_effect=discord.NotFound(MagicMock(status=404), "gone"))
         assert await surface.send_text("hello") is None
+
+    async def test_a_deleted_thread_is_only_contacted_once(self) -> None:
+        """Later assistant events must not retry a thread already known missing."""
+        surface = _make_surface()
+        surface.thread.send = AsyncMock(side_effect=discord.NotFound(MagicMock(status=404), "gone"))
+
+        assert await surface.send_text("first") is None
+        assert await surface.send_text("second") is None
+
+        surface.thread.send.assert_awaited_once()
+
+    async def test_known_deleted_thread_skips_completion_files(self) -> None:
+        """Completion must not attempt attachments after text found the thread missing."""
+        surface = _make_surface()
+        surface.thread.send = AsyncMock(side_effect=discord.NotFound(MagicMock(status=404), "gone"))
+        await surface.send_text("first")
+
+        with patch("claude_discord.surface.send_files", new_callable=AsyncMock) as send:
+            await surface.deliver_files(
+                [OutboundFile(display_name="result.txt", path="/tmp/result.txt")]
+            )
+
+        send.assert_not_awaited()
+
+    async def test_unexpected_send_failure_does_not_mark_thread_missing(self) -> None:
+        """Only Discord NotFound changes the delivery state."""
+        surface = _make_surface()
+        surface.thread.send = AsyncMock(side_effect=RuntimeError("unexpected bug"))
+
+        with pytest.raises(RuntimeError, match="unexpected bug"):
+            await surface.send_text("first")
+
+        surface.thread.send.side_effect = None
+        surface.thread.send.return_value = FakeMessage("second")
+        assert await surface.send_text("second") == "555"
+        assert surface.thread.send.await_count == 2
 
 
 class TestActivityMapsToAnEditedEmbed:


### PR DESCRIPTION
## Summary

- remember when Discord reports a conversation thread as missing
- skip later text, notices, activities, and completion attachments for that surface
- log the missing-thread condition once
- keep unexpected delivery exceptions visible

## Test plan

- [x] `uv run pytest tests/test_discord_surface.py tests/test_event_processor.py -q`
- [x] `uv run ruff check claude_discord/surface.py tests/test_discord_surface.py`
- [x] `uv run ruff format --check claude_discord/surface.py tests/test_discord_surface.py`
- [x] `uv run pyright claude_discord/surface.py`
- [x] `uv run pytest tests/ -q` (2624 passed)

Closes #552