### PR TITLE
feat: install Ollama models from /model

### DIFF
--- a/claude_code_core/local_backend.py
+++ b/claude_code_core/local_backend.py
@@ -25,11 +25,16 @@ Two consequences worth keeping in mind:
 
 from __future__ import annotations
 
+import asyncio
+import json
 import logging
 import os
+import re
 from dataclasses import dataclass
 from pathlib import Path
-from urllib.parse import urlparse
+from urllib import error as urllib_error
+from urllib import request as urllib_request
+from urllib.parse import urlparse, urlsplit, urlunsplit
 
 from .codex_runner import CodexRunner
 
@@ -40,12 +45,20 @@ __all__ = [
     "LocalCodexRunner",
     "build_local_config_toml",
     "ensure_codex_home",
+    "ollama_pull_url",
+    "pull_ollama_model",
+    "validate_ollama_model_name",
     "verify_quiet_settings",
 ]
 
 DEFAULT_BASE_URL = "http://127.0.0.1:11434/v1"
 DEFAULT_MODEL = "gpt-oss:120b"
 PROVIDER_ID = "ccdb_local"
+DEFAULT_OLLAMA_PULL_TIMEOUT_SECONDS = 6 * 60 * 60
+OLLAMA_MODEL_NAME_PATTERN = re.compile(
+    r"^[A-Za-z0-9][A-Za-z0-9._-]*(?:/[A-Za-z0-9][A-Za-z0-9._-]*)*"
+    r"(?::[A-Za-z0-9][A-Za-z0-9._-]*)?$"
+)
 
 # Settings that keep a local run local. Each maps to the TOML line that must be
 # present in the generated config; verify_quiet_settings() reports any that are
@@ -89,6 +102,97 @@ class LocalModelConfig:
             model=_env("CCDB_LOCAL_MODEL") or DEFAULT_MODEL,
             codex_home=Path(home) if home else None,
         )
