### PR TITLE
fix(spawn): recover the whole chunked seed for auto_start=false threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`auto_start=false` seeds are no longer truncated to their first message** — a spawn seed longer
+  than Discord's 2,000-character limit is posted as several messages by `spawn_session`, but
+  `_fetch_seed_context` read only message #1. The Claude session that started on the human's reply
+  therefore woke up with a seed cut off mid-sentence, invisibly, and worse the longer the seed was
+  (a daily news digest lost most of its items). It now reads the leading run of bot messages,
+  stopping at the first human message, bounded by `SEED_CONTEXT_MESSAGE_LIMIT`.
+
 - **`POST /api/spawn` honours `user_id`** — the field was already being sent by callers and silently
   dropped, so a spawned thread never appeared in the requester's joined list and the miss looked
   like success. The user is now added as a thread member before the seed message is posted, matching

--- a/claude_discord/cogs/claude_chat.py
+++ b/claude_discord/cogs/claude_chat.py
@@ -53,6 +53,12 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# How many messages to scan when recovering an ``auto_start=false`` seed.
+# A seed is chunked at Discord's per-message limit, so this bounds the seed at
+# roughly 40 x 2,000 characters — far more than any real prompt, while still
+# refusing to walk an entire thread's history on a malformed one.
+SEED_CONTEXT_MESSAGE_LIMIT = 40
+
 # ---------------------------------------------------------------------------
 # /help command metadata
 #
@@ -1242,23 +1248,29 @@ class ClaudeChatCog(commands.Cog):
 
     @staticmethod
     async def _fetch_seed_context(thread: discord.Thread) -> str | None:
-        """Return the text of the first (seed) message in a thread, if posted by the bot.
+        """Return the seed text of a thread, if it was posted by the bot.
 
         Used to recover context from ``/api/spawn`` threads with ``auto_start=false``,
         where the bot posted a seed message but did not start Claude.  Returns
-        ``None`` if the seed message cannot be retrieved or was not from a bot.
+        ``None`` if the seed cannot be retrieved or was not from a bot.
+
+        Reads the *leading run* of bot messages, not just the first one: a prompt
+        longer than Discord's per-message limit is chunked by ``spawn_session``, so
+        taking only message #1 hands Claude a seed cut off mid-sentence — silently,
+        and worse the longer the seed is. The run stops at the first human message,
+        which is the reply that triggered this lookup.
         """
         try:
-            # oldest_first via after=None with limit=1 is the most efficient
-            # way to get the first message in a thread.
-            first_messages = [msg async for msg in thread.history(limit=1, oldest_first=True)]
-            if not first_messages:
-                return None
-            seed = first_messages[0]
-            # Only include bot-authored seed messages (from /api/spawn).
-            if not seed.author.bot:
-                return None
-            return seed.content or None
+            chunks: list[str] = []
+            async for message in thread.history(
+                limit=SEED_CONTEXT_MESSAGE_LIMIT, oldest_first=True
+            ):
+                # Only include bot-authored seed messages (from /api/spawn).
+                if not message.author.bot:
+                    break
+                if message.content:
+                    chunks.append(message.content)
+            return "\n".join(chunks) or None
         except Exception:
             logger.debug("Failed to fetch seed message for thread %d", thread.id, exc_info=True)
             return None

--- a/tests/test_claude_chat.py
+++ b/tests/test_claude_chat.py
@@ -671,6 +671,60 @@ class TestFetchSeedContext:
         assert result == "☀️ おはようございます！"
 
     @pytest.mark.asyncio
+    async def test_joins_a_chunked_seed(self) -> None:
+        """A seed longer than Discord's limit is posted as several bot messages.
+
+        Returning only the first one truncates the context Claude wakes up with,
+        which is invisible in the reply and gets worse the longer the seed is.
+        """
+        chunks = []
+        for text in ("part one", "part two", "part three"):
+            msg = MagicMock()
+            msg.author.bot = True
+            msg.content = text
+            chunks.append(msg)
+
+        human = MagicMock()
+        human.author.bot = False
+        human.content = "please write this up"
+
+        thread = MagicMock(spec=discord.Thread)
+        thread.id = 42
+
+        async def _fake_history(**kwargs: object):
+            for msg in [*chunks, human]:
+                yield msg
+
+        thread.history = _fake_history
+
+        result = await ClaudeChatCog._fetch_seed_context(thread)
+        assert result == "part one\npart two\npart three"
+
+    @pytest.mark.asyncio
+    async def test_stops_at_the_first_human_message(self) -> None:
+        """Later bot messages are not seed context — they are the conversation."""
+        seed = MagicMock()
+        seed.author.bot = True
+        seed.content = "seed"
+        human = MagicMock()
+        human.author.bot = False
+        human.content = "reply"
+        later_bot = MagicMock()
+        later_bot.author.bot = True
+        later_bot.content = "answer"
+
+        thread = MagicMock(spec=discord.Thread)
+        thread.id = 42
+
+        async def _fake_history(**kwargs: object):
+            for msg in (seed, human, later_bot):
+                yield msg
+
+        thread.history = _fake_history
+
+        assert await ClaudeChatCog._fetch_seed_context(thread) == "seed"
+
+    @pytest.mark.asyncio
     async def test_returns_none_for_non_bot_message(self) -> None:
         """When the first message is from a human, return None."""
         seed_msg = MagicMock()


### PR DESCRIPTION
## Problem

`spawn_session()` chunks a prompt longer than Discord's 2,000-character limit across several messages. `_fetch_seed_context()` — the path that gives a `auto_start=false` thread its context when a human finally replies — read only the **first** message:

```python
first_messages = [msg async for msg in thread.history(limit=1, oldest_first=True)]
```

So a session woken by a human reply saw a seed cut off mid-sentence. Nothing reports this: the reply reads plausibly, and the loss grows with the seed's length. A daily news digest posted as a seed loses most of its items — the reader sees all of them on screen, the model sees the first ~2,000 characters.

## Fix

Read the **leading run of bot messages**, stopping at the first human message (that message is the reply that triggered the lookup), joined with newlines. Bounded by `SEED_CONTEXT_MESSAGE_LIMIT = 40` — roughly 80 KB of seed, far beyond any real prompt, while still refusing to walk a whole thread's history.

## Tests

`tests/test_claude_chat.py::TestFetchSeedContext`, two added:

- `test_joins_a_chunked_seed` — three bot messages followed by a human reply return all three, joined
- `test_stops_at_the_first_human_message` — bot messages *after* the human reply are conversation, not seed

Existing cases (single seed, human-authored first message, empty thread, API error) unchanged. `pytest tests/test_claude_chat.py` → 111 passed.

## Context

`auto_start=false` is about to carry real traffic: a daily briefing thread posts its content as the seed and deliberately does not start a session, so nobody pays for a turn that only restates what is already on screen. That makes seed fidelity load-bearing.