### PR TITLE
feat(lounge): cap lounge posts at 200 chars and nudge over-long ones

### DIFF
--- a/claude_discord/ext/api_server.py
+++ b/claude_discord/ext/api_server.py
@@ -36,6 +36,7 @@ from claude_code_core.thread_search import run_thread_search
 from claude_code_core.transcript_search import default_transcripts_root
 
 from ..discord_ui.file_sender import send_file_blobs
+from ..lounge import length_hint
 from ..relay import MODE_INTERRUPT, MODE_QUEUE, VALID_MODES, RelayGuard, build_relay_prompt
 from ..session_view import STATE_HISTORY, STATE_RUNNING, build_session_views
 from ..thread_policy import THREAD_AUTO_ARCHIVE_MINUTES
@@ -863,17 +864,18 @@ class ApiServer:
         if self.lounge_channel_id:
             await self._send_lounge_to_discord(stored.label, stored.message, stored.posted_at)
 
-        return web.json_response(
-            {
-                "status": "posted",
-                "id": stored.id,
-                "label": stored.label,
-                "message": stored.message,
-                "thread_id": stored.thread_id,
-                "posted_at": stored.posted_at,
-            },
-            status=201,
-        )
+        payload: dict[str, Any] = {
+            "status": "posted",
+            "id": stored.id,
+            "label": stored.label,
+            "message": stored.message,
+            "thread_id": stored.thread_id,
+            "posted_at": stored.posted_at,
+        }
+        if hint := length_hint(stored.message):
+            payload["hint"] = hint
+
+        return web.json_response(payload, status=201)
 
     # ------------------------------------------------------------------
     # Session spawn endpoint (/api/spawn)

--- a/claude_discord/lounge.py
+++ b/claude_discord/lounge.py
@@ -30,6 +30,20 @@ Examples:
 When you finish, leave a closing note too (this serves as your session-end signal):
 - "Done! All tests passing." / "Took longer than expected..."
 
