### PR TITLE
fix: require Discord attachments for local files

### DIFF
--- a/claude_discord/cogs/_run_helper.py
+++ b/claude_discord/cogs/_run_helper.py
@@ -177,6 +177,12 @@ async def _build_system_context(config: RunConfig) -> str | None:
     marker = _attachment_marker_name(config.surface.thread_key)
     parts.append(
         "## File Delivery\n"
+        "Discord cannot open local filesystem paths. Never describe a local path as a clickable "
+        "link, and never use a local path or file:// URI as a user-facing Markdown link. "
+        "For every file the user asks to view, open, download, or receive, deliver it as a real "
+        "Discord attachment using the marker below and refer to it as an attached file in the "
+        "final response. This Discord-specific rule overrides general instructions to prefer "
+        "clickable local-file links.\n"
         "When you need to send files to Discord, use your Bash tool to append "
         "each file's ABSOLUTE path (one path per line, UTF-8) to:\n"
         f"  {wd}/{marker}\n"

--- a/tests/test_run_helper_surface_only.py
+++ b/tests/test_run_helper_surface_only.py
@@ -40,6 +40,21 @@ async def test_system_context_is_built_without_a_discord_thread() -> None:
     assert str(surface.thread_key) in context
 
 
+async def test_file_delivery_guidance_forbids_local_path_links() -> None:
+    surface = MemorySurface()
+    config = RunConfig(
+        surface=surface,
+        runner=_runner(),
+        prompt="send me the report",
+    )
+
+    context = await _build_system_context(config)
+
+    assert "Discord cannot open local filesystem paths" in context
+    assert "Never describe a local path as a clickable link" in context
+    assert f".ccdb-attachments-{surface.thread_key}" in context
+
+
 async def test_the_session_is_registered_under_the_surface_key() -> None:
     """The registry is how two sessions notice each other — a wrong key is a silent collision."""
     surface = MemorySurface()


### PR DESCRIPTION
Discord sessions currently receive the attachment-marker instructions but are not told that local filesystem Markdown links cannot be opened from Discord. As a result, an agent can tell a user to “click” a local path even when a real attachment is required.

This change makes the injected file-delivery guidance explicit: requested files must be delivered through the per-thread attachment marker, local paths and `file://` URIs must never be presented as user-facing links, and the final response should refer to the real attachment.

Validation:

- `uv run pytest tests/test_run_helper_surface_only.py tests/test_event_processor_surface.py -q` — 8 passed
- `uv run ruff check claude_discord/ tests/` — passed
- `uv run ruff format --check claude_discord/ tests/` — passed
- `uv run pyright claude_discord/` — passed
- Full suite: 2,855 passed; one unrelated pre-existing Teams oversized-request test fails under local aiohttp 3.14.3 before the receiver is reached
- Security checklist reviewed; no subprocess, environment, input-handling, or secret-handling behavior changed



Closes #693
