### PR TITLE
Use backend-neutral completion notification

### DIFF
--- a/claude_discord/discord_ui/thread_dashboard.py
+++ b/claude_discord/discord_ui/thread_dashboard.py
@@ -159,7 +159,7 @@ class ThreadStatusDashboard:
         if should_mention and thread is not None:
             try:
                 await thread.send(
-                    f"🟡 <@{self._owner_id}> Claude has finished — your reply is needed here."
+                    f"🟡 <@{self._owner_id}> The agent has finished — your reply is needed here."
                 )
             except (discord.HTTPException, RuntimeError):
                 logger.debug("Failed to send owner mention in thread %d", thread_id, exc_info=True)

--- a/tests/test_thread_dashboard.py
+++ b/tests/test_thread_dashboard.py
@@ -141,7 +141,7 @@ class TestOwnerMention:
 
         thread.send.assert_called_once()
         sent_text = thread.send.call_args.args[0]
-        assert "<@42>" in sent_text
+        assert sent_text == "🟡 <@42> The agent has finished — your reply is needed here."
 
     @pytest.mark.asyncio
     async def test_mention_not_sent_if_already_waiting(self) -> None:


### PR DESCRIPTION
## Summary

- replace the Claude-specific completion message with “The agent has finished”
- make the regression test assert the exact notification copy

## Verification

- 2,786 tests passed
- ruff check and format check passed
- pyright passed
- coverage: 84%

Fixes #660