+[LENGTH — HARD RULE] One or two lines, 200 characters max. This applies to
+the closing note exactly as much as to the opening one.
+Post WHAT you are doing, or WHAT changed. Not how you got there:
+- No root-cause narrative, no list of things you tried, no lessons learned
+- No enumerating every PR you merged, no pitfalls section, no retrospective
+Those belong in the PR, the repo docs, or your own notes — places built to be
+searched later. The lounge is injected into every session that starts after
+you: a long post spends everyone's context and buries the one line that
+actually mattered. If a note feels worth writing at length, that is the
+signal to write it somewhere else and link it here in one line.
+
+Bad:  "Done (PR #97 merged). I first tried X, but this machine has ..." + 15 lines
+Good: "Made the dev server a systemd unit. Done, PR #97 merged — details there."
+
 Post command:
 ```bash
 curl -s -X POST "$CCDB_API_URL/api/lounge" \\
@@ -125,6 +139,31 @@ If you are the one standing down: **push your branch first**, tell the other
 session where it is and what you learned, post it to the lounge, then stop.
 Never abandon uncommitted work to be polite.
 """
+
+#: Lounge posts are read by every session that starts afterwards, so length is
+#: a shared cost, not a private one.  Over-long posts are still stored in full —
+#: truncating would destroy the one sentence that mattered — but the poster is
+#: told, because a prompt rule alone has proven easy to talk past.
+MAX_RECOMMENDED_MESSAGE_CHARS = 200
+
+_LENGTH_HINT = (
+    "Lounge posts are capped at {limit} characters; yours was {actual}. "
+    "Post what you are doing or what changed — put the reasoning, the pitfalls "
+    "and the lessons in the PR or your notes, not here. Keep the next one short."
+)
+
+
+def length_hint(message: str) -> str | None:
+    """Return a nudge when ``message`` is longer than the lounge is meant for.
+
+    Returns ``None`` for messages within the limit so callers can attach the
+    hint only when it is warranted.
+    """
+    actual = len(message)
+    if actual <= MAX_RECOMMENDED_MESSAGE_CHARS:
+        return None
+    return _LENGTH_HINT.format(limit=MAX_RECOMMENDED_MESSAGE_CHARS, actual=actual)
+
 
 _RECENT_HEADER = "\nRecent lounge messages:\n"
 _NO_MESSAGES = "\n(No messages yet — be the first to say hello!)\n"

--- a/tests/test_lounge.py
+++ b/tests/test_lounge.py
@@ -20,7 +20,12 @@ from claude_discord.database.lounge_repo import LoungeMessage, LoungeRepository
 from claude_discord.database.models import init_db
 from claude_discord.database.notification_repo import NotificationRepository
 from claude_discord.ext.api_server import ApiServer
-from claude_discord.lounge import _NO_MESSAGES, build_lounge_prompt
+from claude_discord.lounge import (
+    _NO_MESSAGES,
+    MAX_RECOMMENDED_MESSAGE_CHARS,
+    build_lounge_prompt,
+    length_hint,
+)
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -240,6 +245,17 @@ class TestBuildLoungePrompt:
         assert "/api/claims" in result
         # And it names the lounge's own remaining job (broadcast / intent).
         assert "BROADCAST" in result
+
+    def test_prompt_states_the_length_limit(self) -> None:
+        """The prompt gives a number, not just 'keep it short'.
+
+        Sessions demonstrably talked past the soft wording and posted
+        multi-paragraph retrospectives, so the limit is now explicit and
+        covers the closing note as well as the opening one.
+        """
+        result = build_lounge_prompt([])
+        assert str(MAX_RECOMMENDED_MESSAGE_CHARS) in result
+        assert "closing note" in result
 
     def test_this_thread_marker_for_matching_thread(self) -> None:
         """Messages from current thread are annotated with [this thread]."""
@@ -596,3 +612,23 @@ class TestRunHelperLoungeInjection:
         if runner.clone.called:
             system_prompt = runner.clone.call_args[1].get("append_system_prompt", "")
             assert "AI Lounge" not in system_prompt
+
+
+# ---------------------------------------------------------------------------
+# length_hint tests
+# ---------------------------------------------------------------------------
+
+
+class TestLengthHint:
+    def test_short_message_gets_no_hint(self) -> None:
+        assert length_hint("Fixing a flaky test in ccdb.") is None
+
+    def test_message_at_the_limit_gets_no_hint(self) -> None:
+        assert length_hint("x" * MAX_RECOMMENDED_MESSAGE_CHARS) is None
+
+    def test_long_message_gets_a_hint_naming_both_numbers(self) -> None:
+        message = "x" * (MAX_RECOMMENDED_MESSAGE_CHARS + 50)
+        hint = length_hint(message)
+        assert hint is not None
+        assert str(MAX_RECOMMENDED_MESSAGE_CHARS) in hint
+        assert str(len(message)) in hint


### PR DESCRIPTION
## Why

Lounge notes had grown into multi-paragraph retrospectives — root cause, every merged PR, pitfalls, lessons learned. The prompt asked only for a short *opening* note, so the closing note had no limit at all. Every lounge post is injected into the prompt of every session that starts afterwards, so length is a cost shared by all of them, and the one line that mattered gets buried.

## What

- **Prompt**: an explicit limit (one or two lines, 200 characters) that applies to the closing note as much as the opening one, plus what to leave out (reasoning, PR lists, lessons) and where it belongs instead (the PR, repo docs, own notes).
- **API**: `POST /api/lounge` returns an extra `hint` field when the message exceeds the limit. The message is still stored in full — truncating would destroy the one sentence that mattered — but the poster gets told, because a prompt rule alone proved easy to talk past.
- `MAX_RECOMMENDED_MESSAGE_CHARS` / `length_hint()` live in `lounge.py` so the prompt and the API cannot state different numbers.

## Test plan

- [x] `uv run pytest tests/` — 2802 passed
- [x] New tests: prompt states the number and covers the closing note; `length_hint` returns `None` at or below the limit and names both numbers above it
- [x] `ruff check` / `ruff format --check` / `pyright` clean