+
+
+def validate_ollama_model_name(model: str) -> str:
+    """Validate and normalize a user-provided Ollama model identifier.
+
+    Model names are sent as JSON, never interpolated into a shell command. The
+    strict grammar still rejects whitespace, control characters, URL syntax,
+    and accidentally pasted prose before a long-running pull begins.
+    """
+    normalized = model.strip()
+    if (
+        not normalized
+        or len(normalized) > 255
+        or OLLAMA_MODEL_NAME_PATTERN.fullmatch(normalized) is None
+    ):
+        raise ValueError(
+            "Invalid Ollama model name. Use letters, numbers, '.', '_', '-', '/', "
+            "and one optional ':tag'."
+        )
+    return normalized
+
+
+def ollama_pull_url(base_url: str) -> str:
+    """Derive Ollama's native ``/api/pull`` URL from the configured API URL.
+
+    The local backend uses Ollama's OpenAI-compatible endpoint, normally
+    ``http://host:11434/v1``. Pulling a model uses Ollama's native API on the
+    same origin, so only the terminal ``/v1`` is replaced.
+    """
+    parsed = urlsplit(base_url.strip())
+    if (
+        parsed.scheme not in {"http", "https"}
+        or not parsed.hostname
+        or parsed.username is not None
+        or parsed.password is not None
+    ):
+        raise ValueError("CCDB_LOCAL_BASE_URL must be an HTTP(S) URL without credentials")
+
+    path = parsed.path.rstrip("/")
+    if path.endswith("/v1"):
+        path = path[:-3]
+    prefix = path.rstrip("/")
+    pull_path = f"{prefix}/api/pull" if prefix else "/api/pull"
+    return urlunsplit((parsed.scheme, parsed.netloc, pull_path, "", ""))
+
+
+def _pull_ollama_model_sync(
+    model: str,
+    *,
+    config: LocalModelConfig,
+    timeout_seconds: float,
+) -> None:
+    """Perform one blocking, non-streaming Ollama pull request."""
+    payload = json.dumps({"model": model, "stream": False}).encode("utf-8")
+    request = urllib_request.Request(
+        ollama_pull_url(config.base_url),
+        data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib_request.urlopen(request, timeout=timeout_seconds) as response:
+            body = response.read()
+    except (urllib_error.HTTPError, urllib_error.URLError, TimeoutError, OSError) as exc:
+        raise RuntimeError(f"Ollama model pull request failed: {exc}") from exc
+
+    try:
+        result = json.loads(body.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise RuntimeError("Ollama returned an invalid response to the model pull request") from exc
+
+    if not isinstance(result, dict) or result.get("status") != "success":
+        detail = result.get("error") or result.get("status") if isinstance(result, dict) else None
+        suffix = f": {detail}" if detail else ""
+        raise RuntimeError(f"Ollama model pull did not complete successfully{suffix}")
+
+
+async def pull_ollama_model(
+    model: str,
+    *,
+    config: LocalModelConfig | None = None,
+    timeout_seconds: float = DEFAULT_OLLAMA_PULL_TIMEOUT_SECONDS,
+) -> None:
+    """Pull an Ollama model without blocking the Discord event loop."""
+    normalized = validate_ollama_model_name(model)
+    await asyncio.to_thread(
+        _pull_ollama_model_sync,
+        normalized,
+        config=config or LocalModelConfig.from_env(),
+        timeout_seconds=timeout_seconds,
+    )
 
 
 def build_local_config_toml(config: LocalModelConfig) -> str:

--- a/claude_discord/cogs/backend_command.py
+++ b/claude_discord/cogs/backend_command.py
@@ -13,7 +13,7 @@ follow-up).
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import discord
 from discord import app_commands
@@ -21,6 +21,7 @@ from discord.app_commands import Choice
 from discord.ext import commands
 
 from claude_code_core.codex_runner import VALID_CODEX_EFFORTS
+from claude_code_core.local_backend import pull_ollama_model, validate_ollama_model_name
 
 from ..backend_settings import (
     ALL_BACKENDS,
@@ -94,7 +95,7 @@ def _model_label(model: str | None) -> str:
 
 
 class BackendCommandCog(commands.Cog):
-    """/backend and /model slash commands."""
+    """/backend, /model, /effort, and /engine-status slash commands."""
 
     def __init__(
         self,
@@ -135,6 +136,18 @@ class BackendCommandCog(commands.Cog):
         if thread_id is not None:
             return SCOPE_THREAD, thread_id
         return SCOPE_GLOBAL, None
+
+    async def _send_install_result(
+        self,
+        interaction: discord.Interaction,
+        message: str,
+    ) -> None:
+        """Post the result after the initial interaction response was consumed."""
+        channel: Any = interaction.channel
+        if channel is not None:
+            await channel.send(message)
+        else:
+            await interaction.followup.send(message)
 
     # ── /backend ───────────────────────────────────────────────────
 
@@ -267,7 +280,7 @@ class BackendCommandCog(commands.Cog):
 
     @app_commands.command(
         name="model",
-        description="Show or switch the model for the current backend",
+        description="Show, switch, or install a model for the current backend",
     )
     @app_commands.choices(
         scope=[
@@ -277,7 +290,8 @@ class BackendCommandCog(commands.Cog):
     )
     @app_commands.autocomplete(name=_model_name_autocomplete)
     @app_commands.describe(
-        name="Model id (e.g. sonnet, opus, gpt-5.6-sol, o4-mini). Omit to show current.",
+        name="Model id to select. Omit to show current or use install for Ollama.",
+        install="Ollama model id to pull and select (local backend only).",
         scope=(
             "thread: only this thread; global: server-wide. "
             "Default: thread when in thread, else global."
@@ -287,12 +301,21 @@ class BackendCommandCog(commands.Cog):
         self,
         interaction: discord.Interaction,
         name: str | None = None,
+        install: str | None = None,
         scope: str | None = None,
     ) -> None:
         thread_id_now = self._thread_id_or_none(interaction)
 
+        if name is not None and install is not None:
+            await interaction.response.send_message(
+                "Choose either `name` to select an installed model or `install` to pull one, "
+                "not both.",
+                ephemeral=True,
+            )
+            return
+
         # Show current
-        if name is None:
+        if name is None and install is None:
             backend_for_thread = (
                 await self._settings.current_backend(thread_id_now)
                 if thread_id_now is not None
@@ -334,6 +357,39 @@ class BackendCommandCog(commands.Cog):
             target_thread_id if resolved_scope == SCOPE_THREAD else None
         )
 
+        installed = install is not None
+        if install is not None:
+            if backend_for_save != "local":
+                await interaction.response.send_message(
+                    "Model installation is available only for the `local` backend. "
+                    "Run `/backend name:local` first.",
+                    ephemeral=True,
+                )
+                return
+            try:
+                name = validate_ollama_model_name(install)
+            except ValueError as exc:
+                await interaction.response.send_message(f"❌ {exc}", ephemeral=True)
+                return
+
+            await interaction.response.send_message(
+                f"📦 Installing `{name}` from Ollama. This can take a while; "
+                "I will post again when it finishes.",
+                ephemeral=False,
+            )
+            try:
+                await pull_ollama_model(name)
+            except Exception as exc:
+                logger.exception("Failed to install Ollama model %s", name)
+                detail = str(exc).strip()[:500] or type(exc).__name__
+                await self._send_install_result(
+                    interaction,
+                    f"❌ Ollama model installation failed for `{name}`: {detail}",
+                )
+                return
+
+        # The show-current and mutually-exclusive branches above guarantee this.
+        assert name is not None
         await self._settings.set_model(backend_for_save, name, thread_id=target_thread_id)
 
         # Global change → also update shared runner.model so the next
@@ -350,11 +406,18 @@ class BackendCommandCog(commands.Cog):
             if resolved_scope == SCOPE_THREAD and target_thread_id is not None
             else "**globally**"
         )
-        await interaction.response.send_message(
-            f"\U0001f9e0 Model set to `{name}` for `{backend_for_save}` "
-            f"{scope_label}. Next session will use it.",
-            ephemeral=False,
-        )
+        if installed:
+            await self._send_install_result(
+                interaction,
+                f"✅ Installed `{name}` from Ollama and set it for `local` "
+                f"{scope_label}. It is ready for the next session.",
+            )
+        else:
+            await interaction.response.send_message(
+                f"\U0001f9e0 Model set to `{name}` for `{backend_for_save}` "
+                f"{scope_label}. Next session will use it.",
+                ephemeral=False,
+            )
 
     # ── /effort ────────────────────────────────────────────────────
 

--- a/docs/local-backend.md
+++ b/docs/local-backend.md
@@ -47,13 +47,10 @@ local thread cannot fall back to a paid endpoint by accident.
 
 ## Setup
 
-1. Run any OpenAI-compatible local runtime that serves `/v1/responses`. Ollama
-   does. codex-cli dropped `wire_api = "chat"`, so an endpoint that only offers
-   chat completions will not work.
-2. Pull a model that can actually drive tools. `gpt-oss:120b` works; small
-   models tend to fail at multi-step tool use rather than answer badly, which
-   is harder to notice.
-3. Point ccdb at it:
+1. Run Ollama, or another OpenAI-compatible local runtime that serves
+   `/v1/responses`. Ollama does. codex-cli dropped `wire_api = "chat"`, so an
+   endpoint that only offers chat completions will not work.
+2. Point ccdb at it:
 
 ```bash
 CCDB_LOCAL_BASE_URL=http://192.168.1.3:11434/v1   # note the /v1
@@ -61,14 +58,46 @@ CCDB_LOCAL_MODEL=gpt-oss:120b
 # CCDB_LOCAL_CODEX_HOME=/home/you/.ccdb/local-codex-home   # optional
 ```
 
-4. In Discord: `/backend local`. The session embed turns olive and reads
-   🏠 Local model.
+3. In Discord, select the backend: `/backend name:local`.
+4. Either select a model already present in Ollama with `/model name:<model>`,
+   or install and select one with `/model install:<model>`.
+
+For example:
+
+```text
+/backend name:local
+/model install:qwen3.6:35b-a3b-mtp-q4_K_M
+```
+
+The session embed turns olive and reads 🏠 Local model.
 
 | Variable | Default | Meaning |
 |---|---|---|
 | `CCDB_LOCAL_BASE_URL` | `http://127.0.0.1:11434/v1` | OpenAI-compatible endpoint serving `/v1/responses` |
 | `CCDB_LOCAL_MODEL` | `gpt-oss:120b` | Model id to request |
 | `CCDB_LOCAL_CODEX_HOME` | `~/.ccdb/local-codex-home` | ccdb-owned CLI home; regenerated on every spawn |
+
+## Installing an Ollama model from Discord
+
+`/model install:<model>` is available only while the selected backend for the
+chosen scope is `local`. ccdb derives Ollama's native `/api/pull` endpoint from
+`CCDB_LOCAL_BASE_URL`, asks Ollama to pull the model, and immediately
+acknowledges the command so a large download does not exceed Discord's
+interaction deadline.
+
+When the pull succeeds, ccdb stores the model for the same scope as the command
+and uses it for the next session. A global install also updates the shared
+default runner immediately. If the pull fails, the previous model selection is
+left unchanged.
+
+The bot process must be able to reach the Ollama host's native API, not only its
+OpenAI-compatible `/v1` routes. Model downloads can be large and consume
+substantial disk space; Ollama remains responsible for registry access,
+download progress, storage, and deduplication.
+
+Model names are sent as JSON to Ollama, never through a shell. ccdb accepts the
+normal Ollama `name[:tag]` and namespaced `namespace/name[:tag]` forms and
+rejects whitespace, URL syntax, and control characters before starting a pull.
 
 ## Honest expectations
 

--- a/tests/test_ollama_model_install.py
+++ b/tests/test_ollama_model_install.py
@@ -1,0 +1,232 @@
+"""Tests for installing and selecting Ollama models through /model."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import aiosqlite
+import pytest
+
+from claude_code_core.local_backend import (
+    LocalModelConfig,
+    ollama_pull_url,
+    pull_ollama_model,
+    validate_ollama_model_name,
+)
+from claude_discord.backend_factory import BackendFactory
+from claude_discord.backend_settings import BackendSettings
+from claude_discord.cogs.backend_command import BackendCommandCog
+from claude_discord.database.settings_repo import SettingsRepository
+
+MODEL = "qwen3.6:35b-a3b-mtp-q4_K_M"
+
+
+class _FakeResponse:
+    def __init__(self, body: dict[str, object]) -> None:
+        self._body = json.dumps(body).encode("utf-8")
+
+    def __enter__(self) -> _FakeResponse:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return self._body
+
+
+@pytest.fixture
+def local_config(tmp_path: Path) -> LocalModelConfig:
+    return LocalModelConfig(
+        base_url="http://192.168.1.3:11434/v1",
+        model="gpt-oss:120b",
+        codex_home=tmp_path / "local-codex-home",
+    )
+
+
+class TestOllamaPull:
+    def test_derives_native_pull_endpoint_from_openai_compatible_url(self) -> None:
+        assert ollama_pull_url("http://192.168.1.3:11434/v1") == (
+            "http://192.168.1.3:11434/api/pull"
+        )
+
+    def test_accepts_realistic_ollama_model_name(self) -> None:
+        assert validate_ollama_model_name(MODEL) == MODEL
+
+    @pytest.mark.parametrize("model", ["", "has space:7b", "model?tag", "model#tag"])
+    def test_rejects_invalid_model_names(self, model: str) -> None:
+        with pytest.raises(ValueError, match="Ollama model name"):
+            validate_ollama_model_name(model)
+
+    async def test_pull_posts_non_streaming_request(
+        self,
+        local_config: LocalModelConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        captured: dict[str, object] = {}
+
+        def _urlopen(request, *, timeout: float):
+            captured["url"] = request.full_url
+            captured["method"] = request.get_method()
+            captured["body"] = json.loads(request.data.decode("utf-8"))
+            captured["timeout"] = timeout
+            return _FakeResponse({"status": "success"})
+
+        monkeypatch.setattr("claude_code_core.local_backend.urllib_request.urlopen", _urlopen)
+
+        await pull_ollama_model(MODEL, config=local_config)
+
+        assert captured["url"] == "http://192.168.1.3:11434/api/pull"
+        assert captured["method"] == "POST"
+        assert captured["body"] == {"model": MODEL, "stream": False}
+
+    async def test_pull_rejects_non_success_response(
+        self,
+        local_config: LocalModelConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        def _urlopen(request, *, timeout: float):
+            return _FakeResponse({"status": "pulling manifest"})
+
+        monkeypatch.setattr("claude_code_core.local_backend.urllib_request.urlopen", _urlopen)
+
+        with pytest.raises(RuntimeError, match="did not complete successfully"):
+            await pull_ollama_model(MODEL, config=local_config)
+
+
+async def _new_settings_repo() -> SettingsRepository:
+    tmp = Path(tempfile.mkdtemp()) / "settings.db"
+    async with aiosqlite.connect(str(tmp)) as db:
+        await db.execute("CREATE TABLE settings (key TEXT PRIMARY KEY, value TEXT NOT NULL)")
+        await db.commit()
+    return SettingsRepository(str(tmp))
+
+
+async def _settings() -> BackendSettings:
+    repo = await _new_settings_repo()
+    return BackendSettings(
+        repo,
+        env_backend="claude",
+        env_model_for_claude="sonnet",
+        env_model_for_codex="",
+    )
+
+
+def _make_cog(settings: BackendSettings) -> tuple[BackendCommandCog, MagicMock]:
+    factory = BackendFactory(
+        claude_command="claude",
+        codex_command="codex",
+        permission_mode="acceptEdits",
+        working_dir=None,
+        timeout_seconds=300,
+        dangerously_skip_permissions=False,
+        allowed_tools=None,
+        append_system_prompt=None,
+        effort=None,
+    )
+    chat_cog = MagicMock()
+    chat_cog.runner = MagicMock()
+    cog = BackendCommandCog(MagicMock(), settings=settings, factory=factory, chat_cog=chat_cog)
+    return cog, chat_cog
+
+
+def _channel_interaction() -> MagicMock:
+    interaction = MagicMock()
+    interaction.channel = MagicMock()
+    interaction.channel.send = AsyncMock()
+    interaction.response = MagicMock()
+    interaction.response.send_message = AsyncMock()
+    return interaction
+
+
+class TestModelInstallCommand:
+    async def test_local_install_pulls_then_selects_model(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        settings = await _settings()
+        await settings.set_backend("local")
+        cog, chat_cog = _make_cog(settings)
+        interaction = _channel_interaction()
+        pull = AsyncMock()
+        monkeypatch.setattr("claude_discord.cogs.backend_command.pull_ollama_model", pull)
+
+        await cog.model_command.callback(
+            cog,
+            interaction,
+            name=None,
+            install=MODEL,
+            scope="global",
+        )
+
+        pull.assert_awaited_once_with(MODEL)
+        assert await settings.current_model("local") == MODEL
+        assert chat_cog.runner.model == MODEL
+        started = interaction.response.send_message.await_args.args[0]
+        assert "Installing" in started
+        completed = interaction.channel.send.await_args.args[0]
+        assert "Installed" in completed
+        assert MODEL in completed
+
+    async def test_install_is_rejected_for_non_local_backend(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        settings = await _settings()
+        cog, _ = _make_cog(settings)
+        interaction = _channel_interaction()
+        pull = AsyncMock()
+        monkeypatch.setattr("claude_discord.cogs.backend_command.pull_ollama_model", pull)
+
+        await cog.model_command.callback(
+            cog,
+            interaction,
+            name=None,
+            install=MODEL,
+            scope="global",
+        )
+
+        pull.assert_not_awaited()
+        assert await settings.explicit_model("claude") is None
+        message = interaction.response.send_message.await_args.args[0]
+        assert "local" in message.lower()
+
+    async def test_failed_pull_does_not_select_model(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        settings = await _settings()
+        await settings.set_backend("local")
+        cog, _ = _make_cog(settings)
+        interaction = _channel_interaction()
+        pull = AsyncMock(side_effect=RuntimeError("offline"))
+        monkeypatch.setattr("claude_discord.cogs.backend_command.pull_ollama_model", pull)
+
+        await cog.model_command.callback(
+            cog,
+            interaction,
+            name=None,
+            install=MODEL,
+            scope="global",
+        )
+
+        assert await settings.explicit_model("local") is None
+        completed = interaction.channel.send.await_args.args[0]
+        assert "failed" in completed.lower()
+
+    async def test_name_and_install_are_mutually_exclusive(self) -> None:
+        settings = await _settings()
+        await settings.set_backend("local")
+        cog, _ = _make_cog(settings)
+        interaction = _channel_interaction()
+
+        await cog.model_command.callback(
+            cog,
+            interaction,
+            name="gpt-oss:120b",
+            install=MODEL,
+            scope="global",
+        )
+
+        message = interaction.response.send_message.await_args.args[0]
+        assert "either" in message.lower()


### PR DESCRIPTION
## Summary

- add `/model install:<model>` for the `local` backend
- call Ollama's native `/api/pull` endpoint derived from `CCDB_LOCAL_BASE_URL`
- acknowledge the Discord interaction immediately, then report completion after the pull
- automatically persist and select the installed model in the command's scope
- leave the existing model unchanged when installation fails
- document setup, behavior, and security constraints

## Implementation details

- model names are strictly validated and sent as JSON; no shell command is constructed
- the blocking Ollama request runs through `asyncio.to_thread` so the Discord event loop remains responsive
- embedded credentials in `CCDB_LOCAL_BASE_URL` are rejected
- the pull has a bounded six-hour timeout and requires Ollama to return `status: success`

## Test plan

- [x] tests added before implementation
- [x] `ruff check`
- [x] `ruff format --check`
- [x] `pyright`
- [x] full pytest suite on Python 3.12 and 3.13
- [x] manual security audit: validated JSON input, no shell interpolation, credentialed URLs rejected, errors bounded
- [x] CodeQL security scan

## Example

```text
/backend name:local
/model install:qwen3.6:35b-a3b-mtp-q4_K_M
```
