### PR TITLE
fix: expose model actions as Discord subcommands

### DIFF
--- a/claude_discord/cogs/backend_command.py
+++ b/claude_discord/cogs/backend_command.py
@@ -1,14 +1,4 @@
-"""/backend and /model slash commands for runtime backend switching.
-
-Persists the selection to ``SettingsRepository`` via ``BackendSettings``
-and swaps out ``ClaudeChatCog.runner`` so the next session uses the new
-backend immediately. Subsequent sessions inherit the new default.
-
-For now the scope is **global** only (per-thread overrides are persisted
-by ``BackendSettings`` and ``ClaudeChatCog`` will honour them when the
-factory path lands — keeping the public surface stable across that
-follow-up).
-"""
+"""Runtime slash commands for selecting backends, models, and effort."""
 
 from __future__ import annotations
 
@@ -37,37 +27,22 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-
 SCOPE_THREAD = "thread"
 SCOPE_GLOBAL = "global"
 
-# Valid reasoning-effort levels per backend. Codex and Claude do not share the
-# same set (Claude has "max"; Codex has "minimal"/"xhigh"), so /effort validates
-# against the level set of whichever backend is currently active.
 VALID_EFFORTS: dict[str, frozenset[str]] = {
     "claude": frozenset({"low", "medium", "high", "max"}),
     "codex": VALID_CODEX_EFFORTS,
-    "local": VALID_CODEX_EFFORTS,  # same CLI, same levels
+    "local": VALID_CODEX_EFFORTS,
 }
 
-# Ordered effort levels per backend for the /effort autocomplete (frozensets are
-# unordered; surfacing them low→high reads naturally in the Discord dropdown).
 EFFORT_ORDER: dict[str, list[str]] = {
     "claude": ["low", "medium", "high", "max"],
     "codex": ["minimal", "low", "medium", "high", "xhigh"],
     "local": ["minimal", "low", "medium", "high", "xhigh"],
 }
 
