### PR TITLE
fix(drift): report a bot that never restarted, not just a forgotten dev worktree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **The deploy-drift check now also catches a bot that simply never restarted** — it answered one
+  question ("is a forgotten `make dev-on` worktree in production?") and returned `OK: main-tree
+  mode` for everything else, which is a guard that reports on the case it was written for and waves
+  the rest through. Main-tree mode has its own silent staleness: the checkout only pulls in
+  `pre-start.sh`, so a bot that has not restarted keeps serving whatever was merged before it
+  booted, while the tree says `main` and every `git pull` keeps succeeding. The check now compares
+  the *running process* against `origin/main` — commits merged after the service's
+  `ActiveEnterTimestamp` are the ones not running — and reports how long the oldest of them has
+  been waiting. Because restarts are batched deliberately (an in-flight session does not survive
+  one), it reports from day one but only exits 1 past `CCDB_STALE_DAYS` (default 3). A machine
+  without systemd, or an unreadable unit, says so instead of silently passing. `CCDB_SERVICE`
+  overrides the unit name.
+
 - **`scripts/check-deploy-drift.sh` (also `make drift`)** — reports when the bot is loading code
   that is not on `origin/main`. `make dev-on` is the right tool for testing a change against real
   Discord traffic, but nothing expires it: `pre-start.sh` printed one line at boot and never

--- a/scripts/check-deploy-drift.sh
+++ b/scripts/check-deploy-drift.sh
@@ -8,18 +8,88 @@
 # never mentions it again, so a forgotten `make dev-on` keeps a side branch in
 # production indefinitely while every merged PR appears to deploy and does not.
 #
+# Main-tree mode has its own way of running stale code: the checkout only pulls
+# in pre-start.sh, so a bot that has not restarted keeps serving whatever was
+# merged before it booted. That is silent in exactly the same way -- the tree
+# says main, `git pull` keeps succeeding, and nothing compares the *running*
+# process against origin/main. So this script reports both kinds of staleness.
+#
 # Exit codes:
-#   0  main-tree mode, or dev mode on code already merged to origin/main
-#   1  dev mode on code that is NOT on origin/main  (drift)
+#   0  running the newest code, or dev mode on code already merged to origin/main
+#   1  drift: dev mode on unmerged code, or merged commits undeployed too long
 #   2  dev mode configured but unusable (marker points nowhere)
 set -u
 
 CCDB_HOME="${CCDB_HOME:-$HOME/claude-code-discord-bridge}"
 MARKER="$HOME/.ccdb-dev-worktree"
+SERVICE="${CCDB_SERVICE:-discord-bot}"
+# A merged commit is not "undeployed" the moment it lands -- restarts are
+# disruptive, so they are batched. Report from day one, alert after this many.
+STALE_DAYS="${CCDB_STALE_DAYS:-3}"
+
+# ── main-tree mode: is the running process the newest code? ──
+#
+# The honest measure is not "is the checkout behind origin/main" (a pull without
+# a restart changes nothing) but "which commits landed after the bot started".
+# That single number covers both a stale checkout and a pulled-but-not-restarted
+# one, and it stays quiet on a machine that restarts often.
+report_undeployed() {
+    git -C "$CCDB_HOME" fetch -q origin main 2>/dev/null || true
+
+    local started
+    started="$(systemctl show -p ActiveEnterTimestamp --value "$SERVICE" 2>/dev/null || true)"
+    if [ -z "$started" ]; then
+        echo "OK: main-tree mode (no $MARKER)"
+        echo "    Cannot read $SERVICE start time; skipped the freshness check."
+        return 0
+    fi
+    local started_epoch
+    started_epoch="$(date -d "$started" +%s 2>/dev/null || echo 0)"
+    if [ "$started_epoch" -eq 0 ]; then
+        echo "OK: main-tree mode (no $MARKER)"
+        echo "    Could not parse '$started'; skipped the freshness check."
+        return 0
+    fi
+
+    local count
+    count="$(git -C "$CCDB_HOME" rev-list --count "origin/main" --since="@$started_epoch" 2>/dev/null || echo 0)"
+    if [ "$count" -eq 0 ]; then
+        echo "OK: main-tree mode, running the newest code on origin/main."
+        return 0
+    fi
+
+    # Oldest of the commits the running process is missing -- how long the wait
+    # has actually lasted, not how long ago the newest one landed. Sort by date
+    # rather than taking the last line: git log orders by the commit graph, and
+    # a merge can put an older commit anywhere in that list.
+    local oldest_epoch age_days
+    oldest_epoch="$(git -C "$CCDB_HOME" log "origin/main" --since="@$started_epoch" --format=%ct 2>/dev/null | sort -n | head -1)"
+    oldest_epoch="${oldest_epoch:-$started_epoch}"
+    age_days=$(( ( $(date +%s) - oldest_epoch ) / 86400 ))
+
+    if [ "$age_days" -lt "$STALE_DAYS" ]; then
+        echo "OK: main-tree mode. $count commit(s) merged since the bot started"
+        echo "    (oldest ${age_days}d old); they deploy on the next restart."
+        return 0
+    fi
+
+    cat <<REPORT
+DRIFT: merged code has been waiting ${age_days} days for a restart.
+
+  service  : $SERVICE, up since $started
+  missing  : $count commit(s) merged after that and therefore not running
+  oldest   : ${age_days} day(s) old (threshold: ${STALE_DAYS}, \$CCDB_STALE_DAYS)
+
+Restart when the bot is idle -- 'systemctl restart $SERVICE' pulls, syncs and
+validates through pre-start.sh. An in-flight session does not survive it, so
+check for running sessions first.
+REPORT
+    return 1
+}
 
 if [ ! -f "$MARKER" ]; then
