### PR TITLE
feat: make the Codex status-line labels language-selectable (CCDB_STATUS_LANG)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -164,3 +164,8 @@ SESSION_TIMEOUT_SECONDS=300
 # SAS credential; never commit its real value or print it in logs.
 # CCDB_FRONTENDS=discord,teams
 # CCDB_TEAMS_QUEUE_URL=https://account.queue.core.windows.net/relay?<SAS>
+
+# Language for the Codex status-line labels only (週次 / クレジット / 上限到達).
+# `en` renders them as 7d / credits / limit reached. Default is `ja`, so leaving
+# this unset keeps the current output unchanged.
+# CCDB_STATUS_LANG=en

--- a/README.md
+++ b/README.md
@@ -898,6 +898,7 @@ for idle deadlines, attachment retries, credentials and startup rollback.
 | `CCDB_MODEL` | Model to use (overrides `CLAUDE_MODEL`) | `sonnet` |
 | `CCDB_MODEL_DISCOVERY` | Set to `0` to stop the `/model` autocomplete from asking the Anthropic models endpoint which models your credentials can see (and from reading the Codex CLI's local model catalog), and always use the static suggestion list instead. Discovery is read-only, reuses the Claude Code CLI's own auth, and already falls back on its own when offline, unauthenticated, or on Bedrock/Vertex/Foundry | `1` |
 | `CCDB_PERMISSION_MODE` | Permission mode for CLI (overrides `CLAUDE_PERMISSION_MODE`) | `acceptEdits` |
+| `CCDB_STATUS_LANG` | Language for the Codex status-line labels (`週次` / `クレジット` / `上限到達`). `en` renders them as `7d` / `credits` / `limit reached`, matching the English used elsewhere in the UI. Unrecognised values fall back to `ja`. Affects only those labels — Japanese prompt text and phrase matching are unaffected. | `ja` |
 | `CCDB_DANGEROUSLY_SKIP_PERMISSIONS` | Skip all permission checks — overrides `CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS` | `false` |
 | `CCDB_WORKING_DIR` | Working directory for CLI (overrides `CLAUDE_WORKING_DIR`) | current dir |
 | `CCDB_ALLOWED_TOOLS` | Comma-separated list of allowed tools (overrides `CLAUDE_ALLOWED_TOOLS`) | (optional) |

--- a/claude_discord/cogs/event_processor.py
+++ b/claude_discord/cogs/event_processor.py
@@ -1116,7 +1116,10 @@ async def _post_engine_status_footer(
     Anthropic quota stays visible for side-by-side comparison.
     """
     from ..backend_settings import BackendSettings
-    from ..discord_ui.engine_status import get_codex_status_line
+    from ..discord_ui.engine_status import (
+        codex_status_unavailable_line,
+        get_codex_status_line,
+    )
 
     # Resolve the Codex-status mode (off when no settings resolver is wired,
     # e.g. headless flows).
@@ -1130,7 +1133,7 @@ async def _post_engine_status_footer(
     if show_codex:
         codex_line = await get_codex_status_line(codex_command)
         if codex_line is None and mode == "on":
-            codex_line = "\U0001f916 Codex: 残量取得失敗（codex login 済みか確認）"
+            codex_line = codex_status_unavailable_line()
 
     # Render the Claude statusLine on Claude turns, or whenever the Codex line
     # is being shown (so both engines appear together). On non-Claude turns the

--- a/claude_discord/discord_ui/engine_status.py
+++ b/claude_discord/discord_ui/engine_status.py
@@ -19,6 +19,7 @@ import asyncio
 import contextlib
 import json
 import logging
+import os
 import shlex
 import time
 from collections.abc import Awaitable, Callable
@@ -36,6 +37,47 @@ _DEFAULT_TTL = 90.0
 # Failures (codex missing, not logged in) are cached for a shorter window so we
 # do not hammer a broken setup on every message, but still recover quickly.
 _FAIL_TTL = 30.0
+
+# Status-line labels. The bot's other surfaces are English, so deployments
+# outside Japan end up with one mixed-language line. `CCDB_STATUS_LANG=en`
+# switches just these labels; the default keeps the existing Japanese output so
+# no current deployment changes behaviour.
+#
+# "weekly" is a label, not a translation: `en` reports `7d`, which matches the
+# `5h` / `1d` / `30m` forms `_window_label()` already produces for every other
+# duration.
+_STATUS_LABELS: dict[str, dict[str, str]] = {
+    "ja": {
+        "weekly": "週次",
+        "credits": "クレジット",
+        "unlimited": "無制限",
+        "limit_reached": "上限到達",
+        "usage_unavailable": "残量取得失敗（codex login 済みか確認）",
+    },
+    "en": {
+        "weekly": "7d",
+        "credits": "credits",
+        "unlimited": "unlimited",
+        "limit_reached": "limit reached",
+        "usage_unavailable": "usage unavailable (check that codex is logged in)",
+    },
+}
+_DEFAULT_STATUS_LANG = "ja"
+
+
+def _labels() -> dict[str, str]:
+    """Return the status-line label set selected by ``CCDB_STATUS_LANG``.
+
+    An unset or unrecognised value falls back to the existing Japanese labels,
+    so a typo degrades to today's behaviour rather than to empty strings.
+    """
+    lang = os.getenv("CCDB_STATUS_LANG", _DEFAULT_STATUS_LANG).strip().lower()
+    return _STATUS_LABELS.get(lang, _STATUS_LABELS[_DEFAULT_STATUS_LANG])
+
+
+def codex_status_unavailable_line() -> str:
+    """The line shown when Codex usage cannot be read but the mode is ``on``."""
+    return f"\U0001f916 Codex: {_labels()['usage_unavailable']}"
 
 
 async def fetch_codex_rate_limits(
@@ -129,7 +171,7 @@ def _window_label(window_duration_mins: object) -> str | None:
     if minutes <= 0:
         return None
     if minutes == 10080:
-        return "週次"
+        return _labels()["weekly"]
     if minutes % 1440 == 0:
         return f"{minutes // 1440}d"
     if minutes % 60 == 0:
@@ -150,7 +192,8 @@ def _window_segment(snap: dict | None, fallback_label: str) -> str | None:
 def format_codex_status_line(data: dict | None) -> str | None:
     """Format a ``account/rateLimits/read`` result into one Discord line.
 
-    Example: ``🤖 Codex: 5h 1% · 週次 8% · クレジット 0 (prolite)``.
+    Example: ``🤖 Codex: 5h 1% · 週次 8% · クレジット 0 (prolite)``, or with
+    ``CCDB_STATUS_LANG=en`` set, ``🤖 Codex: 5h 1% · 7d 8% · credits 0 (prolite)``.
     Returns ``None`` when there is nothing meaningful to show.
     """
     if not isinstance(data, dict):
@@ -159,20 +202,22 @@ def format_codex_status_line(data: dict | None) -> str | None:
     if not isinstance(snap, dict):
         return None
 
+    labels = _labels()
+
     segments: list[str] = []
     primary = _window_segment(snap.get("primary"), "5h")
     if primary is not None:
         segments.append(primary)
-    secondary = _window_segment(snap.get("secondary"), "週次")
+    secondary = _window_segment(snap.get("secondary"), labels["weekly"])
     if secondary is not None:
         segments.append(secondary)
 
     credit_info = snap.get("credits")
     if isinstance(credit_info, dict):
         if credit_info.get("unlimited"):
-            segments.append("クレジット 無制限")
+            segments.append(f"{labels['credits']} {labels['unlimited']}")
         elif credit_info.get("balance") is not None:
-            segments.append(f"クレジット {credit_info.get('balance')}")
+            segments.append(f"{labels['credits']} {credit_info.get('balance')}")
 
     if not segments:
         return None
@@ -180,7 +225,7 @@ def format_codex_status_line(data: dict | None) -> str | None:
     plan = snap.get("planType")
     suffix = f" ({plan})" if plan else ""
     reached = snap.get("rateLimitReachedType")
-    warn = " ⚠ 上限到達" if reached else ""
+    warn = f" ⚠ {labels['limit_reached']}" if reached else ""
     return f"\U0001f916 Codex: {' · '.join(segments)}{suffix}{warn}"
 
 

--- a/tests/test_engine_status.py
+++ b/tests/test_engine_status.py
@@ -6,6 +6,7 @@ import pytest
 
 from claude_discord.discord_ui.engine_status import (
     CodexStatusProvider,
+    codex_status_unavailable_line,
     format_codex_status_line,
 )
 
@@ -113,6 +114,90 @@ class TestFormat:
     @pytest.mark.parametrize("bad", [None, {}, {"rateLimits": None}, {"rateLimits": {}}, "x"])
     def test_returns_none_for_unusable(self, bad: object) -> None:
         assert format_codex_status_line(bad) is None  # type: ignore[arg-type]
+
+
+class TestStatusLanguage:
+    """`CCDB_STATUS_LANG` swaps the status-line labels and nothing else."""
+
+    def test_defaults_to_japanese_when_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("CCDB_STATUS_LANG", raising=False)
+        line = format_codex_status_line(SAMPLE)
+        assert line is not None
+        assert "週次 8%" in line
+        assert "クレジット 0" in line
+
+    def test_english_labels(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("CCDB_STATUS_LANG", "en")
+        line = format_codex_status_line(SAMPLE)
+        assert line is not None
+        assert "7d 8%" in line
+        assert "credits 0" in line
+        assert "週次" not in line
+        assert "クレジット" not in line
+
+    def test_english_weekly_matches_other_duration_labels(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`7d` is the same form `_window_label` already emits for 1d/2d."""
+        monkeypatch.setenv("CCDB_STATUS_LANG", "en")
+        line = format_codex_status_line(WEEKLY_PRIMARY_SAMPLE)
+        assert line is not None
+        assert "7d 15%" in line
+
+    def test_english_unlimited_credits(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("CCDB_STATUS_LANG", "en")
+        data = {"rateLimits": {"primary": {"usedPercent": 5}, "credits": {"unlimited": True}}}
+        line = format_codex_status_line(data)
+        assert line is not None
+        assert "credits unlimited" in line
+
+    def test_english_rate_limit_reached(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("CCDB_STATUS_LANG", "en")
+        data = {
+            "rateLimits": {
+                "primary": {"usedPercent": 99},
+                "rateLimitReachedType": "primary",
+            }
+        }
+        line = format_codex_status_line(data)
+        assert line is not None
+        assert "⚠ limit reached" in line
+
+    def test_japanese_rate_limit_reached_unchanged(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("CCDB_STATUS_LANG", raising=False)
+        data = {
+            "rateLimits": {
+                "primary": {"usedPercent": 99},
+                "rateLimitReachedType": "primary",
+            }
+        }
+        line = format_codex_status_line(data)
+        assert line is not None
+        assert "⚠ 上限到達" in line
+
+    @pytest.mark.parametrize("value", ["", "  ", "de", "EN-GB", "japanese"])
+    def test_unknown_value_falls_back_to_japanese(
+        self, monkeypatch: pytest.MonkeyPatch, value: str
+    ) -> None:
+        """A typo degrades to today's output, never to empty labels."""
+        monkeypatch.setenv("CCDB_STATUS_LANG", value)
+        line = format_codex_status_line(SAMPLE)
+        assert line is not None
+        assert "週次 8%" in line
+
+    def test_case_and_whitespace_insensitive(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("CCDB_STATUS_LANG", "  EN  ")
+        line = format_codex_status_line(SAMPLE)
+        assert line is not None
+        assert "7d 8%" in line
+
+    def test_unavailable_line_follows_the_same_setting(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("CCDB_STATUS_LANG", raising=False)
+        assert "残量取得失敗" in codex_status_unavailable_line()
+        monkeypatch.setenv("CCDB_STATUS_LANG", "en")
+        assert "usage unavailable" in codex_status_unavailable_line()
 
 
 class TestProviderCache:


### PR DESCRIPTION
Closes #685.

## What

Adds `CCDB_STATUS_LANG` so the Codex status-line labels can render in English, and routes the six user-facing literals through it.

**The default is `ja`.** An unset or unrecognised value produces byte-identical output to today, so no existing deployment changes behaviour.

```
default (unchanged) : 🤖 Codex: 5h 1% · 週次 38% · クレジット 0 (pro)
                      🤖 Codex: 残量取得失敗（codex login 済みか確認）

CCDB_STATUS_LANG=en : 🤖 Codex: 5h 1% · 7d 38% · credits 0 (pro)
                      🤖 Codex: usage unavailable (check that codex is logged in)
```

## `7d`, not a translation of `週次`

`_window_label()` already emits `5h`, `1d`, `2d`, `30m` from the reported duration. The `10080` branch was the only one that didn't follow that pattern, so `en` reports `7d` and the function becomes internally consistent rather than gaining a second vocabulary.

## Scope

Deliberately limited to status-line labels. The other Japanese in the tree is functional, not cosmetic, and is untouched:

| Location | Why it stays |
|---|---|
| `cogs/prompt_builder.py` | Japanese phrase matching (`送って`, `ください`, …) — language *support*, a feature |
| `ext/api_server.py` ~1852-1883 | thread-summarisation prompt; editing it would change behaviour |
| `discord_ui/thread_renamer.py` | title regex matches `title:` **and** `タイトル:`, bilingual by design |
| code comments | not user-facing |

## Changes

- `discord_ui/engine_status.py` — `_STATUS_LABELS` table, `_labels()` resolver, and `codex_status_unavailable_line()` so the failure line follows the same setting.
- `cogs/event_processor.py` — uses that helper instead of an inline literal.
- `tests/test_engine_status.py` — 9 new tests. Existing assertions on the Japanese literals are unchanged and still pass, which is the regression guard for the default.
- `README.md`, `.env.example` — documented.

Unknown values (`""`, `"  "`, `"de"`, `"japanese"`) fall back to `ja` rather than to empty labels, and the lookup is case/whitespace-insensitive (`"  EN  "` works). Both are covered by tests.

## Verification

- `uv run pytest tests/test_engine_status.py` — **33 passed**
- `uv run ruff check claude_discord/ claude_teams/` — clean
- `uv run ruff format --check claude_discord/ claude_teams/` — clean

Both lint commands are the ones from `.github/workflows/ci.yml`.

⚠️ On the full suite I see 8 failures in `tests/test_api_teams_sync.py` and `tests/test_deploy_drift_script.py` — **these reproduce on a clean checkout of `7fc303c` with this branch stashed**, so they're environmental (they want real git/systemd state) and unrelated to this change. Flagging in case they're news.

Happy to switch to plain English literals or drop the env var entirely if you'd rather not carry the setting — the label table alone would make that a one-line change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019RdJcaaDVP6SmaeP7BU7vC
