### PR TITLE
fix: prevent multiline log injection (#642)

### DIFF
--- a/claude_discord/database/resume_repo.py
+++ b/claude_discord/database/resume_repo.py
@@ -71,7 +71,13 @@ class PendingResumeRepository:
             )
             await db.commit()
             row_id: int = cursor.lastrowid or 0
-        logger.info("Marked thread %d for resume (reason=%s, row_id=%d)", thread_id, reason, row_id)
+        safe_reason = reason.replace("\r", " ").replace("\n", " ")
+        logger.info(
+            "Marked thread %d for resume (reason=%s, row_id=%d)",
+            thread_id,
+            safe_reason,
+            row_id,
+        )
         return row_id
 
     async def get_pending(self) -> list[PendingResume]:

--- a/claude_discord/database/summary_repo.py
+++ b/claude_discord/database/summary_repo.py
@@ -103,11 +103,13 @@ class ThreadSummaryRepository:
         rec = await self.get(summary_key)
         if rec is None:
             raise RuntimeError(f"Failed to retrieve thread summary {summary_key} after upsert")
+        safe_summary_key = summary_key.replace("\r", " ").replace("\n", " ")
+        safe_marker = str(rec["marker"]).replace("\r", " ").replace("\n", " ")
         logger.info(
             "Thread summary saved: key=%s (%d chars) marker=%s",
-            summary_key,
+            safe_summary_key,
             len(summary),
-            rec["marker"],
+            safe_marker,
         )
         return rec
 
@@ -120,7 +122,8 @@ class ThreadSummaryRepository:
             await db.commit()
             removed = cursor.rowcount > 0
         if removed:
-            logger.info("Thread summary deleted: key=%s", summary_key)
+            safe_summary_key = summary_key.replace("\r", " ").replace("\n", " ")
+            logger.info("Thread summary deleted: key=%s", safe_summary_key)
         return removed
 
     async def count(self) -> int:

--- a/tests/test_resume_repo.py
+++ b/tests/test_resume_repo.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import tempfile
 
@@ -51,6 +52,21 @@ class TestMark:
         assert p.session_id == "sid-xyz"
         assert p.reason == "custom_reason"
         assert p.resume_prompt == "Please continue."
+
+    @pytest.mark.asyncio
+    async def test_mark_does_not_write_multiline_log_entries(
+        self,
+        repo: PendingResumeRepository,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        caplog.set_level(logging.INFO, logger="claude_discord.database.resume_repo")
+
+        await repo.mark(99, reason="restart\r\nforged")
+
+        message = caplog.records[-1].getMessage()
+        assert "\r" not in message
+        assert "\n" not in message
+        assert "reason=restart  forged" in message
 
 
 class TestGetPending:

--- a/tests/test_summary_repo.py
+++ b/tests/test_summary_repo.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import tempfile
 
@@ -63,6 +64,38 @@ async def test_delete_removes_row(repo: ThreadSummaryRepository) -> None:
     assert await repo.get("teams:thread:1") is None
     # Deleting a missing key is a no-op that reports False.
     assert await repo.delete("teams:thread:1") is False
+
+
+@pytest.mark.asyncio
+async def test_upsert_does_not_write_multiline_log_entries(
+    repo: ThreadSummaryRepository, caplog: pytest.LogCaptureFixture
+) -> None:
+    caplog.set_level(logging.INFO, logger="claude_discord.database.summary_repo")
+
+    await repo.upsert("teams:\r\nforged", summary="v1", marker="100\nforged")
+
+    message = caplog.records[-1].getMessage()
+    assert "\r" not in message
+    assert "\n" not in message
+    assert "key=teams:  forged" in message
+    assert "marker=100 forged" in message
+
+
+@pytest.mark.asyncio
+async def test_delete_does_not_write_multiline_log_entries(
+    repo: ThreadSummaryRepository, caplog: pytest.LogCaptureFixture
+) -> None:
+    summary_key = "teams:\r\nforged"
+    await repo.upsert(summary_key, summary="v1")
+    caplog.clear()
+    caplog.set_level(logging.INFO, logger="claude_discord.database.summary_repo")
+
+    assert await repo.delete(summary_key) is True
+
+    message = caplog.records[-1].getMessage()
+    assert "\r" not in message
+    assert "\n" not in message
+    assert "key=teams:  forged" in message
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- replace embedded CR/LF characters before logging summary keys, markers, and resume reasons
- add regression coverage for summary upsert/delete and pending-resume logs
- dismiss nine non-actionable CodeQL findings with finding-specific explanations

## Test plan

- [x] `uv run pytest tests/test_summary_repo.py tests/test_resume_repo.py -q` (18 passed)
- [x] `uv run ruff check .`
- [x] `uv run ruff format --check claude_discord/ claude_code_core/ tests/`
- [x] `uv run pyright claude_discord/ claude_code_core/` (0 errors)
- [x] `uvx bandit -r claude_discord claude_code_core -q` (0 high-severity findings)
- [x] `uv run pytest tests/ -q --cov=claude_discord` (2,630 passed, 85% coverage)

Closes #642