-    echo "OK: main-tree mode (no $MARKER)"
-    exit 0
+    report_undeployed
+    exit $?
 fi
 
 WORKTREE="$(cat "$MARKER" 2>/dev/null | tr -d '[:space:]')"

--- a/tests/test_deploy_drift_script.py
+++ b/tests/test_deploy_drift_script.py
@@ -8,7 +8,9 @@ a detector that cannot fail is worth nothing.
 
 from __future__ import annotations
 
+import os
 import subprocess
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -19,6 +21,27 @@ def _git(repo: Path, *args: str) -> str:
     return subprocess.run(
         ["git", *args], cwd=repo, check=True, capture_output=True, text=True
     ).stdout.strip()
+
+
+def _ago(days: float) -> str:
+    """An absolute timestamp N days back — git rejects relative committer dates."""
+    when = datetime.now(UTC) - timedelta(days=days)
+    return when.isoformat()
+
+
+def _commit(repo: Path, name: str, *, days_ago: float = 0) -> None:
+    """One commit, optionally backdated — the age is what the check reports."""
+    (repo / name).write_text("x = 1\n")
+    _git(repo, "add", "-A")
+    when = _ago(days_ago)
+    subprocess.run(
+        ["git", "commit", "-q", "-m", name],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "GIT_AUTHOR_DATE": when, "GIT_COMMITTER_DATE": when},
+    )
 
 
 def _init_origin(base: Path) -> Path:
@@ -32,31 +55,115 @@ def _init_origin(base: Path) -> Path:
     _git(repo, "config", "user.name", "Test")
     (repo / "claude_discord").mkdir()
     (repo / "claude_discord" / "__init__.py").write_text("")
-    _git(repo, "add", "-A")
-    _git(repo, "commit", "-q", "-m", "init")
+    # Backdated: the freshness check counts commits newer than the bot's start
+    # time, so a history that begins "now" would make every test look stale.
+    _commit(repo, "init.py", days_ago=60)
     _git(repo, "push", "-q", "origin", "main")
     return repo
 
 
