### PR TITLE
fix: distinguish unavailable Teams attachments from retryable failures (#644)

### DIFF
--- a/claude_discord/ext/api_server.py
+++ b/claude_discord/ext/api_server.py
@@ -2200,6 +2200,18 @@ class ApiServer:
                 # A full scan means nothing above is unexamined any more.
                 coverage["oldest_seen_mid"] = None
                 coverage["full_scan"] = True
+            raw_scan = raw_coverage.get("attachment_scan")
+            if isinstance(raw_scan, dict):
+                try:
+                    detected = int(raw_scan.get("detected", 0))
+                    ignored = int(raw_scan.get("ignored", 0))
+                except (TypeError, ValueError):
+                    detected = ignored = -1
+                if 0 <= ignored <= detected <= 100_000:
+                    coverage["attachment_scan"] = {
+                        "detected": detected,
+                        "ignored": ignored,
+                    }
         return (ref, messages, coverage), None
 
     async def teams_sync_plan(self, request: web.Request) -> web.Response:
@@ -2226,6 +2238,7 @@ class ApiServer:
             messages,
             stored,
             pending=meta.get("pending_attachments") or [],
+            unavailable=meta.get("unavailable_attachments") or [],
         )
         return web.json_response(
             {
@@ -2240,6 +2253,16 @@ class ApiServer:
                 # it wrong costs one extra sync, not a hole in the history.
                 "newest_have_mid": plan.newest_have_mid,
                 "pending": meta.get("pending_attachments") or [],
+                "unavailable": meta.get("unavailable_attachments") or [],
+                "attachment_summary": meta.get("attachment_summary")
+                or {
+                    "detected": 0,
+                    "saved": 0,
+                    "unavailable": 0,
+                    "ignored": 0,
+                    "pending": len(meta.get("pending_attachments") or []),
+                },
+                "message_count": int(meta.get("message_count") or len(stored)),
                 # What this server supports, so a client can tell it apart from
                 # an older one. `conversation_scope` is the permission a client
                 # needs before it may upload a partially-scrolled chat: against
@@ -2281,6 +2304,7 @@ class ApiServer:
 
         created = updated = attachments_saved = 0
         fresh_pending: list[dict] = []
+        fresh_unavailable: list[dict] = []
         for msg in ordered:
             position = known.index(int(msg.mid))
             prev_mid = str(known[position - 1]) if position > 0 else None
@@ -2295,9 +2319,22 @@ class ApiServer:
                 updated += 1
             attachments_saved += report["attachments_saved"]
             fresh_pending.extend(report["pending"])
+            fresh_unavailable.extend(report["unavailable"])
 
-        pending = store.merge_pending(thread_dir, fresh_pending, pushed=ordered)
-        meta = store.write_meta(thread_dir, ref, pending=pending, coverage=coverage)
+        unavailable = store.merge_unavailable(thread_dir, fresh_unavailable, pushed=ordered)
+        pending = store.merge_pending(
+            thread_dir,
+            fresh_pending,
+            pushed=ordered,
+            unavailable=unavailable,
+        )
+        meta = store.write_meta(
+            thread_dir,
+            ref,
+            pending=pending,
+            unavailable=unavailable,
+            coverage=coverage,
+        )
         logger.info(
             "Teams sync: %s (+%d new, %d updated, %d attachments, %d pending)",
             _sanitize_log(thread_dir.name),
@@ -2315,6 +2352,8 @@ class ApiServer:
                 # Never reported as an empty success: whatever did not arrive is
                 # listed here, in thread.json and in the folder's README.
                 "pending": pending,
+                "unavailable": unavailable,
+                "attachment_summary": meta["attachment_summary"],
                 "message_count": meta["message_count"],
             }
         )

--- a/claude_discord/ext/teams_store.py
+++ b/claude_discord/ext/teams_store.py
@@ -322,7 +322,7 @@ class TeamsVaultStore:
                 self._archive_version(thread_dir, msg.mid, str(previous.get("hash") or ""), note)
             first_synced = self._existing_first_synced(note) or now
 
-        saved, pending = self._save_attachments(thread_dir, msg)
+        saved, pending, unavailable = self._save_attachments(thread_dir, msg)
         note.write_text(
             teams_sync.render_message(
                 msg,
@@ -332,6 +332,7 @@ class TeamsVaultStore:
                 first_synced_at=first_synced,
                 last_synced_at=now,
                 pending=pending,
+                unavailable=unavailable,
             ),
             encoding="utf-8",
         )
@@ -345,6 +346,7 @@ class TeamsVaultStore:
             "edited": edited,
             "attachments_saved": saved,
             "pending": pending,
+            "unavailable": unavailable,
         }
 
     def _existing_first_synced(self, note: Path) -> str | None:
