### PR TITLE
[docs-sync] Document /api/spawn user_id and the .env.* ignore rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,20 @@ curl -X POST "$CCDB_API_URL/api/spawn" \
 
 This is useful for notification-style workflows (e.g. daily briefings, CI alerts) where you want to display information upfront and let the user decide whether to engage Claude.
 
+**Adding the requester to the thread (`user_id`)** — A spawned thread is created by the bot, so nobody is watching it: it sits in the channel list until someone goes looking. Pass a Discord `user_id` and ccdb adds that user as a thread member before the seed message is posted, so the thread lands in their joined list and they see it from its first line.
+
+```bash
+curl -X POST "$CCDB_API_URL/api/spawn" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "prompt": "Triage the failing nightly build",
+    "thread_name": "Nightly Triage",
+    "user_id": 123456789012345678
+  }'
+```
+
+A `user_id` that is not a positive integer is a caller bug and is rejected with 400. A Discord-side failure to add the member is only a visibility miss and is suppressed — a spawn that already created the thread and started Claude is never reported as failed.
+
 Claude subprocesses receive `DISCORD_THREAD_ID` as an environment variable, so a running session can spawn child sessions to parallelize work.
 
 ### Authenticated External Ingest with Result Retrieval (`/api/ingest`)
@@ -506,6 +520,7 @@ Behind the scenes:
 - **Secret isolation** — Bot token stripped from subprocess environment
 - **User authorization** — `allowed_user_ids` restricts who can invoke Claude
 - **Log injection prevention** — User-provided API values are sanitized (newlines stripped) before writing to logs
+- **Credential files stay untracked** — `.gitignore` covers `.env.*`, not just `.env`, because operators leave dated backups (`.env.bak-…`) beside the real file and each one holds a live bot token; `.env.example` is re-included explicitly so the template stays tracked
 - **Local-model backend** (optional) — `/backend local` runs a thread against a model on your own hardware. ccdb owns a separate CLI home with the update check and analytics disabled, because a "local" run otherwise still contacts the vendor; it refuses to start if those settings are missing — see [docs/local-backend.md](docs/local-backend.md)
 - **Remote AG-UI backend** (optional) — `/backend agui` connects the existing Discord/Teams session machinery to any HTTP/SSE AG-UI agent while preserving ccdb's session ledger, rendering, cancellation, and operational controls — see [docs/agui-backend.md](docs/agui-backend.md)
 - **`/ask` — explicit escalation** (optional) — sends one anonymized, self-contained question to a strong external model with no project context, no files and no tools, then restores your real names in the answer; the isolation is verified before every spawn — see [docs/escalation.md](docs/escalation.md)
@@ -1123,7 +1138,7 @@ uv sync --extra api
 | GET | `/api/tasks` | List registered tasks |
 | DELETE | `/api/tasks/{id}` | Remove a task |
 | PATCH | `/api/tasks/{id}` | Update a task (enable/disable, change schedule) |
-| POST | `/api/spawn` | Create a new Discord thread and start a Claude Code session (non-blocking); pass `auto_start: false` to defer Claude until the first user reply |
+| POST | `/api/spawn` | Create a new Discord thread and start a Claude Code session (non-blocking); pass `auto_start: false` to defer Claude until the first user reply, or `user_id` to add the requester to the thread |
 | POST | `/api/ingest` | Authenticated external spawn (browser extension / webhook) with base64 attachments; returns a `result_id` when result retrieval is configured |
 | GET | `/api/ingest/{result_id}` | Poll the spawned session's final reply (`status`/`result`/`error`/`thread_id`) |
 | GET | `/api/ingest/summary` | Read the running summary + `marker` for a long ingest thread by `key` (ingest-token gated) so the client can export only the diff |

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -260,6 +260,20 @@ curl -X POST "$CCDB_API_URL/api/spawn" \
 
 デイリーブリーフィングや CI アラートなど、情報を先に表示してユーザーが Claude に問いかけるかどうかを判断するワークフローに便利です。
 
+**リクエスト元をスレッドに追加する（`user_id`）** — スポーンされたスレッドは Bot が作成するため、誰も見ていない状態で生まれます。チャンネル一覧の中に埋もれ、探しに行かないと気づけません。Discord の `user_id` を渡すと、ccdb はシードメッセージを投稿する**前に**そのユーザーをスレッドメンバーとして追加します。スレッドは参加済み一覧に現れ、ユーザーは最初の 1 行目からやり取りを追えます。
+
+```bash
+curl -X POST "$CCDB_API_URL/api/spawn" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "prompt": "失敗した nightly ビルドをトリアージして",
+    "thread_name": "Nightly Triage",
+    "user_id": 123456789012345678
+  }'
+```
+
+正の整数でない `user_id` は呼び出し側のバグなので 400 で拒否します。一方、Discord 側でのメンバー追加失敗は「見えにくい」だけの問題なので抑制されます。スレッドを作成して Claude をすでに起動できたスポーンを、失敗として報告することはありません。
+
 Claude のサブプロセスには `DISCORD_THREAD_ID` 環境変数が渡されるため、実行中のセッションから子セッションを起動して作業を並列化できます。
 
 ### 認証済み外部インジェストと結果取得 (`/api/ingest`)