-# Suggested model ids per backend for the /model autocomplete. The model field is
-# free-text — any id the backend CLI accepts is allowed — so these are only
-# convenience suggestions surfaced in the dropdown, not an enforced allowlist.
-# Codex model defaults live in ~/.codex/config.toml; ccdb never pins one, so the
-# Codex suggestions are common ids only (typing any other id still works).
-#
-# The Claude entry is a *fallback*: normally the suggestions are discovered live
-# (see model_catalog), so a new model shows up without a ccdb release. It is
-# deliberately version-free — a hardcoded "Opus 4.8" is exactly the staleness
-# this list used to cause when discovery isn't possible (offline, no creds).
+# Suggestions only: the model fields remain free text.
 SUGGESTED_MODELS: dict[str, list[tuple[str, str]]] = {
     "claude": [
         ("haiku", "fastest, cheapest (alias — newest Haiku)"),
@@ -81,7 +56,6 @@ SUGGESTED_MODELS: dict[str, list[tuple[str, str]]] = {
         ("gpt-5.5-codex", "GPT-5.5 Codex"),
         ("o4-mini", "o4-mini (fast)"),
     ],
-    # Whatever your local runtime has pulled. CCDB_LOCAL_MODEL sets the default.
     "local": [
         ("gpt-oss:120b", "gpt-oss 120B (tool use, needs real VRAM)"),
         ("qwen3.5:35b", "Qwen3.5 35B"),
@@ -90,12 +64,17 @@ SUGGESTED_MODELS: dict[str, list[tuple[str, str]]] = {
 
 
 def _model_label(model: str | None) -> str:
-    """Human-readable model label; ``None`` means the backend CLI's own default."""
+    """Human-readable model label; ``None`` means the backend CLI default."""
     return f"`{model}`" if model else "_(CLI default)_"
 
 
 class BackendCommandCog(commands.Cog):
-    """/backend, /model, /effort, and /engine-status slash commands."""
+    """Backend, model, effort, and engine-status slash commands."""
+
+    model_group = app_commands.Group(
+        name="model",
+        description="Show, select, or install a model for the current backend",
+    )
 
     def __init__(
         self,
@@ -110,29 +89,21 @@ class BackendCommandCog(commands.Cog):
         self._factory = factory
         self._chat_cog = chat_cog
 
-    # ── helpers ────────────────────────────────────────────────────
-
     def _thread_id_or_none(self, interaction: discord.Interaction) -> int | None:
-        ch = interaction.channel
-        if isinstance(ch, discord.Thread):
-            return ch.id
+        channel = interaction.channel
+        if isinstance(channel, discord.Thread):
+            return channel.id
         return None
 
     def _resolve_scope(
         self, interaction: discord.Interaction, requested: str | None
     ) -> tuple[str, int | None]:
-        """Decide whether the command applies to a thread or globally.
-
-        - If ``requested`` is explicit, honour it (require thread context if
-          ``thread``).
-        - Otherwise: invoked inside a thread → thread; in a channel → global.
-        """
+        """Resolve an explicit scope, or default to thread when in a thread."""
         thread_id = self._thread_id_or_none(interaction)
         if requested == SCOPE_GLOBAL:
             return SCOPE_GLOBAL, None
         if requested == SCOPE_THREAD:
             return SCOPE_THREAD, thread_id
-        # auto
         if thread_id is not None:
             return SCOPE_THREAD, thread_id
         return SCOPE_GLOBAL, None
@@ -149,6 +120,23 @@ class BackendCommandCog(commands.Cog):
         else:
             await interaction.followup.send(message)
 
+    async def _set_model_selection(
+        self,
+        *,
+        backend: str,
+        name: str,
+        resolved_scope: str,
+        target_thread_id: int | None,
+    ) -> None:
+        """Persist a model and update the global default runner when applicable."""
+        await self._settings.set_model(backend, name, thread_id=target_thread_id)
+        if resolved_scope == SCOPE_GLOBAL and self._chat_cog.runner is not None:
+            try:
+                self._chat_cog.runner.model = name  # type: ignore[assignment]
+                logger.info("ClaudeChatCog default runner.model swapped to %s", name)
+            except Exception:
+                logger.exception("Failed to update ClaudeChatCog.runner.model")
+
     # ── /backend ───────────────────────────────────────────────────
 
     @app_commands.command(
@@ -156,7 +144,7 @@ class BackendCommandCog(commands.Cog):
         description="Show or switch the AI backend",
     )
     @app_commands.choices(
-        name=[Choice(name=b, value=b) for b in ALL_BACKENDS],
+        name=[Choice(name=backend, value=backend) for backend in ALL_BACKENDS],
         scope=[
             Choice(name="thread", value=SCOPE_THREAD),
             Choice(name="global", value=SCOPE_GLOBAL),
@@ -177,24 +165,20 @@ class BackendCommandCog(commands.Cog):
     ) -> None:
         thread_id_now = self._thread_id_or_none(interaction)
 
-        # Show current selection if no name provided
         if name is None:
-            current_t = (
+            current_thread = (
                 await self._settings.current_backend(thread_id_now)
                 if thread_id_now is not None
                 else None
             )
-            current_g = await self._settings.current_backend(None)
-            lines: list[str] = [
-                f"\U0001f9e0 **Global backend**: `{current_g}`",
-            ]
-            if thread_id_now is not None and current_t is not None:
-                tag = " (thread override)" if current_t != current_g else ""
-                lines.append(f"\U0001f9f5 **This thread**: `{current_t}`{tag}")
+            current_global = await self._settings.current_backend(None)
+            lines = [f"🧠 **Global backend**: `{current_global}`"]
+            if thread_id_now is not None and current_thread is not None:
+                tag = " (thread override)" if current_thread != current_global else ""
+                lines.append(f"🧵 **This thread**: `{current_thread}`{tag}")
             await interaction.response.send_message("\n".join(lines), ephemeral=True)
             return
 
-        # Validate
         if name not in ALL_BACKENDS:
             await interaction.response.send_message(
                 f"Unknown backend `{name}`. Choose: {', '.join(ALL_BACKENDS)}.",
@@ -210,13 +194,8 @@ class BackendCommandCog(commands.Cog):
             )
             return
 
-        # Persist the new backend. Keep the old session record: its ID points to
-        # the JSONL transcript used for the first cross-backend handoff turn.
         await self._settings.set_backend(name, thread_id=target_thread_id)
 
-        # If global change, also swap the shared default runner so the next
-        # ClaudeChatCog session inherits it (thread overrides will be honoured
-        # by ClaudeChatCog at spawn time once it consults BackendSettings).
         if resolved_scope == SCOPE_GLOBAL:
             try:
                 model = await self._settings.current_model(name, None)
@@ -235,22 +214,16 @@ class BackendCommandCog(commands.Cog):
             if resolved_scope == SCOPE_THREAD and target_thread_id is not None
             else "**globally**"
         )
-        emoji = {"codex": "\U0001f300", "local": "\U0001f3e0", "agui": "\U0001f50c"}.get(
-            name, "\U0001f916"
-        )
+        emoji = {"codex": "🌀", "local": "🏠", "agui": "🔌"}.get(name, "🤖")
         await interaction.response.send_message(
             f"{emoji} Backend set to `{name}` {scope_label}. Next session will use it.",
             ephemeral=False,
         )
 
-    # ── /model ─────────────────────────────────────────────────────
+    # ── /model show|set|install ────────────────────────────────────
 
     async def _backend_for_autocomplete(self, interaction: discord.Interaction) -> str:
-        """Resolve the backend whose suggestions an autocomplete should show.
-
-        Mirrors the command's default scope resolution: in a thread, the thread's
-        backend; otherwise the global backend.
-        """
+        """Resolve the backend whose model suggestions should be displayed."""
         thread_id = self._thread_id_or_none(interaction)
         return await self._settings.current_backend(thread_id)
 
@@ -259,11 +232,7 @@ class BackendCommandCog(commands.Cog):
         interaction: discord.Interaction,
         current: str,
     ) -> list[Choice[str]]:
-        """Suggest models for the active backend, filtered by what's typed.
-
-        Claude suggestions are discovered live so a newly launched model appears
-        without a ccdb release; discovery falls back to ``SUGGESTED_MODELS``.
-        """
+        """Suggest models for the active backend, filtered by typed text."""
         backend = await self._backend_for_autocomplete(interaction)
         if backend == "claude":
             suggestions = await claude_model_choices(fallback=SUGGESTED_MODELS["claude"])
@@ -271,16 +240,50 @@ class BackendCommandCog(commands.Cog):
             suggestions = SUGGESTED_MODELS.get(backend, [])
         current_lower = current.lower()
         choices: list[Choice[str]] = []
-        for value, desc in suggestions:
+        for value, description in suggestions:
             if current_lower and current_lower not in value.lower():
                 continue
-            label = f"{value} — {desc}"
+            label = f"{value} — {description}"
             choices.append(Choice(name=label[:100], value=value))
         return choices[:25]
 
-    @app_commands.command(
-        name="model",
-        description="Show, switch, or install a model for the current backend",
+    @model_group.command(
+        name="show",
+        description="Show the current model selection",
+    )
+    async def model_show_command(self, interaction: discord.Interaction) -> None:
+        thread_id_now = self._thread_id_or_none(interaction)
+        backend_for_thread = (
+            await self._settings.current_backend(thread_id_now)
+            if thread_id_now is not None
+            else await self._settings.current_backend(None)
+        )
+        current_thread = (
+            await self._settings.current_model(backend_for_thread, thread_id_now)
+            if thread_id_now is not None
+            else None
+        )
+        backend_for_global = await self._settings.current_backend(None)
+        current_global = await self._settings.current_model(
+            backend_for_global, None
+        ) or self._factory.default_model_for(backend_for_global)
+        lines = [
+            f"🧠 **Global model**: {_model_label(current_global)} "
+            f"(for `{backend_for_global}`)",
+        ]
+        if thread_id_now is not None:
+            resolved_thread = current_thread or self._factory.default_model_for(
+                backend_for_thread
+            )
+            lines.append(
+                f"🧵 **This thread**: {_model_label(resolved_thread)} "
+                f"(for `{backend_for_thread}`)"
+            )
+        await interaction.response.send_message("\n".join(lines), ephemeral=True)
+
+    @model_group.command(
+        name="set",
+        description="Select a model for the current backend",
     )
     @app_commands.choices(
         scope=[
@@ -290,59 +293,18 @@ class BackendCommandCog(commands.Cog):
     )
     @app_commands.autocomplete(name=_model_name_autocomplete)
     @app_commands.describe(
-        name="Model id to select. Omit to show current or use install for Ollama.",
-        install="Ollama model id to pull and select (local backend only).",
+        name="Model id to select.",
         scope=(
             "thread: only this thread; global: server-wide. "
             "Default: thread when in thread, else global."
         ),
     )
-    async def model_command(
+    async def model_set_command(
         self,
         interaction: discord.Interaction,
-        name: str | None = None,
-        install: str | None = None,
+        name: str,
         scope: str | None = None,
     ) -> None:
-        thread_id_now = self._thread_id_or_none(interaction)
-
-        if name is not None and install is not None:
-            await interaction.response.send_message(
-                "Choose either `name` to select an installed model or `install` to pull one, "
-                "not both.",
-                ephemeral=True,
-            )
-            return
-
-        # Show current
-        if name is None and install is None:
-            backend_for_thread = (
-                await self._settings.current_backend(thread_id_now)
-                if thread_id_now is not None
-                else await self._settings.current_backend(None)
-            )
-            current_t = (
-                await self._settings.current_model(backend_for_thread, thread_id_now)
-                if thread_id_now is not None
-                else None
-            )
-            backend_for_global = await self._settings.current_backend(None)
-            current_g = await self._settings.current_model(
-                backend_for_global, None
-            ) or self._factory.default_model_for(backend_for_global)
-            lines: list[str] = [
-                f"\U0001f9e0 **Global model**: {_model_label(current_g)} "
-                f"(for `{backend_for_global}`)",
-            ]
-            if thread_id_now is not None:
-                resolved_t = current_t or self._factory.default_model_for(backend_for_thread)
-                lines.append(
-                    f"\U0001f9f5 **This thread**: {_model_label(resolved_t)} "
-                    f"(for `{backend_for_thread}`)"
-                )
-            await interaction.response.send_message("\n".join(lines), ephemeral=True)
-            return
-
         resolved_scope, target_thread_id = self._resolve_scope(interaction, scope)
         if resolved_scope == SCOPE_THREAD and target_thread_id is None:
             await interaction.response.send_message(
@@ -351,73 +313,107 @@ class BackendCommandCog(commands.Cog):
             )
             return
 
-        # Determine which backend this model is for: read current backend
-        # for the chosen scope.
-        backend_for_save = await self._settings.current_backend(
+        backend = await self._settings.current_backend(
             target_thread_id if resolved_scope == SCOPE_THREAD else None
         )
-
-        installed = install is not None
-        if install is not None:
-            if backend_for_save != "local":
-                await interaction.response.send_message(
-                    "Model installation is available only for the `local` backend. "
-                    "Run `/backend name:local` first.",
-                    ephemeral=True,
-                )
-                return
-            try:
-                name = validate_ollama_model_name(install)
-            except ValueError as exc:
-                await interaction.response.send_message(f"❌ {exc}", ephemeral=True)
-                return
-
-            await interaction.response.send_message(
-                f"📦 Installing `{name}` from Ollama. This can take a while; "
-                "I will post again when it finishes.",
-                ephemeral=False,
-            )
-            try:
-                await pull_ollama_model(name)
-            except Exception as exc:
-                logger.exception("Failed to install Ollama model %s", name)
-                detail = str(exc).strip()[:500] or type(exc).__name__
-                await self._send_install_result(
-                    interaction,
-                    f"❌ Ollama model installation failed for `{name}`: {detail}",
-                )
-                return
-
-        # The show-current and mutually-exclusive branches above guarantee this.
-        assert name is not None
-        await self._settings.set_model(backend_for_save, name, thread_id=target_thread_id)
-
-        # Global change → also update shared runner.model so the next
-        # ClaudeChatCog session uses the new model right away.
-        if resolved_scope == SCOPE_GLOBAL and self._chat_cog.runner is not None:
-            try:
-                self._chat_cog.runner.model = name  # type: ignore[assignment]
-                logger.info("ClaudeChatCog default runner.model swapped to %s", name)
-            except Exception:
-                logger.exception("Failed to update ClaudeChatCog.runner.model")
+        await self._set_model_selection(
+            backend=backend,
+            name=name,
+            resolved_scope=resolved_scope,
+            target_thread_id=target_thread_id,
+        )
 
         scope_label = (
             f"<#{target_thread_id}>"
             if resolved_scope == SCOPE_THREAD and target_thread_id is not None
             else "**globally**"
         )
-        if installed:
+        await interaction.response.send_message(
+            f"🧠 Model set to `{name}` for `{backend}` {scope_label}. "
+            "Next session will use it.",
+            ephemeral=False,
+        )
+
+    @model_group.command(
+        name="install",
+        description="Install and select an Ollama model for the local backend",
+    )
+    @app_commands.choices(
+        scope=[
+            Choice(name="thread", value=SCOPE_THREAD),
+            Choice(name="global", value=SCOPE_GLOBAL),
+        ],
+    )
+    @app_commands.describe(
+        name="Ollama model id to pull and select.",
+        scope=(
+            "thread: only this thread; global: server-wide. "
+            "Default: thread when in thread, else global."
+        ),
+    )
+    async def model_install_command(
+        self,
+        interaction: discord.Interaction,
+        name: str,
+        scope: str | None = None,
+    ) -> None:
+        resolved_scope, target_thread_id = self._resolve_scope(interaction, scope)
+        if resolved_scope == SCOPE_THREAD and target_thread_id is None:
+            await interaction.response.send_message(
+                "`scope:thread` requires the command to be run inside a thread.",
+                ephemeral=True,
+            )
+            return
+
+        backend = await self._settings.current_backend(
+            target_thread_id if resolved_scope == SCOPE_THREAD else None
+        )
+        if backend != "local":
+            await interaction.response.send_message(
+                "Model installation is available only for the `local` backend. "
+                "Run `/backend name:local` first.",
+                ephemeral=True,
+            )
+            return
+
+        try:
+            normalized_name = validate_ollama_model_name(name)
+        except ValueError as exc:
+            await interaction.response.send_message(f"❌ {exc}", ephemeral=True)
+            return
+
+        await interaction.response.send_message(
+            f"📦 Installing `{normalized_name}` from Ollama. This can take a while; "
+            "I will post again when it finishes.",
+            ephemeral=False,
+        )
+        try:
+            await pull_ollama_model(normalized_name)
+        except Exception as exc:
+            logger.exception("Failed to install Ollama model %s", normalized_name)
+            detail = str(exc).strip()[:500] or type(exc).__name__
             await self._send_install_result(
                 interaction,
-                f"✅ Installed `{name}` from Ollama and set it for `local` "
-                f"{scope_label}. It is ready for the next session.",
+                f"❌ Ollama model installation failed for `{normalized_name}`: {detail}",
             )
-        else:
-            await interaction.response.send_message(
-                f"\U0001f9e0 Model set to `{name}` for `{backend_for_save}` "
-                f"{scope_label}. Next session will use it.",
-                ephemeral=False,
-            )
+            return
+
+        await self._set_model_selection(
+            backend=backend,
+            name=normalized_name,
+            resolved_scope=resolved_scope,
+            target_thread_id=target_thread_id,
+        )
+        scope_label = (
+            f"<#{target_thread_id}>"
+            if resolved_scope == SCOPE_THREAD and target_thread_id is not None
+            else "**globally**"
+        )
+        await self._send_install_result(
+            interaction,
+            f"✅ Installed `{normalized_name}` from Ollama and set it for `local` "
+            f"{scope_label}. It is ready for the next session.",
+        )
 
     # ── /effort ────────────────────────────────────────────────────
 
@@ -426,7 +422,7 @@ class BackendCommandCog(commands.Cog):
         interaction: discord.Interaction,
         current: str,
     ) -> list[Choice[str]]:
-        """Suggest effort levels valid for the active backend, low→high."""
+        """Suggest effort levels valid for the active backend, low to high."""
         backend = await self._backend_for_autocomplete(interaction)
         current_lower = current.lower()
         levels = EFFORT_ORDER.get(backend, sorted(VALID_EFFORTS.get(backend, frozenset())))
@@ -465,19 +461,20 @@ class BackendCommandCog(commands.Cog):
     ) -> None:
         thread_id_now = self._thread_id_or_none(interaction)
 
-        # Show current
         if level is None:
             backend_for_global = await self._settings.current_backend(None)
-            current_g = await self._settings.current_effort(backend_for_global, None)
-            lines: list[str] = [
-                f"⚡ **Global effort**: {self._effort_label(current_g)} "
+            current_global = await self._settings.current_effort(backend_for_global, None)
+            lines = [
+                f"⚡ **Global effort**: {self._effort_label(current_global)} "
                 f"(for `{backend_for_global}`)",
             ]
             if thread_id_now is not None:
                 backend_for_thread = await self._settings.current_backend(thread_id_now)
-                current_t = await self._settings.current_effort(backend_for_thread, thread_id_now)
+                current_thread = await self._settings.current_effort(
+                    backend_for_thread, thread_id_now
+                )
                 lines.append(
-                    f"\U0001f9f5 **This thread**: {self._effort_label(current_t)} "
+                    f"🧵 **This thread**: {self._effort_label(current_thread)} "
                     f"(for `{backend_for_thread}`)"
                 )
             await interaction.response.send_message("\n".join(lines), ephemeral=True)
@@ -491,35 +488,34 @@ class BackendCommandCog(commands.Cog):
             )
             return
 
-        backend_for_save = await self._settings.current_backend(
+        backend = await self._settings.current_backend(
             target_thread_id if resolved_scope == SCOPE_THREAD else None
         )
-        valid = VALID_EFFORTS.get(backend_for_save, frozenset())
+        valid = VALID_EFFORTS.get(backend, frozenset())
         normalized = level.strip().lower()
         if normalized not in valid:
             await interaction.response.send_message(
-                f"❌ Unknown effort `{level}` for `{backend_for_save}`. "
+                f"❌ Unknown effort `{level}` for `{backend}`. "
                 f"Choose: {', '.join(sorted(valid))}.",
                 ephemeral=True,
             )
             return
 
-        await self._settings.set_effort(backend_for_save, normalized, thread_id=target_thread_id)
-
+        await self._settings.set_effort(backend, normalized, thread_id=target_thread_id)
         scope_label = (
             f"<#{target_thread_id}>"
             if resolved_scope == SCOPE_THREAD and target_thread_id is not None
             else "**globally**"
         )
         await interaction.response.send_message(
-            f"⚡ Effort set to `{normalized}` for `{backend_for_save}` "
-            f"{scope_label}. Next session will use it.",
+            f"⚡ Effort set to `{normalized}` for `{backend}` {scope_label}. "
+            "Next session will use it.",
             ephemeral=False,
         )
 
     @staticmethod
     def _effort_label(effort: str | None) -> str:
-        """Human-readable effort label; ``None`` means the backend CLI's default."""
+        """Human-readable effort label; ``None`` means the backend CLI default."""
         return f"`{effort}`" if effort else "_(CLI default)_"
 
     # ── /engine-status ─────────────────────────────────────────────
@@ -529,7 +525,7 @@ class BackendCommandCog(commands.Cog):
         description="Show/set whether the Codex usage line appears after each turn",
     )
     @app_commands.choices(
-        mode=[Choice(name=m, value=m) for m in CODEX_STATUS_MODES],
+        mode=[Choice(name=mode, value=mode) for mode in CODEX_STATUS_MODES],
         scope=[
             Choice(name="thread", value=SCOPE_THREAD),
             Choice(name="global", value=SCOPE_GLOBAL),
@@ -553,14 +549,13 @@ class BackendCommandCog(commands.Cog):
     ) -> None:
         thread_id_now = self._thread_id_or_none(interaction)
 
-        # Show current selection if no mode provided.
         if mode is None:
-            current_g = await self._settings.codex_status_mode(None)
-            lines = [f"\U0001f9e0 **Global Codex status**: `{current_g}`"]
+            current_global = await self._settings.codex_status_mode(None)
+            lines = [f"🧠 **Global Codex status**: `{current_global}`"]
             if thread_id_now is not None:
-                current_t = await self._settings.codex_status_mode(thread_id_now)
-                tag = " (thread override)" if current_t != current_g else ""
-                lines.append(f"\U0001f9f5 **This thread**: `{current_t}`{tag}")
+                current_thread = await self._settings.codex_status_mode(thread_id_now)
+                tag = " (thread override)" if current_thread != current_global else ""
+                lines.append(f"🧵 **This thread**: `{current_thread}`{tag}")
             lines.append(
                 f"-# auto = show Codex usage only when reachable (default: "
                 f"`{CODEX_STATUS_DEFAULT}`)."
@@ -584,13 +579,12 @@ class BackendCommandCog(commands.Cog):
             return
 
         await self._settings.set_codex_status_mode(mode, thread_id=target_thread_id)
-
         scope_label = (
             f"<#{target_thread_id}>"
             if resolved_scope == SCOPE_THREAD and target_thread_id is not None
             else "**globally**"
         )
         await interaction.response.send_message(
-            f"\U0001f300 Codex status set to `{mode}` {scope_label}.",
+            f"🌀 Codex status set to `{mode}` {scope_label}.",
             ephemeral=False,
         )

--- a/claude_discord/cogs/backend_command.py
+++ b/claude_discord/cogs/backend_command.py
@@ -268,16 +268,12 @@ class BackendCommandCog(commands.Cog):
             backend_for_global, None
         ) or self._factory.default_model_for(backend_for_global)
         lines = [
-            f"🧠 **Global model**: {_model_label(current_global)} "
-            f"(for `{backend_for_global}`)",
+            f"🧠 **Global model**: {_model_label(current_global)} (for `{backend_for_global}`)",
         ]
         if thread_id_now is not None:
-            resolved_thread = current_thread or self._factory.default_model_for(
-                backend_for_thread
-            )
+            resolved_thread = current_thread or self._factory.default_model_for(backend_for_thread)
             lines.append(
-                f"🧵 **This thread**: {_model_label(resolved_thread)} "
-                f"(for `{backend_for_thread}`)"
+                f"🧵 **This thread**: {_model_label(resolved_thread)} (for `{backend_for_thread}`)"
             )
         await interaction.response.send_message("\n".join(lines), ephemeral=True)
 
@@ -329,8 +325,7 @@ class BackendCommandCog(commands.Cog):
             else "**globally**"
         )
         await interaction.response.send_message(
-            f"🧠 Model set to `{name}` for `{backend}` {scope_label}. "
-            "Next session will use it.",
+            f"🧠 Model set to `{name}` for `{backend}` {scope_label}. Next session will use it.",
             ephemeral=False,
         )
 
@@ -495,8 +490,7 @@ class BackendCommandCog(commands.Cog):
         normalized = level.strip().lower()
         if normalized not in valid:
             await interaction.response.send_message(
-                f"❌ Unknown effort `{level}` for `{backend}`. "
-                f"Choose: {', '.join(sorted(valid))}.",
+                f"❌ Unknown effort `{level}` for `{backend}`. Choose: {', '.join(sorted(valid))}.",
                 ephemeral=True,
             )
             return

--- a/docs/local-backend.md
+++ b/docs/local-backend.md
@@ -59,14 +59,15 @@ CCDB_LOCAL_MODEL=gpt-oss:120b
 ```
 
 3. In Discord, select the backend: `/backend name:local`.
-4. Either select a model already present in Ollama with `/model name:<model>`,
-   or install and select one with `/model install:<model>`.
+4. Either select a model already present in Ollama with
+   `/model set name:<model>`, or install and select one with
+   `/model install name:<model>`.
 
 For example:
 
 ```text
 /backend name:local
-/model install:qwen3.6:35b-a3b-mtp-q4_K_M
+/model install name:qwen3.6:35b-a3b-mtp-q4_K_M
 ```
 
 The session embed turns olive and reads 🏠 Local model.
@@ -79,8 +80,9 @@ The session embed turns olive and reads 🏠 Local model.
 
 ## Installing an Ollama model from Discord
 
-`/model install:<model>` is available only while the selected backend for the
-chosen scope is `local`. ccdb derives Ollama's native `/api/pull` endpoint from
+`/model install name:<model>` appears as a real Discord subcommand and is
+available only while the selected backend for the chosen scope is `local`.
+ccdb derives Ollama's native `/api/pull` endpoint from
 `CCDB_LOCAL_BASE_URL`, asks Ollama to pull the model, and immediately
 acknowledges the command so a large download does not exceed Discord's
 interaction deadline.

--- a/tests/test_help_sync.py
+++ b/tests/test_help_sync.py
@@ -1,64 +1,71 @@
-"""CI guard: _HELP_CATEGORY in claude_chat.py must stay in sync with all slash commands.
-
-How it works
-------------
-The tests use Python's ``ast`` module to statically parse every cog source file
-and collect the names of all ``@app_commands.command(name=...)`` decorators —
-without starting a bot process.  The collected names are then compared against
-``_HELP_CATEGORY``, the dict that drives the dynamic ``/help`` embed.
-
-Adding a new slash command without updating ``_HELP_CATEGORY`` causes
-``test_all_commands_covered`` to fail, surfacing the omission in CI before
-anyone notices the help is stale.
-
-Deleting a command while leaving its entry in ``_HELP_CATEGORY`` causes
-``test_no_stale_entries`` to fail, keeping the dict tidy.
-"""
+"""CI guard: _HELP_CATEGORY must stay in sync with top-level slash commands."""
 
 from __future__ import annotations
 
 import ast
 import pathlib
 
-# Directory that contains all cog modules.
 _COGS_DIR = pathlib.Path(__file__).parent.parent / "claude_discord" / "cogs"
 
 
-def _collect_app_command_names() -> set[str]:
-    """Return every name= value from @app_commands.command(...) decorators.
+def _keyword_name(call: ast.Call) -> str | None:
+    for keyword in call.keywords:
+        if keyword.arg == "name" and isinstance(keyword.value, ast.Constant):
+            return str(keyword.value.value)
+    return None
 
-    Only matches the exact ``app_commands.command`` form (not prefix-command
-    decorators like ``@commands.command``).
-    """
+
+def _is_app_commands_call(call: ast.Call, attribute: str) -> bool:
+    function = call.func
+    return (
+        isinstance(function, ast.Attribute)
+        and function.attr == attribute
+        and isinstance(function.value, ast.Name)
+        and function.value.id == "app_commands"
+    )
+
+
+def _collect_app_command_names() -> set[str]:
+    """Return every top-level application command and command-group name."""
     names: set[str] = set()
     for path in sorted(_COGS_DIR.glob("*.py")):
         tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+
         for node in ast.walk(tree):
-            # Both sync (FunctionDef) and async (AsyncFunctionDef) defs carry decorators.
             if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
                 continue
-            for dec in node.decorator_list:
-                if not isinstance(dec, ast.Call):
+            for decorator in node.decorator_list:
+                if not isinstance(decorator, ast.Call):
                     continue
-                func = dec.func
-                # Must be an attribute access ending in ".command"
-                if not (isinstance(func, ast.Attribute) and func.attr == "command"):
+                if not _is_app_commands_call(decorator, "command"):
                     continue
-                # Must be specifically "app_commands.command", not e.g. "commands.command"
-                if not (isinstance(func.value, ast.Name) and func.value.id == "app_commands"):
+                name = _keyword_name(decorator)
+                if name is not None:
+                    names.add(name)
+
+        # A slash-command group is registered as one top-level command. Only
+        # inspect direct class assignments so nested child groups are not added
+        # separately to the /help category map.
+        for class_node in (node for node in tree.body if isinstance(node, ast.ClassDef)):
+            for statement in class_node.body:
+                value: ast.expr | None = None
+                if isinstance(statement, ast.Assign):
+                    value = statement.value
+                elif isinstance(statement, ast.AnnAssign):
+                    value = statement.value
+                if not isinstance(value, ast.Call):
                     continue
-                for kw in dec.keywords:
-                    if kw.arg == "name" and isinstance(kw.value, ast.Constant):
-                        names.add(str(kw.value.value))
+                if not _is_app_commands_call(value, "Group"):
+                    continue
+                name = _keyword_name(value)
+                if name is not None:
+                    names.add(name)
+
     return names
 
 
 def test_all_commands_covered() -> None:
-    """Every @app_commands.command must have an entry in _HELP_CATEGORY.
-
-    Fail message tells the developer exactly which command(s) are missing
-    and where to add them.
-    """
+    """Every top-level slash command must have a help category."""
     from claude_discord.cogs.claude_chat import _HELP_CATEGORY
 
     registered = _collect_app_command_names()
@@ -73,28 +80,21 @@ def test_all_commands_covered() -> None:
 
 
 def test_no_stale_entries() -> None:
-    """_HELP_CATEGORY must not contain names that have no matching command.
-
-    Prevents the dict accumulating ghost entries after a command is renamed
-    or removed.
-    """
+    """_HELP_CATEGORY must not contain unregistered top-level commands."""
     from claude_discord.cogs.claude_chat import _HELP_CATEGORY
 
     registered = _collect_app_command_names()
     stale = _HELP_CATEGORY.keys() - registered
     assert not stale, (
-        "_HELP_CATEGORY contains command names with no matching @app_commands.command:\n"
-        + "\n".join(f"  /{name}" for name in sorted(stale))
+        "_HELP_CATEGORY contains command names with no matching application command:\n"
+        + "\n".join(f"  /{name!r}" for name in sorted(stale))
         + "\n\nRemove the stale entries from _HELP_CATEGORY "
         "(claude_discord/cogs/claude_chat.py)."
     )
 
 
 def test_help_itself_is_excluded() -> None:
-    """The 'help' command must be excluded from the embed (value = None).
-
-    /help should not list itself — that would be circular and confusing.
-    """
+    """The help command must be excluded from its own embed."""
     from claude_discord.cogs.claude_chat import _HELP_CATEGORY
 
     assert _HELP_CATEGORY.get("help") is None, (
@@ -104,11 +104,7 @@ def test_help_itself_is_excluded() -> None:
 
 
 def test_section_order_matches_known_sections() -> None:
-    """Every non-None value in _HELP_CATEGORY must appear in _HELP_SECTION_ORDER.
-
-    This prevents commands from silently disappearing because their section
-    name has a typo.
-    """
+    """Every non-None category must appear in _HELP_SECTION_ORDER."""
     from claude_discord.cogs.claude_chat import _HELP_CATEGORY, _HELP_SECTION_ORDER
 
     known_sections = set(_HELP_SECTION_ORDER)

--- a/tests/test_ollama_model_install.py
+++ b/tests/test_ollama_model_install.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import aiosqlite
 import pytest
+from discord import app_commands
 
 from claude_code_core.local_backend import (
     LocalModelConfig,
@@ -133,13 +134,53 @@ def _make_cog(settings: BackendSettings) -> tuple[BackendCommandCog, MagicMock]:
     return cog, chat_cog
 
 
+def _model_subcommand(cog: BackendCommandCog, name: str) -> app_commands.Command:
+    group = next(command for command in cog.get_app_commands() if command.name == "model")
+    assert isinstance(group, app_commands.Group)
+    command = group.get_command(name)
+    assert isinstance(command, app_commands.Command)
+    return command
+
+
 def _channel_interaction() -> MagicMock:
     interaction = MagicMock()
     interaction.channel = MagicMock()
     interaction.channel.send = AsyncMock()
     interaction.response = MagicMock()
     interaction.response.send_message = AsyncMock()
+    interaction.followup = MagicMock()
+    interaction.followup.send = AsyncMock()
     return interaction
+
+
+class TestModelDiscordCommandShape:
+    async def test_model_is_a_group_with_visible_subcommands(self) -> None:
+        settings = await _settings()
+        cog, _ = _make_cog(settings)
+
+        roots = {command.name: command for command in cog.get_app_commands()}
+        model = roots["model"]
+
+        assert isinstance(model, app_commands.Group)
+        assert [command.name for command in model.commands] == ["show", "set", "install"]
+        assert [command.qualified_name for command in model.commands] == [
+            "model show",
+            "model set",
+            "model install",
+        ]
+
+    async def test_set_subcommand_selects_model(self) -> None:
+        settings = await _settings()
+        cog, chat_cog = _make_cog(settings)
+        interaction = _channel_interaction()
+
+        command = _model_subcommand(cog, "set")
+        await command.callback(cog, interaction, name="opus", scope="global")
+
+        assert await settings.current_model("claude") == "opus"
+        assert chat_cog.runner.model == "opus"
+        message = interaction.response.send_message.await_args.args[0]
+        assert "Model set" in message
 
 
 class TestModelInstallCommand:
@@ -153,13 +194,8 @@ class TestModelInstallCommand:
         pull = AsyncMock()
         monkeypatch.setattr("claude_discord.cogs.backend_command.pull_ollama_model", pull)
 
-        await cog.model_command.callback(
-            cog,
-            interaction,
-            name=None,
-            install=MODEL,
-            scope="global",
-        )
+        command = _model_subcommand(cog, "install")
+        await command.callback(cog, interaction, name=MODEL, scope="global")
 
         pull.assert_awaited_once_with(MODEL)
         assert await settings.current_model("local") == MODEL
@@ -179,13 +215,8 @@ class TestModelInstallCommand:
         pull = AsyncMock()
         monkeypatch.setattr("claude_discord.cogs.backend_command.pull_ollama_model", pull)
 
-        await cog.model_command.callback(
-            cog,
-            interaction,
-            name=None,
-            install=MODEL,
-            scope="global",
-        )
+        command = _model_subcommand(cog, "install")
+        await command.callback(cog, interaction, name=MODEL, scope="global")
 
         pull.assert_not_awaited()
         assert await settings.explicit_model("claude") is None
@@ -202,31 +233,9 @@ class TestModelInstallCommand:
         pull = AsyncMock(side_effect=RuntimeError("offline"))
         monkeypatch.setattr("claude_discord.cogs.backend_command.pull_ollama_model", pull)
 
-        await cog.model_command.callback(
-            cog,
-            interaction,
-            name=None,
-            install=MODEL,
-            scope="global",
-        )
+        command = _model_subcommand(cog, "install")
+        await command.callback(cog, interaction, name=MODEL, scope="global")
 
         assert await settings.explicit_model("local") is None
         completed = interaction.channel.send.await_args.args[0]
         assert "failed" in completed.lower()
-
-    async def test_name_and_install_are_mutually_exclusive(self) -> None:
-        settings = await _settings()
-        await settings.set_backend("local")
-        cog, _ = _make_cog(settings)
-        interaction = _channel_interaction()
-
-        await cog.model_command.callback(
-            cog,
-            interaction,
-            name="gpt-oss:120b",
-            install=MODEL,
-            scope="global",
-        )
-
-        message = interaction.response.send_message.await_args.args[0]
-        assert "either" in message.lower()


### PR DESCRIPTION
## Summary

- replace the flat `/model` command options with a real Discord command group
- expose `/model show`, `/model set`, and `/model install` as visible subcommands
- preserve the existing Ollama pull, validation, failure handling, scope persistence, and automatic model selection
- add a regression test that inspects the command tree registered by `discord.py`
- update the help-sync guard to recognize top-level command groups
- correct the local-backend documentation and examples

## Root cause

PR #648 added `install` as an optional parameter on the `/model` command. That made the installation logic callable through a command option, but it did not register `install` as a Discord subcommand. Consequently Discord did not display `/model install` in the slash-command picker.

## Discord command shape

```text
/model show
/model set name:<model>
/model install name:qwen3.6:35b-a3b-mtp-q4_K_M
```

## Test plan

- [x] Python syntax compilation for the changed Python files
- [x] regression test asserts `/model` is an `app_commands.Group`
- [x] regression test asserts the visible qualified names are `model show`, `model set`, and `model install`
- [x] ruff check
- [x] ruff format check
- [x] pyright
- [x] full pytest suite on Python 3.12 and 3.13
- [x] CodeQL security scan
