### PR TITLE
fix: wait for Codex thread writer release

### DIFF
--- a/claude_code_core/codex_runner.py
+++ b/claude_code_core/codex_runner.py
@@ -607,8 +607,10 @@ class CodexRunner:
             event = parse_codex_line(decoded)
             if event:
                 yield event
-                if event.is_complete:
-                    return
+                # ``turn.completed`` can arrive before the CLI process exits.
+                # Keep draining stdout so ``wait()`` below observes the natural
+                # exit and Codex releases its thread-store writer before a
+                # queued resume starts.
                 # Atomic tools (e.g. file_changes) have no completion event of
                 # their own; pair them with a synthetic result so the live
                 # elapsed timer is cancelled instead of accumulating forever.

--- a/tests/test_codex_runner.py
+++ b/tests/test_codex_runner.py
@@ -93,6 +93,25 @@ class _InterruptibleProcess(_FakeProcess):
         self.interrupted.set()
 
 
+class _CompletesBeforeExitProcess(_FakeProcess):
+    """Process that emits turn.completed before its natural exit is observed."""
+
+    def __init__(self, completed_line: bytes) -> None:
+        super().__init__(stdout_lines=[completed_line + b"\n"], returncode=0)
+        self.returncode = None
+        self.terminated = False
+        self.waited = False
+
+    async def wait(self) -> int:
+        self.waited = True
+        self.returncode = 0
+        return 0
+
+    def terminate(self) -> None:
+        self.terminated = True
+        super().terminate()
+
+
 class TestCodexRunnerIsBackend:
     """CodexRunner must satisfy the SessionBackend protocol."""
 
@@ -319,6 +338,28 @@ class TestCodexRunnerClone:
 
 
 class TestCodexRunnerRun:
+    @pytest.mark.asyncio
+    async def test_turn_completed_waits_for_natural_process_exit(self, monkeypatch) -> None:
+        """A terminal event must not release the session while Codex still owns it."""
+        completed_line = json.dumps({"type": "turn.completed", "usage": {}}).encode()
+        process = _CompletesBeforeExitProcess(completed_line)
+
+        async def fake_create_subprocess_exec(*args, **kwargs):
+            return process
+
+        monkeypatch.setattr(
+            "claude_code_core.codex_runner.asyncio.create_subprocess_exec",
+            fake_create_subprocess_exec,
+        )
+        runner = CodexRunner(command="codex")
+
+        events = [event async for event in runner.run("hello")]
+
+        assert len(events) == 1
+        assert events[0].is_complete is True
+        assert process.waited is True
+        assert process.terminated is False
+
     @pytest.mark.asyncio
     async def test_intentional_interrupt_is_not_reported_as_cli_error(
         self, monkeypatch, caplog


### PR DESCRIPTION
## Summary

- continue draining Codex stdout after `turn.completed`
- wait for the CLI process to exit naturally before releasing the per-thread run slot
- add a regression test proving cleanup does not terminate a process that has emitted its terminal event but has not exited yet

Fixes #665

## Verification

- `uv run pytest tests/test_codex_runner.py -q` — 63 passed
- `timeout 900 uv run pytest tests/ -x -q` — 2795 passed
- `uv run ruff check claude_discord/ claude_code_core/ tests/test_codex_runner.py`
- `uv run ruff format --check claude_discord/ claude_code_core/ tests/test_codex_runner.py`
- `uv run pyright claude_discord/ claude_code_core/` — 0 errors (6 pre-existing warnings)
- security-sensitive diff scan clean