-def _run(script_home: Path, repo: Path) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(
-        ["bash", str(SCRIPT)],
-        env={
-            "HOME": str(script_home),
-            "CCDB_HOME": str(repo),
-            "PATH": "/usr/bin:/bin:/usr/local/bin",
-        },
-        capture_output=True,
-        text=True,
-    )
+def _stub_systemctl(base: Path, timestamp: str) -> Path:
+    """A fake ``systemctl`` reporting a fixed unit start time.
+
+    Without it these tests read the *host's* real discord-bot unit, so the
+    result would depend on when the developer last restarted their bot.
+    """
+    bin_dir = base / "stub-bin"
+    bin_dir.mkdir(exist_ok=True)
+    stub = bin_dir / "systemctl"
+    stub.write_text(f'#!/bin/bash\nprintf "%s\\n" {timestamp!r}\n')
+    stub.chmod(0o755)
+    return bin_dir
+
+
+def _run(
+    script_home: Path,
+    repo: Path,
+    *,
+    started: str | None = None,
+    stale_days: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    path = "/usr/bin:/bin:/usr/local/bin"
+    if started is not None:
+        path = f"{_stub_systemctl(script_home, started)}:{path}"
+    env = {
+        "HOME": str(script_home),
+        "CCDB_HOME": str(repo),
+        "PATH": path,
+    }
+    if stale_days is not None:
+        env["CCDB_STALE_DAYS"] = stale_days
+    return subprocess.run(["bash", str(SCRIPT)], env=env, capture_output=True, text=True)
 
 
 def test_no_marker_is_main_tree_mode(tmp_path: Path) -> None:
     repo = _init_origin(tmp_path)
-    result = _run(tmp_path, repo)
+    result = _run(tmp_path, repo, started=_ago(-1))
 
     assert result.returncode == 0
     assert "main-tree mode" in result.stdout
+
+
+def test_main_tree_mode_is_clean_when_the_bot_started_after_the_last_commit(
+    tmp_path: Path,
+) -> None:
+    repo = _init_origin(tmp_path)
+
+    result = _run(tmp_path, repo, started=_ago(-1))
+
+    assert result.returncode == 0
+    assert "running the newest code" in result.stdout
+
+
+def test_commits_merged_since_the_bot_started_are_reported_before_they_are_drift(
+    tmp_path: Path,
+) -> None:
+    """Reported from day one, but a fresh merge must not page anyone."""
+    repo = _init_origin(tmp_path)
+    _commit(repo, "merged.py")
+    _git(repo, "push", "-q", "origin", "main")
+
+    result = _run(tmp_path, repo, started=_ago(2))
+
+    assert result.returncode == 0
+    assert "1 commit(s) merged since the bot started" in result.stdout
+    assert "next restart" in result.stdout
+
+
+def test_undeployed_commits_older_than_the_threshold_are_drift(tmp_path: Path) -> None:
+    """A merge nobody restarted for is the same failure as a stale worktree."""
+    repo = _init_origin(tmp_path)
+    _commit(repo, "merged.py", days_ago=9)
+    _git(repo, "push", "-q", "origin", "main")
+
+    result = _run(tmp_path, repo, started=_ago(20))
+
+    assert result.returncode == 1
+    assert "waiting 9 days for a restart" in result.stdout
+    assert "missing  : 1 commit(s)" in result.stdout
+
+
+def test_the_threshold_is_configurable(tmp_path: Path) -> None:
+    repo = _init_origin(tmp_path)
+    _commit(repo, "merged.py", days_ago=2)
+    _git(repo, "push", "-q", "origin", "main")
+
+    assert _run(tmp_path, repo, started=_ago(5)).returncode == 0
+    assert _run(tmp_path, repo, started=_ago(5), stale_days="1").returncode == 1
+
+
+def test_an_unreadable_service_says_so_instead_of_passing_silently(
+    tmp_path: Path,
+) -> None:
+    """`systemctl` answers 'n/a' for a unit it does not know — not a clean bot."""
+    repo = _init_origin(tmp_path)
+    _commit(repo, "merged.py", days_ago=9)
+    _git(repo, "push", "-q", "origin", "main")
+
+    result = _run(tmp_path, repo, started="n/a")
+
+    assert result.returncode == 0
+    assert "skipped the freshness check" in result.stdout
 
 
 def test_marker_pointing_nowhere_is_reported_not_silently_ignored(tmp_path: Path) -> None:


### PR DESCRIPTION
## Problem

`scripts/check-deploy-drift.sh` answers one question — "is a forgotten `make dev-on` worktree in production?" — and returns `OK: main-tree mode` for everything else. That is a guard that reports on the case it was written for and waves the rest through.

Main-tree mode has its own silent staleness. The checkout only pulls in `pre-start.sh`, so a bot that has not restarted keeps serving whatever was merged before it booted, while the tree still says `main` and every `git pull` keeps succeeding. Nothing compares the *running process* to `origin/main`, so the check reports `OK` for a bot that is days behind.

Found by running it on a host where the bot had been up for four days: `OK: main-tree mode`, with a merged commit undeployed.

## Change

In main-tree mode the script now measures the honest quantity: **commits merged after the service's `ActiveEnterTimestamp`** are the ones not running. That single number covers both a stale checkout and a pulled-but-not-restarted one, and it stays quiet on a machine that restarts often — unlike "is the checkout behind `origin/main`", which a pull silences without deploying anything.

Restarts are batched deliberately (an in-flight session does not survive one), so a fresh merge must not page anyone: the count and the age of the oldest undeployed commit are reported from day one, but the exit code only turns 1 past `CCDB_STALE_DAYS` (default 3).

- `CCDB_SERVICE` overrides the unit name (default `discord-bot`).
- No systemd, or a unit `systemctl` cannot read, prints that it skipped the freshness check rather than passing silently — the two kinds of silence stay distinguishable.
- The dev-worktree paths and their exit codes are unchanged.

## Test plan

- [x] `pytest tests/test_deploy_drift_script.py` — 11 passed. Five new cases cover the added path: clean, reported-but-not-yet-drift, drift past the threshold, a configurable threshold, and an unreadable unit.
- [x] The existing tests read the host's real `discord-bot` unit, so their result depended on when the developer last restarted their bot. They now go through a stubbed `systemctl`, and the fixture history is backdated so a repo created "now" does not look stale.
- [x] Run against the real host in all four states: fresh (0), stale (1), broken marker (2), unreadable unit (0 with an explanation).