### PR TITLE
fix: clear product certification blockers

### DIFF
--- a/claude_teams/relay/receiver.py
+++ b/claude_teams/relay/receiver.py
@@ -145,9 +145,11 @@ class RelayReceiver:
         declared = request.content_length
         if declared is not None and declared > self._max_body_bytes:
             raise _TooLargeError
-        raw = await request.content.read(self._max_body_bytes + 1)
-        if len(raw) > self._max_body_bytes:
-            raise _TooLargeError
+        raw = bytearray()
+        async for chunk in request.content.iter_any():
+            raw.extend(chunk)
+            if len(raw) > self._max_body_bytes:
+                raise _TooLargeError
         try:
             return json.loads(raw)
         except (json.JSONDecodeError, UnicodeDecodeError) as exc:

--- a/tests/test_main_backend.py
+++ b/tests/test_main_backend.py
@@ -44,7 +44,9 @@ class TestEnvVarRename:
         from claude_discord.main import load_config
 
         merged = {**self._REQUIRED, **env}
-        with patch.dict("os.environ", merged, clear=True):
+        # These tests exercise the supplied environment, not a developer's
+        # repository-local .env file discovered by load_config().
+        with patch("claude_discord.main.load_dotenv"), patch.dict("os.environ", merged, clear=True):
             return load_config()
 
     def test_ccdb_model_takes_precedence(self) -> None:


### PR DESCRIPTION
## Summary

- read the complete Teams relay request stream before parsing JSON
- retain the receiver byte limit across fragmented request bodies
- isolate environment configuration tests from repository-local `.env` files

## Verification

- Python 3.12: 2,855 tests passed, 84% line coverage
- Python 3.13: 2,855 tests passed, 81.89% branch coverage
- Ruff lint and formatting passed
- Pyright passed with zero errors
- wheel/sdist build and isolated wheel imports passed
- locked runtime dependency audit found no known vulnerabilities
- AST dangerous-call scan found no `shell=True`, `os.system`, `eval`, or `exec` calls