### PR TITLE
fix: collect labelled session worktrees and warn when cleanup is off

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -100,6 +100,15 @@ CLAUDE_WORKING_DIR=
 # added alongside the default stdout handler. Useful for monitoring and alerting.
 # CCDB_LOG_FILE=/home/you/claude-code-discord-bridge/logs/discord-bot.log
 
+# Session worktree cleanup (strongly recommended)
+# Every session is instructed to run `git worktree add ../wt-{thread_id}`, so the
+# parent directory of your repositories fills up with one worktree per session.
+# Set this to that parent directory and ccdb removes each clean session worktree
+# at session end and sweeps orphans at startup. Leave it unset and nothing ever
+# does — the instruction still fires, so the leak is silent. Worktrees with
+# uncommitted changes are never removed automatically.
+WORKTREE_BASE_DIR=/home/you
+
 # Limits
 MAX_CONCURRENT_SESSIONS=3
 SESSION_TIMEOUT_SECONDS=300

--- a/claude_discord/setup.py
+++ b/claude_discord/setup.py
@@ -308,6 +308,14 @@ async def setup_bridge(
         if getattr(bot, "worktree_manager", None) is None:
             bot.worktree_manager = WorktreeManager(base_dir=worktree_base_dir)  # type: ignore[attr-defined]
         logger.info("WorktreeManager enabled (base_dir=%s)", worktree_base_dir)
+    else:
+        # Every session is told to create ``wt-{thread_id}``; without a base dir
+        # nothing ever removes them, and the leak is silent because the enabled
+        # branch is the only one that used to log. Say so on the disabled path.
+        logger.warning(
+            "WorktreeManager disabled: WORKTREE_BASE_DIR is not set. Sessions will "
+            "keep creating wt-{thread_id} worktrees and nothing will clean them up."
+        )
 
     # --- Deployment layout -------------------------------------------------
     # One root per deployment. Ten repositories share session_db_path, so this

--- a/claude_discord/worktree.py
+++ b/claude_discord/worktree.py
@@ -29,8 +29,21 @@ logger = logging.getLogger(__name__)
 
 # Branch pattern created by the concurrency notice template:
 # git worktree add ../wt-{thread_id} -b session/{thread_id}
-_SESSION_BRANCH_RE = re.compile(r"^session/(\d+)$")
-_SESSION_WORKTREE_PATH_RE = re.compile(r"wt-(\d+)$")
+#
+# A session that needs a second worktree appends a label to both names
+# (``wt-{thread_id}-obsidian`` on ``session/{thread_id}-obsidian``), so the
+# thread id is a prefix rather than the whole name.  Anchoring these patterns
+# at the end made every labelled worktree invisible to cleanup — the branch
+# still carries the thread id, which is what identifies it as ours.
+_SESSION_BRANCH_RE = re.compile(r"^session/(\d+)(?:-.*)?$")
+
+#: Directory-name prefilter, so scanning ``base_dir`` only shells out to git for
+#: plausible candidates.  It is deliberately *not* an identity test: sessions
+#: label the directory freely and put the label on either side of the thread id
+#: (``wt-{id}-obsidian`` and ``wt-obsidian-{id}`` both occur).  Matching the
+#: directory name against the thread id made every labelled worktree invisible
+#: to cleanup.  The branch is the only reliable identifier, and it decides.
+_SESSION_WORKTREE_DIR_PREFIX = "wt-"
 
 
 @dataclass(frozen=True)
@@ -171,7 +184,7 @@ class WorktreeManager:
         for entry in entries:
             if not entry.is_dir():
                 continue
-            if not _SESSION_WORKTREE_PATH_RE.search(entry.name):
+            if not entry.name.startswith(_SESSION_WORKTREE_DIR_PREFIX):
                 continue
             if not (entry / ".git").exists():
                 continue

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -551,6 +551,41 @@ async def test_setup_bridge_attaches_worktree_manager_when_pre_initialized_to_no
 
 
 @pytest.mark.asyncio
+async def test_setup_bridge_warns_when_worktree_base_dir_is_unset(
+    tmp_path: object,
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unset WORKTREE_BASE_DIR must warn, not pass silently.
+
+    Sessions are instructed to create ``wt-{thread_id}`` regardless of this setting,
+    so a disabled manager means worktrees accumulate forever. Only the *enabled*
+    branch used to log, which made the leaking configuration the quiet one.
+    """
+    import logging
+
+    monkeypatch.delenv("WORKTREE_BASE_DIR", raising=False)
+    bot = _make_bot()
+    bot.worktree_manager = None
+    runner = _make_runner()
+
+    with caplog.at_level(logging.WARNING, logger="claude_discord.setup"):
+        await setup_bridge(
+            bot,
+            runner,
+            session_db_path=str(tmp_path / "sessions.db"),  # type: ignore[operator]
+            enable_scheduler=False,
+        )
+
+    assert any(
+        "WORKTREE_BASE_DIR" in record.message
+        for record in caplog.records
+        if record.levelno >= logging.WARNING
+    )
+    assert bot.worktree_manager is None
+
+
+@pytest.mark.asyncio
 async def test_setup_bridge_defaults_max_concurrent_to_3(tmp_path: object) -> None:
     """Without env var or parameter, max_concurrent defaults to 3."""
     from unittest.mock import patch

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -30,10 +30,42 @@ class TestWorktreeInfo:
         assert wt.is_session_worktree is True
         assert wt.thread_id == 12345
 
+    def test_labelled_session_branch_parsed(self) -> None:
+        """A session's second worktree labels both names and is still ours.
+
+        Regression: anchoring the branch pattern at the end made every
+        ``session/{id}-{label}`` worktree invisible to cleanup, so they
+        accumulated indefinitely while the unlabelled ones were collected.
+        """
+        wt = WorktreeInfo(
+            path="/home/ebi/wt-12345-obsidian",
+            branch="session/12345-obsidian",
+            commit="abc1234",
+            main_repo="/home/ebi/some-repo",
+        )
+        assert wt.is_session_worktree is True
+        assert wt.thread_id == 12345
+
     def test_non_session_branch(self) -> None:
         wt = WorktreeInfo(
             path="/home/ebi/wt-feat-foo",
             branch="feat/my-feature",
+            commit="abc1234",
+            main_repo="/home/ebi/some-repo",
+        )
+        assert wt.is_session_worktree is False
+        assert wt.thread_id is None
+
+    def test_feature_branch_in_a_session_worktree_is_not_session(self) -> None:
+        """A worktree the session renamed onto a real feature branch is left alone.
+
+        The branch — not the directory name — decides. ``wt-12345-ebi-study``
+        checked out on ``fix/issue-45-...`` holds named work that belongs to a
+        PR, so automatic cleanup must not claim it.
+        """
+        wt = WorktreeInfo(
+            path="/home/ebi/wt-12345-ebi-study",
+            branch="fix/issue-45-ga-production-only",
             commit="abc1234",
             main_repo="/home/ebi/some-repo",
         )
@@ -163,6 +195,34 @@ class TestFindSessionWorktrees:
         assert len(worktrees) == 1
         assert worktrees[0].thread_id == 12345
         assert worktrees[0].is_session_worktree is True
+
+    def test_finds_labelled_session_worktrees(self, tmp_path: Path) -> None:
+        """``wt-{id}-{label}`` directories are scanned, not skipped by the path filter.
+
+        Regression: the directory pattern was anchored at the end, so a session's
+        labelled second worktree was never even opened — the branch check that
+        would have claimed it never ran.
+        """
+        for name in ("wt-12345-obsidian", "wt-obsidian-12345"):
+            wt = tmp_path / name
+            wt.mkdir()
+            (wt / ".git").write_text(f"gitdir: /fake/repo/.git/worktrees/{name}\n")
+
+        with (
+            patch("claude_discord.worktree._get_branch", return_value="session/12345-obsidian"),
+            patch("claude_discord.worktree._get_commit", return_value="abc1234"),
+            patch("claude_discord.worktree._find_main_repo", return_value="/fake/repo"),
+        ):
+            wm = WorktreeManager(base_dir=str(tmp_path))
+            worktrees = wm.find_session_worktrees()
+
+        # The label sits on either side of the thread id in practice, so the
+        # directory name must not be the gate — the branch is.
+        assert sorted(w.path for w in worktrees) == [
+            str(tmp_path / "wt-12345-obsidian"),
+            str(tmp_path / "wt-obsidian-12345"),
+        ]
+        assert {w.thread_id for w in worktrees} == {12345}
 
     def test_empty_when_no_session_worktrees(self, tmp_path: Path) -> None:
         wm = WorktreeManager(base_dir=str(tmp_path))


### PR DESCRIPTION
## Summary

Session worktrees accumulated indefinitely for two independent reasons. Both are fixed here.

**1. A disabled manager was silent.** `WORKTREE_BASE_DIR` gates `WorktreeManager`, and only the *enabled* branch logged anything. With the variable unset, session-end cleanup and the startup sweep were both off — while every session still received the mandatory instruction to run `git worktree add`. The leak therefore had no symptom in the logs. The disabled path now emits a warning, and `.env.example` documents the setting.

**2. Labelled worktrees were invisible to the scan.** A session that needs a second worktree labels both names, and the label lands on either side of the thread id — `wt-{id}-obsidian` and `wt-obsidian-{id}` both occur in practice. The directory pattern was anchored on the thread id, so none of them matched and the branch check that would have claimed them never ran.

The directory name is now only a cheap `wt-` prefilter; the **branch** decides. That keeps the existing boundary intact: a worktree renamed onto a real feature branch (`fix/issue-45-...`) is still not a session worktree and is left alone.

## Safety

Unchanged. Worktrees with uncommitted changes are never removed automatically, and git's own refusal to remove a worktree containing submodules is reported rather than forced.

## Test plan

- [x] `pytest` — 2811 passed
- [x] `ruff check` / `ruff format --check` clean
- [x] New regression tests: warning on unset `WORKTREE_BASE_DIR`; labelled worktrees collected from both name shapes; feature-branch worktrees still excluded
- [x] Verified against a real host that had accumulated worktrees: 186 clean ones collected, every dirty one preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)