### PR TITLE
docs: sync the Japanese README with #680, and correct SESSION_TIMEOUT_SECONDS in both languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -908,7 +908,7 @@ for idle deadlines, attachment retries, credentials and startup rollback.
 | `CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS` | Skip all permission checks (legacy — prefer `CCDB_DANGEROUSLY_SKIP_PERMISSIONS`) | `false` |
 | `CLAUDE_WORKING_DIR` | Working directory for Claude (legacy — prefer `CCDB_WORKING_DIR`) | current dir |
 | `MAX_CONCURRENT_SESSIONS` | Max parallel Claude CLI sessions across all code paths (chat, skills, scheduler, webhooks) | `3` |
-| `SESSION_TIMEOUT_SECONDS` | Session inactivity timeout | `300` |
+| `SESSION_TIMEOUT_SECONDS` | Session **idle** timeout in seconds — reset every time output arrives, so an active stream may outlive it. Set `0` to disable the deadline explicitly | `300` |
 | `CCDB_PR_COMPLETION_OWNER` | GitHub owner whose non-draft `session/<thread_id>` PRs trigger one automatic completion continuation. Requires authenticated `gh`; disabled when empty. | (optional) |
 | `DISCORD_OWNER_ID` | User ID to @-mention when Claude needs input | (optional) |
 | `COORDINATION_CHANNEL_ID` | Channel ID used as default fallback for AI Lounge channel | (optional) |

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -881,6 +881,8 @@ CHAT_ONLY_CHANNEL_IDS=444,555
 
 ## 設定
 
+アイドルデッドライン、添付ファイルの再送、認証情報、起動時ロールバックについては [ランタイム復旧とコントロールプレーンの境界](../runtime-reliability.md) を参照してください。
+
 | 変数名 | 説明 | デフォルト |
 |--------|------|-----------|
 | `DISCORD_BOT_TOKEN` | Discord Bot トークン | （必須） |
@@ -905,7 +907,7 @@ CHAT_ONLY_CHANNEL_IDS=444,555
 | `CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS` | 全パーミッションチェックをスキップ（旧名 — `CCDB_DANGEROUSLY_SKIP_PERMISSIONS` を推奨） | `false` |
 | `CLAUDE_WORKING_DIR` | Claude の作業ディレクトリ（旧名 — `CCDB_WORKING_DIR` を推奨） | カレントディレクトリ |
 | `MAX_CONCURRENT_SESSIONS` | 最大並行 Claude CLI セッション数（チャット・スキル・スケジューラ・Webhook の全パスに適用） | `3` |
-| `SESSION_TIMEOUT_SECONDS` | セッション非アクティブタイムアウト | `300` |
+| `SESSION_TIMEOUT_SECONDS` | セッションの**アイドル**タイムアウト（秒）。出力が届くたびにリセットされるため、アクティブなストリームはこの値を超えて継続しうる。`0` でデッドラインを明示的に無効化 | `300` |
 | `CCDB_PR_COMPLETION_OWNER` | 指定したGitHub所有者の非Draft `session/<thread_id>` PRが残っている場合、同じAIを1回だけ自動継続して完了または具体的なブロッカー報告まで進める。認証済み`gh`が必要。 | （オプション） |
 | `DISCORD_OWNER_ID` | Claude が入力待ちのとき @mention する Discord ユーザー ID | （オプション） |
 | `COORDINATION_CHANNEL_ID` | AI Lounge チャンネルのデフォルトフォールバック用チャンネル ID | （オプション） |
@@ -925,6 +927,8 @@ CHAT_ONLY_CHANNEL_IDS=444,555
 | `CCDB_LOG_FILE` | ログファイルのパス。設定するとデフォルトの stdout ハンドラに加えてローテーティングファイルハンドラ（10 MB × 5 バックアップ）が追加される。監視・アラートに便利 | （オプション） |
 | `API_HOST` | REST API バインドアドレス | `127.0.0.1` |
 | `API_PORT` | REST API ポート（設定すると REST API が有効になる） | （オプション） |
+| `CCDB_API_SECRET` | コントロールプレーン用のオプションの Bearer シークレット。セッションランナーにも同じ値が渡される。ループバック以外にバインドする場合は必須 | （オプション） |
+| `CCDB_CONTROL_PLANE_HOST_GUARD` | コントロールプレーンでローカル以外の Host / Origin と転送ヘッダを拒否する。認証済みプロキシを意図的に使う場合は `0` で無効化 | `1` |
 | `CCDB_INGEST_TOKEN` | `POST /api/ingest` 用の Bearer トークン（`api_secret` とは独立）。未設定ならこのエンドポイントは `503` を返す | （オプション） |
 | `CCDB_INGEST_REQUIRE_COMPLETE` | `1` を設定すると、`attachments_manifest` によって添付ファイルの欠落が判明したインジェストを、部分的な証拠でセッションを開始せずに `409` で拒否する | `0` |
 | `CCDB_TEAMS_VAULT_ROOT` | `POST /api/teams/sync` が上流スレッドをミラーリングする先のディレクトリ（メッセージ 1 件につき 1 ファイル）。`CCDB_INGEST_TOKEN` で保護される | `{working_dir}/teams` |


### PR DESCRIPTION
## Summary

`#680` (idle deadlines / session delivery recovery) touched `README.md` in three places and `docs/ja/README.md` in none. This closes that gap and fixes one line that was wrong in **both** languages.

### Japanese sync (`docs/ja/README.md`)

| Brought across | Why it was missing |
|---|---|
| Pointer to `docs/runtime-reliability.md` under **設定** | Added to the English Configuration section by #680 |
| `CCDB_API_SECRET` row | New control-plane Bearer secret, required for non-loopback binds |
| `CCDB_CONTROL_PLANE_HOST_GUARD` row | New Host/Origin guard, `0` opts out for authenticated proxies |

The link is written as `../runtime-reliability.md` — relative to `docs/ja/`, not copied verbatim from the English page, so it resolves.

### Correction in both languages

`SESSION_TIMEOUT_SECONDS` was described only as "Session inactivity timeout". `runner.py` passes `self.timeout_seconds or None` to `asyncio.wait_for`, so:

- `0` disables the deadline outright, and
- the clock resets on every stdout line, so an active stream can outlive the configured value.

Both facts lived only in `docs/runtime-reliability.md`, where a reader of the configuration table would not find them.

## Test plan

- [x] `docs/runtime-reliability.md` exists at the path the new Japanese link resolves to
- [x] Row order in the Japanese table matches English (`API_PORT` → `CCDB_API_SECRET` → `CCDB_CONTROL_PLANE_HOST_GUARD` → `CCDB_INGEST_TOKEN`)
- [x] Docs-only change — no source files touched

---

## 概要（日本語）

`#680` は英語 README を 3 箇所更新したが、`docs/ja/README.md` には 1 箇所も反映されていなかった。その欠落（runtime-reliability へのリンク、`CCDB_API_SECRET`、`CCDB_CONTROL_PLANE_HOST_GUARD`）を補う。

あわせて `SESSION_TIMEOUT_SECONDS` の説明を英語・日本語の両方で修正した。これは**アイドル**タイムアウトであり、出力が届くたびにリセットされ、`0` で無効化できる。この 2 点は設定表からは読み取れず `docs/runtime-reliability.md` にしか書かれていなかった。
