### PR TITLE
[docs-sync] Document dev worktree mode and `make drift`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,6 +56,38 @@ uv run pytest tests/ -v --cov=claude_discord
 
 All tests must pass before submitting a PR.
 
+## Testing Against a Live Bot (dev worktree mode)
+
+Unit tests do not cover everything a Discord surface does. If you run a bot from this
+repository, you can point it at a worktree so it loads your branch instead of the main
+tree — no reinstall, no editable-install juggling:
+
+```bash
+git worktree add ../wt-my-feature -b feature/my-feature
+cd ../wt-my-feature
+make dev-on    # write ~/.ccdb-dev-worktree and restart the bot
+# ... exercise the change on Discord ...
+make dev-off   # remove the marker and restart back onto the main tree
+make drift     # is the bot running code that is not on origin/main?
+```
+
+`make dev-on` writes the worktree path to `~/.ccdb-dev-worktree`; the import hook that
+`scripts/pre-start.sh` installs reads that marker and redirects `claude_discord` /
+`claude_code_core` imports to the worktree. `dev-on` / `dev-off` restart a systemd unit
+named `discord-bot` — adjust the Makefile if your deployment differs.
+
+**Nothing expires dev mode.** A forgotten `make dev-on` keeps a side branch in production
+indefinitely, while every merged PR *appears* to deploy and does not. `make drift`
+(`scripts/check-deploy-drift.sh`) answers that: it names the worktree and branch, says
+whether that commit is an ancestor of `origin/main`, counts how many merged commits are
+therefore not running, and reports how long dev mode has been on. It compares against the
+remote ref rather than a local `main`, which may itself be stale. `pre-start.sh` prints
+the same report on every boot. Exit codes: `0` clean, `1` drift, `2` the marker points
+nowhere (the hook silently falls back to the main tree).
+
+Before switching back, check `.env`: a value only your branch understands falls back to a
+default on the main tree, which changes behaviour without erroring.
+
 ## Code Style
 
 - **Formatter**: `ruff format`

--- a/docs/ja/CONTRIBUTING.md
+++ b/docs/ja/CONTRIBUTING.md
@@ -59,6 +59,39 @@ uv run pytest tests/ -v --cov=claude_discord
 
 PR を提出する前にすべてのテストが通過している必要があります。
 
+## 稼働中のボットで動作確認する（dev worktree モード）
+
+ユニットテストだけでは Discord 上の挙動をすべて検証できません。このリポジトリからボットを
+起動している場合、ボットの読み込み先を worktree に向けることで、本体ツリーではなく自分の
+ブランチを読ませられます。再インストールも editable install の切り替えも不要です:
+
+```bash
+git worktree add ../wt-my-feature -b feature/my-feature
+cd ../wt-my-feature
+make dev-on    # ~/.ccdb-dev-worktree を書き込んでボットを再起動
+# ... Discord 上で変更を実際に操作して確認 ...
+make dev-off   # マーカーを削除して本体ツリーに戻して再起動
+make drift     # ボットは origin/main にないコードを動かしていないか？
+```
+
+`make dev-on` は worktree のパスを `~/.ccdb-dev-worktree` に書き込みます。
+`scripts/pre-start.sh` が仕込む import フックがそのマーカーを読み、`claude_discord` /
+`claude_code_core` の import を worktree へ横取りします。`dev-on` / `dev-off` は
+`discord-bot` という systemd ユニットを再起動するので、デプロイ構成が異なる場合は
+Makefile を調整してください。
+
+**dev モードには有効期限がありません。** `make dev-on` を切り忘れると、サイドブランチが
+そのまま本番に居座り続け、マージした PR は「デプロイされたように見えて実際は動いていない」
+状態になります。`make drift`（`scripts/check-deploy-drift.sh`）はそれを検出します:
+worktree とブランチ名を示し、そのコミットが `origin/main` の祖先かどうかを判定し、
+結果として動いていないマージ済みコミット数を数え、dev モードが何日続いているかを報告します。
+比較対象はリモート参照で、古くなっている可能性のあるローカル `main` は使いません。
+`pre-start.sh` は起動のたびに同じレポートを出力します。終了コード: `0` 正常、`1` ドリフト、
+`2` マーカーの参照先が存在しない（フックは無言で本体ツリーにフォールバックします）。
+
+本体ツリーへ戻す前に `.env` を確認してください。自分のブランチだけが解釈する値は、
+本体ツリーではデフォルトにフォールバックし、エラーを出さないまま挙動が変わります。
+
 ## コードスタイル
 
 - **フォーマッター**: `ruff format`


### PR DESCRIPTION
## Summary / 概要

Documents the deploy-drift check added in #651 (`scripts/check-deploy-drift.sh` / `make drift`)
and the dev worktree mode it guards, which `CONTRIBUTING.md` did not cover at all.

#651 で追加された deploy drift 検査（`scripts/check-deploy-drift.sh` / `make drift`）と、
それが守る dev worktree モードを `CONTRIBUTING.md` に記載しました（従来は未記載）。

## Changes / 変更点

- `CONTRIBUTING.md` — new **Testing Against a Live Bot (dev worktree mode)** section:
  `make dev-on` / `dev-off` / `drift`, how the import hook redirects `claude_discord` /
  `claude_code_core`, why the check compares against `origin/main` rather than a local
  `main`, the exit codes (`0` clean / `1` drift / `2` marker points nowhere), and the
  `.env` warning before switching back.
- `docs/ja/CONTRIBUTING.md` — 同じ節の日本語訳。

## Verification / 検証

Every statement was checked against `scripts/check-deploy-drift.sh` and the `Makefile`
targets in this commit (worktree/branch report, ancestor test, behind-count, marker age,
exit codes). Docs-only change — no source touched.

本文の記述は本コミットの `scripts/check-deploy-drift.sh` と `Makefile` の実装と突き合わせて
確認済みです。ドキュメントのみの変更で、ソースコードは変更していません。
