### PR TITLE
fix: derive Codex rate-limit window labels (#662)

### DIFF
--- a/claude_discord/discord_ui/engine_status.py
+++ b/claude_discord/discord_ui/engine_status.py
@@ -118,6 +118,35 @@ def _fmt_pct(snap: dict | None) -> str | None:
         return None
 
 
+def _window_label(window_duration_mins: object) -> str | None:
+    """Return a compact label derived from a rate-limit duration."""
+    if isinstance(window_duration_mins, bool) or not isinstance(window_duration_mins, (int, float)):
+        return None
+    if not float(window_duration_mins).is_integer():
+        return None
+
+    minutes = int(window_duration_mins)
+    if minutes <= 0:
+        return None
+    if minutes == 10080:
+        return "週次"
+    if minutes % 1440 == 0:
+        return f"{minutes // 1440}d"
+    if minutes % 60 == 0:
+        return f"{minutes // 60}h"
+    return f"{minutes}m"
+
+
+def _window_segment(snap: dict | None, fallback_label: str) -> str | None:
+    """Format one rate-limit window, retaining a legacy positional fallback."""
+    pct = _fmt_pct(snap)
+    if pct is None:
+        return None
+    duration = snap.get("windowDurationMins") if isinstance(snap, dict) else None
+    label = _window_label(duration) or fallback_label
+    return f"{label} {pct}"
+
+
 def format_codex_status_line(data: dict | None) -> str | None:
     """Format a ``account/rateLimits/read`` result into one Discord line.
 
@@ -131,12 +160,12 @@ def format_codex_status_line(data: dict | None) -> str | None:
         return None
 
     segments: list[str] = []
-    primary = _fmt_pct(snap.get("primary"))
+    primary = _window_segment(snap.get("primary"), "5h")
     if primary is not None:
-        segments.append(f"5h {primary}")
-    secondary = _fmt_pct(snap.get("secondary"))
+        segments.append(primary)
+    secondary = _window_segment(snap.get("secondary"), "週次")
     if secondary is not None:
-        segments.append(f"週次 {secondary}")
+        segments.append(secondary)
 
     credit_info = snap.get("credits")
     if isinstance(credit_info, dict):

--- a/tests/test_engine_status.py
+++ b/tests/test_engine_status.py
@@ -21,6 +21,17 @@ SAMPLE = {
     }
 }
 
+WEEKLY_PRIMARY_SAMPLE = {
+    "rateLimits": {
+        "limitId": "codex",
+        "primary": {"usedPercent": 15, "windowDurationMins": 10080},
+        "secondary": None,
+        "credits": {"hasCredits": False, "unlimited": False, "balance": "0"},
+        "planType": "prolite",
+        "rateLimitReachedType": None,
+    }
+}
+
 
 class TestFormat:
     def test_basic_line(self) -> None:
@@ -31,6 +42,50 @@ class TestFormat:
         assert "週次 8%" in line
         assert "クレジット 0" in line
         assert "(prolite)" in line
+
+    def test_weekly_primary_uses_duration_instead_of_position(self) -> None:
+        line = format_codex_status_line(WEEKLY_PRIMARY_SAMPLE)
+        assert line is not None
+        assert "週次 15%" in line
+        assert "5h 15%" not in line
+
+    @pytest.mark.parametrize(
+        ("duration_mins", "expected_label"),
+        [
+            (300, "5h"),
+            (10080, "週次"),
+            (1440, "1d"),
+            (2880, "2d"),
+            (90, "90m"),
+            (30, "30m"),
+        ],
+    )
+    def test_window_label_uses_reported_duration(
+        self, duration_mins: int, expected_label: str
+    ) -> None:
+        data = {
+            "rateLimits": {
+                "primary": {
+                    "usedPercent": 10,
+                    "windowDurationMins": duration_mins,
+                }
+            }
+        }
+        line = format_codex_status_line(data)
+        assert line is not None
+        assert f"{expected_label} 10%" in line
+
+    def test_missing_durations_keep_positional_fallbacks(self) -> None:
+        data = {
+            "rateLimits": {
+                "primary": {"usedPercent": 5},
+                "secondary": {"usedPercent": 9},
+            }
+        }
+        line = format_codex_status_line(data)
+        assert line is not None
+        assert "5h 5%" in line
+        assert "週次 9%" in line
 
     def test_unlimited_credits(self) -> None:
         data = {"rateLimits": {"primary": {"usedPercent": 5}, "credits": {"unlimited": True}}}


### PR DESCRIPTION
## Summary

- derive Codex usage-window labels from `windowDurationMins` instead of assuming `primary` always means five hours
- display a 10,080-minute primary window as weekly while retaining positional fallbacks for older payloads
- add regression coverage for the real `primary=10080 / secondary=null` response shape and other durations

This carries forward the valid duration-derived approach identified in #550 and #616, updated against current `main`. Thank you to @bomber555 and @hanaseleb for reporting and implementing the original corrections.

## Test plan

- [x] `uv run pytest tests/test_engine_status.py -q` (20 passed)
- [x] `env -u CCDB_API_URL -u CCDB_API_SECRET uv run pytest tests/ -q --cov=claude_discord --cov=claude_code_core --cov-report=term` (2,794 passed, 87% coverage)
- [x] `uv run ruff check claude_discord/ claude_code_core/ tests/`
- [x] `uv run ruff format --check claude_discord/ claude_code_core/ tests/`
- [x] `uv run pyright claude_discord/ claude_code_core/` (0 errors)
- [x] live `account/rateLimits/read` response renders the 10,080-minute primary window as weekly

Closes #662