### PR TITLE
fix: honour user_id in /api/spawn so the requester joins the thread

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,13 @@ build/
 .venv/
 
 # Environment variables
+# .env.* too: operators leave dated backups (.env.bak-2026-01-01) next to the
+# real file, and those hold a live bot token. Ignoring only `.env` means one
+# `git add -A` stages a working credential. `.env.example` is the tracked
+# template and is re-included explicitly.
 .env
+.env.*
+!.env.example
 
 # Database
 data/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`POST /api/spawn` honours `user_id`** — the field was already being sent by callers and silently
+  dropped, so a spawned thread never appeared in the requester's joined list and the miss looked
+  like success. The user is now added as a thread member before the seed message is posted, matching
+  what `/api/ingest` already did for the bot owner. A malformed `user_id` is a caller bug and is
+  rejected with 400; a Discord-side failure to add the member is only a visibility miss and is
+  suppressed, because a spawn that already created the thread and started Claude must not be
+  reported as failed.
+
+- **`.gitignore` covers `.env.*`, not just `.env`** — dated backups of the environment file
+  (`.env.bak-…`) sat untracked-but-not-ignored beside the real one, each holding a live bot token,
+  so a single `git add -A` staged a working credential. GitHub push protection caught one such
+  commit before it left the machine; the ignore rule removes the trap rather than relying on the
+  catch. `.env.example` is re-included explicitly so the template stays tracked.
+
 ### Changed
 
 - **Thread-completion recording is opt-in, off by default** — deleting a thread is an everyday,

--- a/claude_discord/cogs/claude_chat.py
+++ b/claude_discord/cogs/claude_chat.py
@@ -802,6 +802,7 @@ class ClaudeChatCog(commands.Cog):
         auto_start: bool = True,
         result_sink: Callable[[str | None, str | None], Awaitable[None]] | None = None,
         attachments: list[tuple[str, bytes]] | None = None,