@@ -508,6 +522,7 @@ ccdb がバックエンド情報を記録する前に作成されたレコード
 - **シークレット分離** — Bot トークンを subprocess 環境から除去
 - **ユーザー認証** — `allowed_user_ids` で Claude を呼び出せるユーザーを制限
 - **ログインジェクション防止** — API 経由のユーザー入力値はログ書き込み前に無害化（改行文字除去）
+- **認証情報ファイルを追跡しない** — `.gitignore` は `.env` だけでなく `.env.*` も対象にする。運用者は実ファイルの隣に日付付きバックアップ（`.env.bak-…`）を残しがちで、その 1 つ 1 つが有効な Bot トークンを保持しているため。テンプレートを追跡し続けられるよう `.env.example` だけは明示的に再包含している
 - **ローカルモデルバックエンド**（オプション）— `/backend local` で自身のハードウェア上のモデルに対してスレッドを実行。通常は「local」実行でもベンダーへ接続するため、ccdb は update check と analytics を無効にした専用 CLI home を管理し、その設定がなければ起動を拒否します — [docs/local-backend.md](../local-backend.md)参照
 - **リモート AG-UI バックエンド**（オプション）— `/backend agui` で既存の Discord/Teams セッション機構を任意の HTTP/SSE AG-UI エージェントへ接続し、ccdb の session ledger、rendering、cancellation、運用制御を維持します — [docs/agui-backend.md](../agui-backend.md)参照
 - **匿名化ゲートウェイ**（オプション）— プロンプトが Claude または Codex へ届く前に組織を識別する語を安定した alias へ置換し、回答内で復元。ローカルモデルが置換漏れを確認し、デフォルトでは漏れを検出すると送信をブロックします。rules file を作成するまでは無効です — [docs/anonymization.md](../anonymization.md)参照
@@ -1123,7 +1138,7 @@ uv sync --extra api
 | GET | `/api/tasks` | 登録済みタスクの一覧 |
 | DELETE | `/api/tasks/{id}` | タスクの削除 |
 | PATCH | `/api/tasks/{id}` | タスクの更新（有効/無効、スケジュール変更） |
-| POST | `/api/spawn` | 新しい Discord スレッドを作成し Claude Code セッションを起動（非ブロッキング）。`auto_start: false` を指定するとユーザーの最初の返信まで Claude の起動を延期できる |
+| POST | `/api/spawn` | 新しい Discord スレッドを作成し Claude Code セッションを起動（非ブロッキング）。`auto_start: false` を指定するとユーザーの最初の返信まで Claude の起動を延期でき、`user_id` を指定するとリクエスト元をスレッドに追加できる |
 | POST | `/api/ingest` | 認証済み外部スポーン（ブラウザ拡張機能 / webhook）。base64 添付ファイル対応。結果取得が設定されている場合 `result_id` を返す |
 | GET | `/api/ingest/{result_id}` | スポーンされたセッションの最終返信をポーリング（`status`/`result`/`error`/`thread_id`） |
 | GET | `/api/ingest/summary` | 長時間続くインジェストスレッドの継続サマリー + `marker` を `key` で読み取り（ingest-token 認証）。クライアントは差分だけをエクスポートできる |


### PR DESCRIPTION
## Summary / 概要

Documents the two user-visible changes from `2db8291` (`fix: honour user_id in /api/spawn`) in both the English and Japanese README.

`2db8291` の 2 つの利用者向け変更を、英語版・日本語版 README の両方に反映します。

### `POST /api/spawn` — `user_id`

The endpoint now adds a Discord user as a thread member before the seed message is posted, but the field was undocumented. Added to the **Programmatic Session Creation** section with a `curl` example, plus the error contract: a non-positive-integer `user_id` is rejected with 400, while a Discord-side failure to add the member is suppressed so an otherwise-successful spawn is never reported as failed. The REST endpoint table row mentions it too.

`user_id` は未文書のままだったため、**Programmatic Session Creation** セクションに `curl` 例とエラー契約（不正値は 400、Discord 側の追加失敗は抑制）を追記し、REST エンドポイント表の行も更新しました。

### Security — `.gitignore` covers `.env.*`

Added a bullet to the **Security** list explaining why the ignore rule spans `.env.*` rather than only `.env`: operators leave dated backups (`.env.bak-…`) beside the real file, each holding a live bot token, so a single `git add -A` could stage a working credential. `.env.example` is re-included explicitly.

**Security** の箇条書きに、`.env` だけでなく `.env.*` を無視する理由（日付付きバックアップが有効な Bot トークンを保持しているため）と、`.env.example` を明示的に再包含している点を追記しました。

## Scope / 対象外

The `invite_user_id` parameter added to `ClaudeChatCog.spawn_session()` is an internal Cog argument; only the REST field `user_id` is documented. No `CONTRIBUTING.md` change was needed — neither change affects the documented contributor workflow.

`ClaudeChatCog.spawn_session()` の `invite_user_id` は内部引数のため文書化していません（外部に見えるのは REST の `user_id` のみ）。`CONTRIBUTING.md` は今回の変更の影響を受けないため未変更です。

## Test plan / テスト計画

- [x] Docs-only change — no code touched
- [x] English and Japanese kept structurally in sync (same anchors, same table row)
- [x] Bilingual notice already present at the top of `docs/ja/README.md`