@@ -375,8 +377,10 @@ class TeamsVaultStore:
         except OSError as exc:
             logger.warning("Could not archive previous version of %s: %s", mid, exc)
 
-    def _save_attachments(self, thread_dir: Path, msg: IncomingMessage) -> tuple[int, list[dict]]:
-        """Write embedded attachment bytes; record everything else as pending.
+    def _save_attachments(
+        self, thread_dir: Path, msg: IncomingMessage
+    ) -> tuple[int, list[dict], list[dict]]:
+        """Write bytes; separate terminal source gaps from retryable failures.
 
         An attachment that cannot be stored is never dropped silently — it is
         returned as pending so it surfaces in thread.json, in the README and in
@@ -387,8 +391,19 @@ class TeamsVaultStore:
 
         saved = 0
         pending: list[dict] = []
+        unavailable: list[dict] = []
         for i, att in enumerate(msg.attachments):
             name = teams_sync.safe_attachment_name(att.name, i)
+            if att.status == "unavailable":
+                unavailable.append(
+                    {
+                        "mid": msg.mid,
+                        "name": name,
+                        "reason": att.reason or "取得元で利用できません",
+                        "url": att.url,
+                    }
+                )
+                continue
             if att.status != "embedded" or not att.data_b64:
                 pending.append(
                     {
@@ -429,7 +444,7 @@ class TeamsVaultStore:
                 pending.append({"mid": msg.mid, "name": name, "reason": f"書き込み失敗: {exc}"})
                 continue
             saved += 1
-        return saved, pending
+        return saved, pending, unavailable
 
     def _append_chain(self, thread_dir: Path, entry: dict) -> None:
         path = thread_dir / "chain.jsonl"
@@ -461,6 +476,7 @@ class TeamsVaultStore:
         ref: ThreadRef,
         *,
         pending: list[dict],
+        unavailable: list[dict] | None = None,
         coverage: dict,
         now: str | None = None,
     ) -> dict:
@@ -469,6 +485,27 @@ class TeamsVaultStore:
         chain = self.read_chain(thread_dir)
         latest = self.latest_chain(thread_dir)
         previous = self.read_meta(thread_dir)
+        unavailable = unavailable or []
+        saved_total = sum(len(self._attachments_present(thread_dir, mid)) for mid in latest)
+        scan = coverage.get("attachment_scan") or {}
+        previous_summary = previous.get("attachment_summary") or {}
+        ignored = int(scan.get("ignored", previous_summary.get("ignored", 0)) or 0)
+        detected = int(
+            scan.get(
+                "detected",
+                previous_summary.get(
+                    "detected", saved_total + len(unavailable) + len(pending) + ignored
+                ),
+            )
+            or 0
+        )
+        attachment_summary = {
+            "detected": detected,
+            "saved": saved_total,
+            "unavailable": len(unavailable),
+            "ignored": ignored,
+            "pending": len(pending),
+        }
         authors = [str(e.get("author") or "") for e in latest.values()]
         meta = {
             "team": ref.team,
@@ -480,6 +517,8 @@ class TeamsVaultStore:
             "message_count": len(latest),
             "coverage": {**(previous.get("coverage") or {}), **coverage},
             "pending_attachments": pending,
+            "unavailable_attachments": unavailable,
+            "attachment_summary": attachment_summary,
             "first_synced_at": previous.get("first_synced_at") or now,
             "last_synced_at": now,
         }
@@ -497,6 +536,7 @@ class TeamsVaultStore:
         fresh: list[dict],
         *,
         pushed: list[IncomingMessage] | None = None,
+        unavailable: list[dict] | None = None,
     ) -> list[dict]:
         """Carry forward unresolved gaps, drop resolved or obsolete ones.
 
@@ -512,10 +552,15 @@ class TeamsVaultStore:
             for msg in pushed or []
         }
         merged: dict[tuple[str, str], dict] = {}
+        unavailable_keys = {
+            (str(item.get("mid") or ""), str(item.get("name") or "")) for item in unavailable or []
+        }
         for item in (self.read_meta(thread_dir).get("pending_attachments") or []) + fresh:
             mid = str(item.get("mid") or "")
             name = str(item.get("name") or "")
             if not mid or not name:
+                continue
+            if (mid, name) in unavailable_keys:
                 continue
             if mid in declared_by_mid and name not in declared_by_mid[mid]:
                 continue
@@ -534,4 +579,32 @@ class TeamsVaultStore:
             )
             if current is None or candidate_priority >= current_priority:
                 merged[key] = candidate
+        return sorted(merged.values(), key=lambda i: (i["mid"], i["name"]))
+
+    def merge_unavailable(
+        self,
+        thread_dir: Path,
+        fresh: list[dict],
+        *,
+        pushed: list[IncomingMessage] | None = None,
+    ) -> list[dict]:
+        """Carry forward terminal source gaps until bytes arrive or inventory changes."""
+        declared_by_mid = {
+            msg.mid: {teams_sync.safe_attachment_name(att.name) for att in msg.attachments}
+            for msg in pushed or []
+        }
+        fresh_keys = {(str(item.get("mid") or ""), str(item.get("name") or "")) for item in fresh}
+        merged: dict[tuple[str, str], dict] = {}
+        for item in (self.read_meta(thread_dir).get("unavailable_attachments") or []) + fresh:
+            mid = str(item.get("mid") or "")
+            name = str(item.get("name") or "")
+            if not mid or not name:
+                continue
+            if mid in declared_by_mid and name not in declared_by_mid[mid]:
+                continue
+            if name in self._attachments_present(thread_dir, mid):
+                continue
+            if mid in declared_by_mid and (mid, name) not in fresh_keys:
+                continue
+            merged[(mid, name)] = {**item, "mid": mid, "name": name}
         return sorted(merged.values(), key=lambda i: (i["mid"], i["name"]))

--- a/claude_discord/ext/teams_sync.py
+++ b/claude_discord/ext/teams_sync.py
@@ -319,6 +319,7 @@ def build_plan(
     incoming: list[IncomingMessage],
     stored: dict[str, StoredMessage],
     pending: list[dict] | None = None,
+    unavailable: list[dict] | None = None,
 ) -> SyncPlan:
     """Decide what the client still needs to send.
 