+        invite_user_id: int | None = None,
     ) -> discord.Thread:
         """Create a new thread and optionally start a Claude Code session.
 
@@ -835,6 +836,10 @@ class ClaudeChatCog(commands.Cog):
                         seed prompt. Lets a programmatic caller (e.g. a Forgejo
                         Issue watcher via ``/api/spawn``) surface the original
                         attachments so they're viewable in the thread.
+            invite_user_id: Optional Discord user to add as a thread member, so
+                        a thread nobody was watching still lands in their joined
+                        list. Best-effort: a failure here is a visibility miss,
+                        never a reason to fail a spawn that already succeeded.
 
         Returns:
             The newly created :class:`discord.Thread`.
@@ -845,6 +850,11 @@ class ClaudeChatCog(commands.Cog):
             type=discord.ChannelType.public_thread,
             auto_archive_duration=THREAD_AUTO_ARCHIVE_MINUTES,
         )
+        # Added before the seed message so the requester sees the thread from its
+        # first line, not after Claude has already been talking to itself.
+        if invite_user_id:
+            with contextlib.suppress(Exception):
+                await thread.add_user(discord.Object(id=invite_user_id))
         # Post the prompt so StatusManager has a Message to add reactions to.
         # Long prompts (e.g. an ingested Teams thread) exceed Discord's
         # per-message limit, so chunk the seed for display. The full prompt is

--- a/claude_discord/ext/api_server.py
+++ b/claude_discord/ext/api_server.py
@@ -1403,6 +1403,10 @@ class ApiServer:
                 (optional; defaults to ``true``).  When ``false``, only the
                 thread and seed message are created — a Claude session will
                 start when a user replies in the thread.
+            user_id: Discord user to add to the new thread (optional), so the
+                thread appears in their joined list instead of having to be
+                found in the channel. Mirrors what ``/api/ingest`` does for the
+                bot owner.
 
         Returns (201):
             ``{"status": "spawned", "thread_id": "...", "thread_name": "..."}``
@@ -1453,6 +1457,19 @@ class ApiServer:
         thread_name: str | None = data.get("thread_name") or None
         auto_start: bool = data.get("auto_start", True)
 
+        # Validated here rather than swallowed downstream: a typo'd user_id is a
+        # caller bug and should say so, while a Discord-side failure to add the
+        # member is only a visibility miss and must never fail the spawn.
+        raw_user_id = data.get("user_id")
+        invite_user_id: int | None = None
+        if raw_user_id is not None:
+            try:
+                invite_user_id = int(raw_user_id)
+            except (TypeError, ValueError):
+                return web.json_response({"error": "user_id must be an integer"}, status=400)
+            if invite_user_id <= 0:
+                return web.json_response({"error": "user_id must be positive"}, status=400)
+
         # Optional attachments to post into the new thread (e.g. files attached
         # to a Forgejo Issue forwarded by a watcher). Decoded here; posting is
         # handled inside spawn_session right after the seed prompt.
@@ -1467,6 +1484,7 @@ class ApiServer:
                 thread_name=thread_name,
                 auto_start=auto_start,
                 attachments=decoded_attachments or None,
+                invite_user_id=invite_user_id,
             )
         except Exception as exc:
             logger.error("spawn_session failed: %s", exc, exc_info=True)

--- a/tests/test_api_server.py
+++ b/tests/test_api_server.py
@@ -609,6 +609,41 @@ class TestSpawn:
         await client.close()
 
     @pytest.mark.asyncio
+    async def test_spawn_forwards_user_id_as_invite(
+        self, spawn_client: TestClient, mock_cog: MagicMock
+    ) -> None:
+        """A caller-supplied user_id must reach spawn_session, not be dropped."""
+        resp = await spawn_client.post(
+            "/api/spawn",
+            json={"prompt": "Check the backlog", "user_id": 418192003549888523},
+        )
+        assert resp.status == 201
+        assert mock_cog.spawn_session.await_args.kwargs["invite_user_id"] == 418192003549888523
+
+    @pytest.mark.asyncio
+    async def test_spawn_without_user_id_invites_nobody(
+        self, spawn_client: TestClient, mock_cog: MagicMock
+    ) -> None:
+        await spawn_client.post("/api/spawn", json={"prompt": "Check the backlog"})
+        assert mock_cog.spawn_session.await_args.kwargs["invite_user_id"] is None
+
+    @pytest.mark.asyncio
+    async def test_spawn_rejects_non_numeric_user_id(
+        self, spawn_client: TestClient, mock_cog: MagicMock
+    ) -> None:
+        resp = await spawn_client.post("/api/spawn", json={"prompt": "Hello", "user_id": "@ebi"})
+        assert resp.status == 400
+        mock_cog.spawn_session.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_spawn_rejects_non_positive_user_id(
+        self, spawn_client: TestClient, mock_cog: MagicMock
+    ) -> None:
+        resp = await spawn_client.post("/api/spawn", json={"prompt": "Hello", "user_id": 0})
+        assert resp.status == 400
+        mock_cog.spawn_session.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_spawn_returns_201_with_thread_info(
         self, spawn_client: TestClient, mock_cog: MagicMock
     ) -> None:

--- a/tests/test_claude_chat.py
+++ b/tests/test_claude_chat.py
@@ -476,6 +476,70 @@ class TestSpawnSession:
         assert call_kwargs["type"] == discord.ChannelType.public_thread
 
     @pytest.mark.asyncio
+    async def test_spawn_adds_invited_user_to_thread(self) -> None:
+        """invite_user_id makes the requester a thread member, before the seed message."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        import discord
+
+        thread = MagicMock(spec=discord.Thread)
+        thread.send = AsyncMock()
+        thread.add_user = AsyncMock()
+
+        channel = MagicMock()
+        channel.create_thread = AsyncMock(return_value=thread)
+
+        cog = ClaudeChatCog(bot=MagicMock(), repo=MagicMock(), runner=MagicMock())
+
+        with patch.object(cog, "_run_claude", new=AsyncMock()):
+            await cog.spawn_session(channel, "Do the thing", invite_user_id=418192003549888523)
+
+        thread.add_user.assert_awaited_once()
+        assert thread.add_user.await_args.args[0].id == 418192003549888523
+
+    @pytest.mark.asyncio
+    async def test_spawn_without_invite_adds_nobody(self) -> None:
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        import discord
+
+        thread = MagicMock(spec=discord.Thread)
+        thread.send = AsyncMock()
+        thread.add_user = AsyncMock()
+
+        channel = MagicMock()
+        channel.create_thread = AsyncMock(return_value=thread)
+
+        cog = ClaudeChatCog(bot=MagicMock(), repo=MagicMock(), runner=MagicMock())
+
+        with patch.object(cog, "_run_claude", new=AsyncMock()):
+            await cog.spawn_session(channel, "Do the thing")
+
+        thread.add_user.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_spawn_survives_add_user_failure(self) -> None:
+        """A Discord-side add_user failure is a visibility miss, never a failed spawn."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        import discord
+
+        thread = MagicMock(spec=discord.Thread)
+        thread.send = AsyncMock()
+        thread.add_user = AsyncMock(side_effect=RuntimeError("Missing Permissions"))
+
+        channel = MagicMock()
+        channel.create_thread = AsyncMock(return_value=thread)
+
+        cog = ClaudeChatCog(bot=MagicMock(), repo=MagicMock(), runner=MagicMock())
+
+        with patch.object(cog, "_run_claude", new=AsyncMock()):
+            result = await cog.spawn_session(channel, "Do the thing", invite_user_id=999)
+
+        assert result is thread
+        thread.send.assert_awaited()
+
+    @pytest.mark.asyncio
     async def test_spawn_uses_custom_thread_name(self) -> None:
         """thread_name overrides the default (prompt[:100])."""
         from unittest.mock import AsyncMock, MagicMock, patch


### PR DESCRIPTION
## Problem

`POST /api/spawn` documented `prompt`, `channel_id`, `thread_name` and `auto_start`, and read exactly those keys. Callers were already sending `user_id` in the body with the intent that the requester be added to the new thread. aiohttp does not reject unknown JSON fields, so the request returned `201 spawned` and the field was dropped on the floor.

The visible effect: a thread spawned from another session never landed in the requester's joined list, so a session started on their behalf could run to completion unnoticed. The failure mode is the quiet kind — the API says success, and nothing anywhere says the invite did not happen.

`/api/ingest` has always added the bot owner to the thread it creates (`_ingest_add_owner`), for exactly this reason. `/api/spawn` simply never grew the equivalent.

## Change

- `spawn_session()` takes `invite_user_id` and adds that user as a thread member **before** the seed message is posted, so the requester sees the thread from its first line rather than after Claude has been talking to itself.
- `/api/spawn` parses and validates `user_id` at the boundary: a non-integer or non-positive id returns `400` and no thread is created.
- A Discord-side `add_user` failure (missing permission, deleted user) is suppressed. A typo is a caller bug worth reporting; a permission miss is only a visibility problem and must not fail a spawn that already created the thread and started Claude.

## Also in this PR

`.gitignore` now covers `.env.*`, not just `.env`. Dated backups of the environment file sit untracked-but-not-ignored next to the real one and each holds a live bot token, so a single `git add -A` stages a working credential. GitHub push protection caught such a commit on this branch before it left the machine; the ignore rule removes the trap instead of relying on the catch. `.env.example` is re-included explicitly so the template stays tracked.

## Test plan

- [x] `test_spawn_forwards_user_id_as_invite` — the id reaches `spawn_session`
- [x] `test_spawn_without_user_id_invites_nobody` — absent field stays absent
- [x] `test_spawn_rejects_non_numeric_user_id` / `test_spawn_rejects_non_positive_user_id` — 400, and `spawn_session` is never awaited
- [x] `test_spawn_adds_invited_user_to_thread` — `add_user` is awaited with the right id
- [x] `test_spawn_survives_add_user_failure` — the spawn still returns the thread and posts the seed
- [x] Full suite: 2650 passed
- [x] `ruff format` / `ruff check`: clean