@@ -338,6 +339,11 @@ def build_plan(
         name = str(item.get("name") or "")
         if mid and name:
             pending_by_mid.setdefault(mid, set()).add(name)
+    unavailable_keys = {
+        (str(item.get("mid") or ""), str(item.get("name") or ""))
+        for item in unavailable or []
+        if item.get("mid") and item.get("name")
+    }
     if stored:
         plan.newest_have_mid = max(stored, key=_mid_sort_key)
     for msg in incoming:
@@ -350,7 +356,7 @@ def build_plan(
         for att in msg.attachments:
             name = safe_attachment_name(att.name)
             present = current is not None and name in current.attachments_present
-            if not present:
+            if not present and (msg.mid, name) not in unavailable_keys:
                 plan.want_attachments.append({"mid": msg.mid, "name": name})
     plan.want_messages.sort(key=_mid_sort_key)
     return plan
@@ -375,6 +381,7 @@ def render_message(
     first_synced_at: str,
     last_synced_at: str,
     pending: list[dict],
+    unavailable: list[dict] | None = None,
 ) -> str:
     """Render one message as an Obsidian note with YAML frontmatter.
 
@@ -397,6 +404,7 @@ def render_message(
         "deleted": msg.deleted,
         "attachments": [safe_attachment_name(a.name) for a in msg.attachments],
         "attachments_pending": [p["name"] for p in pending],
+        "attachments_unavailable": [p["name"] for p in unavailable or []],
         "first_synced_at": first_synced_at,
         "last_synced_at": last_synced_at,
     }
@@ -468,6 +476,7 @@ def render_readme(meta: dict, chain: list[dict]) -> str:
     whole rewrite exists to remove.
     """
     pending = meta.get("pending_attachments") or []
+    unavailable = meta.get("unavailable_attachments") or []
     coverage = meta.get("coverage") or {}
     lines = [
         f"# Teams スレッド: {meta.get('title', '')}",
@@ -494,6 +503,13 @@ def render_readme(meta: dict, chain: list[dict]) -> str:
     if pending:
         lines += ["## ⚠️ 未取得の添付", ""]
         for item in pending:
+            lines.append(
+                f"- `{item.get('name', '')}`（{item.get('mid', '')}）— {item.get('reason', '')}"
+            )
+        lines.append("")
+    if unavailable:
+        lines += ["## 取得元で利用できない添付", ""]
+        for item in unavailable:
             lines.append(
                 f"- `{item.get('name', '')}`（{item.get('mid', '')}）— {item.get('reason', '')}"
             )

--- a/tests/test_api_teams_sync.py
+++ b/tests/test_api_teams_sync.py
@@ -346,6 +346,66 @@ async def test_pending_clears_once_the_bytes_arrive(client: TestClient) -> None:
     assert (await resp.json())["pending"] == []
 
 
+async def test_source_unavailable_is_terminal_and_reported_separately(
+    client: TestClient,
+) -> None:
+    """A confirmed source-side 404 is visible, but not retryable pending work."""
+    resp = await client.post(
+        "/api/teams/sync/push",
+        headers=AUTH,
+        json=thread_body(
+            messages=[
+                msg(
+                    ROOT,
+                    "x",
+                    "h1",
+                    attachments=[
+                        {
+                            "name": "gone.txt",
+                            "status": "unavailable",
+                            "url": "https://contoso.sharepoint.com/sites/team/gone.txt",
+                            "reason": "Authenticated source returned HTTP 404",
+                        }
+                    ],
+                )
+            ],
+            coverage={
+                "full_scan": True,
+                "attachment_scan": {"detected": 10, "ignored": 1},
+            },
+        ),
+    )
+    body = await resp.json()
+
+    assert body["pending"] == []
+    assert body["unavailable"] == [
+        {
+            "mid": ROOT,
+            "name": "gone.txt",
+            "reason": "Authenticated source returned HTTP 404",
+            "url": "https://contoso.sharepoint.com/sites/team/gone.txt",
+        }
+    ]
+    assert body["attachment_summary"] == {
+        "detected": 10,
+        "saved": 0,
+        "unavailable": 1,
+        "ignored": 1,
+        "pending": 0,
+    }
+
+    plan = await client.post(
+        "/api/teams/sync/plan",
+        headers=AUTH,
+        json=thread_body(messages=[{"mid": ROOT, "hash": "h1", "attachments": ["gone.txt"]}]),
+    )
+    plan_body = await plan.json()
+    assert plan_body["want_messages"] == []
+    assert plan_body["want_attachments"] == []
+    assert plan_body["attachment_summary"] == body["attachment_summary"]
+    assert plan_body["message_count"] == 1
+
+
 async def test_obsolete_pending_clears_when_the_message_inventory_changes(
     client: TestClient,
 ) -> None:


### PR DESCRIPTION
## Summary

- store authenticated source-side attachment failures separately from retryable pending items
- keep unavailable metadata visible in thread files and API responses
- return durable message and attachment summary counts to sync clients
- preserve existing clients and thread metadata

## Test plan

- [x] All checks passed!
- [x] 89 files already formatted
- [x] 0 errors, 0 warnings, 0 informations
- [x] ........................................................................ [  2%]
........................................................................ [  5%]
........................................................................ [  8%]
........................................................................ [ 10%]
........................................................................ [ 13%]
........................................................................ [ 16%]
........................................................................ [ 19%]
........................................................................ [ 21%]
........................................................................ [ 24%]
........................................................................ [ 27%]
........................................................................ [ 30%]
........................................................................ [ 32%]
........................................................................ [ 35%]
........................................................................ [ 38%]
........................................................................ [ 41%]
........................................................................ [ 43%]
........................................................................ [ 46%]
........................................................................ [ 49%]
........................................................................ [ 51%]
........................................................................ [ 54%]
........................................................................ [ 57%]
........................................................................ [ 60%]
........................................................................ [ 62%]
........................................................................ [ 65%]
........................................................................ [ 68%]
........................................................................ [ 71%]
........................................................................ [ 73%]
........................................................................ [ 76%]
........................................................................ [ 79%]
........................................................................ [ 82%]
........................................................................ [ 84%]
........................................................................ [ 87%]
........................................................................ [ 90%]
........................................................................ [ 93%]
........................................................................ [ 95%]
........................................................................ [ 98%]
.......................................                                  [100%]
=============================== warnings summary ===============================
tests/test_api_server.py::TestIngest::test_zip_members_with_the_same_name_both_survive
  /home/ebi/.local/share/uv/python/cpython-3.13.13-linux-x86_64-gnu/lib/python3.13/zipfile/__init__.py:1655: UserWarning: Duplicate name: 'image.png'
    return self._open_to_write(zinfo, force_zip64=force_zip64)

tests/test_ask_feature.py::TestAskViewOtherCallback::test_other_callback_edits_original_message_when_session_gone
  /home/ebi/.local/share/uv/python/cpython-3.13.13-linux-x86_64-gnu/lib/python3.13/unittest/mock.py:2199: RuntimeWarning: coroutine 'Queue.get' was never awaited
    setattr(_type, entry, MagicProxy(entry, self))
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

tests/test_auto_upgrade.py::TestUpgradeSteps::test_success_adds_check_reaction
tests/test_auto_upgrade.py::TestUpgradeSteps::test_no_restart_shows_completion
tests/test_auto_upgrade.py::TestUpgradeApprovalView::test_bot_click_is_ignored
tests/test_runner.py::TestInterrupt::test_interrupt_falls_back_to_kill_on_asyncio_timeout
tests/test_runner.py::TestRunTimeout::test_run_yields_error_on_asyncio_timeout
tests/test_upgrade_slash.py::TestUpgradeSlashCommandEnabled::test_already_running_sends_ephemeral
tests/test_upgrade_slash.py::TestUpgradeSlashCommandEnabled::test_thread_name_uses_trigger_prefix
tests/test_upgrade_slash.py::TestUpgradeSlashCommandFromThread::test_creates_thread_in_parent_channel_when_invoked_from_thread
tests/test_upgrade_slash.py::TestUpgradeSlashCommandFromThread::test_defers_response_from_thread
  /home/ebi/.local/share/uv/python/cpython-3.13.13-linux-x86_64-gnu/lib/python3.13/unittest/mock.py:2253: RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited
    def __init__(self, name, parent):
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

tests/test_auto_upgrade.py::TestUpgradeSteps::test_restart_command_fired
  /home/ebi/.local/share/uv/python/cpython-3.13.13-linux-x86_64-gnu/lib/python3.13/unittest/mock.py:361: RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited
    def _set(self, value, name=name, _the_name=_the_name):
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

tests/test_auto_upgrade.py::TestRestartApproval::test_no_approval_mode_skips_wait
  /home/ebi/.local/share/uv/python/cpython-3.13.13-linux-x86_64-gnu/lib/python3.13/unittest/mock.py:496: RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited
    __dict__['method_calls'] = _CallList()
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

tests/test_auto_upgrade.py::TestActiveSessionCount::test_count_starts_at_zero
tests/test_schedule_wakeup.py::TestScheduleWakeupTaskRegistration::test_registers_one_shot_task
  /home/ebi/.local/share/uv/python/cpython-3.13.13-linux-x86_64-gnu/lib/python3.13/unittest/mock.py:2199: RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited
    setattr(_type, entry, MagicProxy(entry, self))
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

tests/test_runner.py::TestRunTimeout::test_run_yields_error_on_asyncio_timeout
  /home/ebi/wt-1539482904256708698-ccdb/claude_code_core/runner.py:247: RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited
    self._process.stdin.write(line.encode())
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

tests/test_views.py::TestStopViewDisable::test_disable_suppresses_runtime_error_session_closed
  /home/ebi/.local/share/uv/python/cpython-3.13.13-linux-x86_64-gnu/lib/python3.13/unittest/mock.py:444: RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited
    def __new__(
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================ tests coverage ================================
_______________ coverage: platform linux, python 3.13.13-final-0 _______________

Name                                              Stmts   Miss  Cover
---------------------------------------------------------------------
claude_discord/__init__.py                           29      0   100%
claude_discord/backend_factory.py                    56      2    96%
claude_discord/backend_settings.py                  125      6    95%
claude_discord/bot.py                                80     64    20%
claude_discord/claude/__init__.py                     0      0   100%
claude_discord/claude/parser.py                       3      0   100%
claude_discord/claude/rewind.py                       3      0   100%
claude_discord/claude/runner.py                       3      0   100%
claude_discord/claude/types.py                       17      0   100%
claude_discord/cli.py                               224    132    41%
claude_discord/cog_loader.py                         38      2    95%
claude_discord/cogs/__init__.py                      13      0   100%
claude_discord/cogs/_run_helper.py                  194     28    86%
claude_discord/cogs/ask_command.py                   48     30    38%
claude_discord/cogs/auto_upgrade.py                 249     14    94%
claude_discord/cogs/backend_command.py              180     70    61%
claude_discord/cogs/claude_chat.py                  457     68    85%
claude_discord/cogs/collision_watch.py               68     17    75%
claude_discord/cogs/context_links.py                 92      3    97%
claude_discord/cogs/event_processor.py              482     45    91%
claude_discord/cogs/headless_backend.py              27      1    96%
claude_discord/cogs/notification_dispatch.py         73      7    90%
claude_discord/cogs/prompt_builder.py               153     13    92%
claude_discord/cogs/run_config.py                    57      1    98%
claude_discord/cogs/scheduler.py                     80     14    82%
claude_discord/cogs/session_manage.py               406    101    75%
claude_discord/cogs/session_sync.py                  67      5    93%
claude_discord/cogs/skill_command.py                164      2    99%
claude_discord/cogs/webhook_trigger.py               78      0   100%
claude_discord/collision.py                          65      0   100%
claude_discord/concurrency.py                        47      0   100%
claude_discord/cross_backend_handoff.py             116     16    86%
claude_discord/database/__init__.py                   0      0   100%
claude_discord/database/ask_repo.py                  44     21    52%
claude_discord/database/claims_repo.py               67      0   100%
claude_discord/database/frontend_thread_repo.py      57      0   100%
claude_discord/database/inbox_repo.py                37      0   100%
claude_discord/database/ingest_repo.py               55      1    98%
claude_discord/database/lounge_repo.py                3      0   100%
claude_discord/database/models.py                    16      0   100%
claude_discord/database/notification_repo.py         42      0   100%
claude_discord/database/repository.py                 3      0   100%
claude_discord/database/resume_repo.py               42      0   100%
claude_discord/database/settings_repo.py             26      0   100%
claude_discord/database/summary_repo.py              46      1    98%
claude_discord/database/task_repo.py                156      5    97%
claude_discord/deployment.py                         37      0   100%
claude_discord/discord_ui/__init__.py                 4      0   100%
claude_discord/discord_ui/ask_bus.py                 24      0   100%
claude_discord/discord_ui/ask_handler.py             42      4    90%
claude_discord/discord_ui/ask_view.py                74     23    69%
claude_discord/discord_ui/chunker.py                 13      0   100%
claude_discord/discord_ui/embeds.py                 119     20    83%
claude_discord/discord_ui/engine_status.py          119     43    64%
claude_discord/discord_ui/file_sender.py             70      8    89%
claude_discord/discord_ui/inbox_classifier.py        33      5    85%
claude_discord/discord_ui/mentions.py                 7      0   100%
claude_discord/discord_ui/prompt_views.py            85     45    47%
claude_discord/discord_ui/status.py                 117     14    88%
claude_discord/discord_ui/statusline.py              43      1    98%
claude_discord/discord_ui/streaming_manager.py       68     14    79%
claude_discord/discord_ui/table_renderer.py           3      0   100%
claude_discord/discord_ui/thread_context.py          49      2    96%
claude_discord/discord_ui/thread_dashboard.py       113      5    96%
claude_discord/discord_ui/thread_renamer.py          61      1    98%
claude_discord/discord_ui/tool_timer.py              29      0   100%
claude_discord/discord_ui/views.py                  164     41    75%
claude_discord/ext/__init__.py                        0      0   100%
claude_discord/ext/api_server.py                   1185    187    84%
claude_discord/ext/ingest_manifest.py               219     18    92%
claude_discord/ext/teams_store.py                   305     41    87%
claude_discord/ext/teams_sync.py                    201     11    95%
claude_discord/frontend.py                           50      0   100%
claude_discord/lounge.py                             18      0   100%
claude_discord/main.py                               85     52    39%
claude_discord/model_catalog.py                     121      8    93%
claude_discord/pr_completion_gate.py                 55     11    80%
claude_discord/protocols.py                           4      0   100%
claude_discord/relay.py                              40      0   100%
claude_discord/session_sync.py                      135     15    89%
claude_discord/session_view.py                       33      0   100%
claude_discord/setup.py                             188      9    95%
claude_discord/stores.py                             40      0   100%
claude_discord/surface.py                           282     41    85%
claude_discord/teams_integration.py                 131     38    71%
claude_discord/thread_policy.py                       1      0   100%
claude_discord/utils/__init__.py                      0      0   100%
claude_discord/utils/logger.py                       22      0   100%
claude_discord/worktree.py                          119     23    81%
---------------------------------------------------------------------
TOTAL                                              8796   1349    85%
2631 passed, 17 warnings in 80.26s (0:01:20) (2631 passed, 85% coverage)
- [ ] Validate the extension against an authenticated SharePoint 404 thread in dev mode

Closes #644